### PR TITLE
ci: add CI job to test documentation build

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,6 +6,7 @@ Llama Stack uses GitHub Actions for Continuous Integration (CI). Below is a tabl
 | ---- | ---- | ------- |
 | Backward Compatibility Check | [backward-compat.yml](backward-compat.yml) | Check backward compatibility for config.yaml files |
 | API Conformance Tests | [conformance.yml](conformance.yml) | Run the API Conformance test suite on the changes. |
+| Documentation Build | [documentation-build.yml](documentation-build.yml) | Ensure documentation can build successfully |
 | Installer CI | [install-script-ci.yml](install-script-ci.yml) | Test the installation script |
 | Integration Auth Tests | [integration-auth-tests.yml](integration-auth-tests.yml) | Run the integration test suite with Kubernetes authentication |
 | SqlStore Integration Tests | [integration-sql-store-tests.yml](integration-sql-store-tests.yml) | Run the integration test suite with SqlStore |

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,0 +1,43 @@
+name: Documentation Build
+
+run-name: Ensure documentation can build successfully
+
+on:
+  pull_request:
+    - main
+    - 'release-[0-9]+.[0-9]+.x'
+  push:
+    - main
+    - 'release-[0-9]+.[0-9]+.x'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./docs
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run gen-api-docs
+        run: npm run gen-api-docs all
+
+      - name: Build documentation
+        run: npm run build


### PR DESCRIPTION
# What does this PR do?
we've hit issues previously where the docs have ended up in an unbuildable state

this commit adds a CI job to prevent such regressions

Closes #3963
