### PR TITLE
fix: aclose error: 'AsyncStream' object has no attribute 'aclose'. Did you mean: 'close'

### DIFF
--- a/llama_stack/distribution/server/server.py
+++ b/llama_stack/distribution/server/server.py
@@ -180,7 +180,7 @@ async def sse_generator(event_gen_coroutine):
     except asyncio.CancelledError:
         logger.info("Generator cancelled")
         if event_gen:
-            await event_gen.aclose()
+            await event_gen.close()
     except Exception as e:
         logger.exception("Error in sse_generator")
         yield create_sse_event(


### PR DESCRIPTION
There is a error message when Generator got cancelled, like this: 
```
 INFO:     [127.0.0.1:59490](https://www.internalfb.com/phabricator/paste/view/127.0.0.1:59490) - "POST /v1/openai/v1/completions HTTP/1.1" 200 OK
 00:25:41.837 [INFO] Generator cancelled
00:25:41.861 [START] /v1/openai/v1/completions
INFO     2025-06-13 17:25:42,326 __main__:180 server: Generator cancelled
00:25:42.334 [END] /v1/openai/v1/completions [StatusCode.OK] (472.25ms)
 00:25:42.330 [INFO] Generator cancelled
  + Exception Group Traceback (most recent call last):
  |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 263, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | exceptiongroup.ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/server/server.py", line 318, in __call__
    |     return await self.app(scope, receive, send_with_trace_id)
    |   File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/server/server.py", line 360, in __call__
    |     return await self.app(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 714, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 734, in app
    |     await route.handle(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
    |     await self.app(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 74, in app
    |     await response(scope, receive, send)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 262, in __call__
    |     with collapse_excgroups():
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/contextlib.py", line 153, in __exit__
    |     self.gen.throw(typ, value, traceback)
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 266, in wrap
    |     await func()
    |   File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 246, in stream_response
    |     async for chunk in self.body_iterator:
    |   File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/utils/context.py", line 32, in wrapper
    |     item = await gen.__anext__()
    |   File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/server/server.py", line 182, in sse_generator
    |     await event_gen.aclose()
    | AttributeError: 'AsyncStream' object has no attribute 'aclose'. Did you mean: 'close'?
    +------------------------------------
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/server/server.py", line 318, in __call__
    return await self.app(scope, receive, send_with_trace_id)
  File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/server/server.py", line 360, in __call__
    return await self.app(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/routing.py", line 74, in app
    await response(scope, receive, send)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 262, in __call__
    with collapse_excgroups():
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 266, in wrap
    await func()
  File "/Users/kaiwu/miniconda3/envs/stack/lib/python3.10/site-packages/starlette/responses.py", line 246, in stream_response
    async for chunk in self.body_iterator:
  File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/utils/context.py", line 32, in wrapper
    item = await gen.__anext__()
  File "/Users/kaiwu/work/llama-stack/llama_stack/distribution/server/server.py", line 182, in sse_generator
    await event_gen.aclose()
AttributeError: 'AsyncStream' object has no attribute 'aclose'. Did you mean: 'close'?
```
This PR fixed this error message as the AsyncStream class only have [close()](https://github.com/meta-llama/llama-stack-client-python/blob/main/src/llama_stack_client/_streaming.py#L139) defined instead of aclose(). 
## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
Now I did not see any error message from llama-stack server log:
```
INFO     2025-06-16 14:29:57,455 __main__:181 server: Generator cancelled
INFO:     127.0.0.1:50428 - "POST /v1/openai/v1/completions HTTP/1.1" 200 OK
21:29:57.471 [END] /v1/openai/v1/completions [StatusCode.OK] (782.64ms)
 21:29:57.458 [INFO] Generator cancelled
21:29:57.503 [START] /v1/openai/v1/completions
INFO     2025-06-16 14:29:58,047 __main__:181 server: Generator cancelled
21:29:58.052 [END] /v1/openai/v1/completions [StatusCode.OK] (548.30ms)
 21:29:58.049 [INFO] Generator cancelled
21:31:19.216 [START] /v1/openai/v1/completions
INFO:     ::1:50676 - "POST /v1/openai/v1/completions HTTP/1.1" 200 OK
```
