### PR TITLE
feat(tool_groups): Support retrieving MCP server instructions

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -2297,6 +2297,14 @@ paths:
       description: List tools with optional tool group.
       operationId: list_tools_v1_tools_get
       parameters:
+      - name: authorization
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       - name: toolgroup_id
         in: query
         required: false
@@ -10050,6 +10058,10 @@ components:
           - additionalProperties: true
             type: object
           - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
       type: object
       required:
       - identifier
@@ -12046,6 +12058,14 @@ components:
           anyOf:
           - additionalProperties: true
             type: object
+          - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+        authorization:
+          anyOf:
+          - type: string
           - type: 'null'
       type: object
       required:
@@ -14065,6 +14085,11 @@ components:
           - type: 'null'
           nullable: true
           title: URL
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+          nullable: true
       required:
       - toolgroup_id
       - provider_id

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -611,6 +611,14 @@ paths:
       description: List tools with optional tool group.
       operationId: list_tools_v1_tools_get
       parameters:
+      - name: authorization
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       - name: toolgroup_id
         in: query
         required: false
@@ -6631,6 +6639,10 @@ components:
           - additionalProperties: true
             type: object
           - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
       type: object
       required:
       - identifier
@@ -8627,6 +8639,14 @@ components:
           anyOf:
           - additionalProperties: true
             type: object
+          - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+        authorization:
+          anyOf:
+          - type: string
           - type: 'null'
       type: object
       required:
@@ -10648,6 +10668,11 @@ components:
           - type: 'null'
           nullable: true
           title: URL
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+          nullable: true
       required:
       - toolgroup_id
       - provider_id

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -6680,6 +6680,10 @@ components:
           - additionalProperties: true
             type: object
           - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
       type: object
       required:
       - identifier
@@ -10172,6 +10176,11 @@ components:
           - type: 'null'
           nullable: true
           title: URL
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+          nullable: true
       required:
       - toolgroup_id
       - provider_id

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -8484,6 +8484,10 @@ components:
           - additionalProperties: true
             type: object
           - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
       type: object
       required:
       - identifier
@@ -12477,6 +12481,11 @@ components:
           - type: 'null'
           nullable: true
           title: URL
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+          nullable: true
       required:
       - toolgroup_id
       - provider_id

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -2297,6 +2297,14 @@ paths:
       description: List tools with optional tool group.
       operationId: list_tools_v1_tools_get
       parameters:
+      - name: authorization
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Authorization
       - name: toolgroup_id
         in: query
         required: false
@@ -10050,6 +10058,10 @@ components:
           - additionalProperties: true
             type: object
           - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
       type: object
       required:
       - identifier
@@ -12046,6 +12058,14 @@ components:
           anyOf:
           - additionalProperties: true
             type: object
+          - type: 'null'
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+        authorization:
+          anyOf:
+          - type: string
           - type: 'null'
       type: object
       required:
@@ -14065,6 +14085,11 @@ components:
           - type: 'null'
           nullable: true
           title: URL
+        mcp_server_instructions:
+          anyOf:
+          - type: string
+          - type: 'null'
+          nullable: true
       required:
       - toolgroup_id
       - provider_id

--- a/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
+++ b/src/llama_stack/providers/inline/agents/meta_reference/responses/streaming.py
@@ -102,6 +102,11 @@ from .utils import (
 logger = get_logger(name=__name__, category="agents::meta_reference")
 tracer = trace.get_tracer(__name__)
 
+# Maximum length for MCP server instructions (untrusted remote input)
+# These instructions come from external MCP servers and should be treated as untrusted.
+# Set to 0 to disable including MCP server instructions entirely.
+MCP_INSTRUCTIONS_MAX_LENGTH = 1000
+
 
 def convert_tooldef_to_chat_tool(tool_def):
     """Convert a ToolDef to OpenAI ChatCompletionToolParam format.
@@ -197,6 +202,8 @@ class StreamingResponseOrchestrator:
         self.accumulated_builtin_output_tokens = 0
         # Accumulate MCP server instructions
         self.mcp_server_instructions: list[str] = []
+        # Map server_label -> instructions for restoring when reusing MCP lists
+        self.server_label_to_instructions: dict[str, str] = {}
 
     async def _create_refusal_response(self, violation_message: str) -> OpenAIResponseObjectStream:
         """Create a refusal response to replace streaming content."""
@@ -283,6 +290,9 @@ class StreamingResponseOrchestrator:
             yield stream_event
 
         # Add accumulated MCP server instructions to the system message/instructions
+        # NOTE: These are untrusted inputs from external MCP servers.
+        # They have been truncated to MCP_INSTRUCTIONS_MAX_LENGTH and logged.
+        # Consider this a trust boundary as these instructions can influence model behavior.
         if self.mcp_server_instructions:
             mcp_instructions_text = "\n\n".join(self.mcp_server_instructions)
             if self.instructions:
@@ -320,6 +330,18 @@ class StreamingResponseOrchestrator:
 
         n_iter = 0
         messages = self.ctx.messages.copy()
+
+        # Update/insert system message with accumulated instructions (including MCP server instructions)
+        if self.instructions:
+            from llama_stack_api import OpenAISystemMessageParam
+
+            if messages and isinstance(messages[0], OpenAISystemMessageParam):
+                # Update existing system message with accumulated instructions
+                messages[0] = OpenAISystemMessageParam(content=self.instructions)
+            else:
+                # Insert new system message at the beginning
+                messages.insert(0, OpenAISystemMessageParam(content=self.instructions))
+
         final_status = "completed"
         last_completion_result: ChatCompletionResult | None = None
 
@@ -1275,13 +1297,27 @@ class StreamingResponseOrchestrator:
 
             # Retrieve MCP server instructions from tooldef metadata
             # Check the first tool for server instructions (all tools from same server share instructions)
-            if tool_defs.data:
+            # NOTE: MCP server instructions are untrusted remote input.
+            # Only include them if MCP_INSTRUCTIONS_MAX_LENGTH > 0 (opt-in).
+            if tool_defs.data and MCP_INSTRUCTIONS_MAX_LENGTH > 0:
                 first_tool = tool_defs.data[0]
                 if first_tool.metadata and "mcp_server_instructions" in first_tool.metadata:
                     mcp_instructions = first_tool.metadata["mcp_server_instructions"]
                     # Accumulate instructions (avoiding duplicates)
                     if mcp_instructions and mcp_instructions not in self.mcp_server_instructions:
+                        # Truncate if exceeds max length
+                        if len(mcp_instructions) > MCP_INSTRUCTIONS_MAX_LENGTH:
+                            logger.warning(
+                                f"MCP server instructions from {mcp_tool.server_label} truncated from "
+                                f"{len(mcp_instructions)} to {MCP_INSTRUCTIONS_MAX_LENGTH} characters"
+                            )
+                            mcp_instructions = mcp_instructions[:MCP_INSTRUCTIONS_MAX_LENGTH] + "...[truncated]"
+                        logger.info(
+                            f"Including MCP server instructions from {mcp_tool.server_label} ({len(mcp_instructions)} chars)"
+                        )
                         self.mcp_server_instructions.append(mcp_instructions)
+                        # Store instructions by server_label for later reuse
+                        self.server_label_to_instructions[mcp_tool.server_label] = mcp_instructions
 
             # Create the MCP list tools message
             mcp_list_message = OpenAIResponseOutputMessageMCPListTools(
@@ -1441,6 +1477,16 @@ class StreamingResponseOrchestrator:
             if self.ctx.chat_tools is None:
                 self.ctx.chat_tools = []
             self.ctx.chat_tools.append(openai_tool)  # type: ignore[arg-type]  # Returns dict but ChatCompletionToolParam expects TypedDict
+
+        # Restore MCP server instructions for this server_label if they were previously stored
+        # This ensures consistent behavior between fresh MCP list and reused MCP list
+        if original.server_label in self.server_label_to_instructions:
+            mcp_instructions = self.server_label_to_instructions[original.server_label]
+            if mcp_instructions and mcp_instructions not in self.mcp_server_instructions:
+                logger.info(
+                    f"Restoring MCP server instructions from {original.server_label} ({len(mcp_instructions)} chars)"
+                )
+                self.mcp_server_instructions.append(mcp_instructions)
 
         mcp_list_message = OpenAIResponseOutputMessageMCPListTools(
             id=f"mcp_list_{uuid.uuid4()}",

--- a/src/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
+++ b/src/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
@@ -51,7 +51,9 @@ class ModelContextProtocolToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime
         # Get other headers from provider data (but NOT authorization)
         provider_headers = await self.get_headers_from_request(mcp_endpoint.uri)
 
-        tools_response = await list_mcp_tools(endpoint=mcp_endpoint.uri, headers=provider_headers, authorization=authorization)
+        tools_response = await list_mcp_tools(
+            endpoint=mcp_endpoint.uri, headers=provider_headers, authorization=authorization
+        )
         return tools_response
 
     async def invoke_tool(

--- a/src/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
+++ b/src/llama_stack/providers/remote/tool_runtime/model_context_protocol/model_context_protocol.py
@@ -51,7 +51,8 @@ class ModelContextProtocolToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime
         # Get other headers from provider data (but NOT authorization)
         provider_headers = await self.get_headers_from_request(mcp_endpoint.uri)
 
-        return await list_mcp_tools(endpoint=mcp_endpoint.uri, headers=provider_headers, authorization=authorization)
+        tools_response = await list_mcp_tools(endpoint=mcp_endpoint.uri, headers=provider_headers, authorization=authorization)
+        return tools_response
 
     async def invoke_tool(
         self, tool_name: str, kwargs: dict[str, Any], authorization: str | None = None

--- a/src/llama_stack/providers/utils/tools/mcp.py
+++ b/src/llama_stack/providers/utils/tools/mcp.py
@@ -432,7 +432,7 @@ async def list_mcp_tools(
             # The session was already initialized in client_wrapper, but we need
             # to access the init result. We'll need to capture it separately.
             # For now, get it via the session's internal state if available
-            if hasattr(session, '_init_result') and session._init_result:
+            if hasattr(session, "_init_result") and session._init_result:
                 instructions = session._init_result.instructions
             await _list_tools_from_session(session)
 

--- a/src/llama_stack_api/tools.py
+++ b/src/llama_stack_api/tools.py
@@ -44,12 +44,14 @@ class ToolGroupInput(BaseModel):
     :param provider_id: ID of the provider that will handle this tool group
     :param args: (Optional) Additional arguments to pass to the provider
     :param mcp_endpoint: (Optional) Model Context Protocol endpoint for remote tools
+    :param mcp_server_instructions: (Optional) Instructions from the MCP server (from initialize response)
     """
 
     toolgroup_id: str
     provider_id: str
     args: dict[str, Any] | None = None
     mcp_endpoint: URL | None = None
+    mcp_server_instructions: str | None = None
 
 
 @json_schema_type
@@ -59,11 +61,13 @@ class ToolGroup(Resource):
     :param type: Type of resource, always 'tool_group'
     :param mcp_endpoint: (Optional) Model Context Protocol endpoint for remote tools
     :param args: (Optional) Additional arguments for the tool group
+    :param mcp_server_instructions: (Optional) Instructions from the MCP server (from initialize response)
     """
 
     type: Literal[ResourceType.tool_group] = ResourceType.tool_group
     mcp_endpoint: URL | None = None
     args: dict[str, Any] | None = None
+    mcp_server_instructions: str | None = None
 
 
 @json_schema_type
@@ -116,6 +120,7 @@ class ToolGroups(Protocol):
         provider_id: str,
         mcp_endpoint: URL | None = None,
         args: dict[str, Any] | None = None,
+        mcp_server_instructions: str | None = None,
     ) -> None:
         """Register a tool group.
 
@@ -123,6 +128,7 @@ class ToolGroups(Protocol):
         :param provider_id: The ID of the provider to use for the tool group.
         :param mcp_endpoint: The MCP endpoint to use for the tool group.
         :param args: A dictionary of arguments to pass to the tool group.
+        :param mcp_server_instructions: Instructions from the MCP server (from initialize response).
         """
         ...
 

--- a/src/llama_stack_api/tools.py
+++ b/src/llama_stack_api/tools.py
@@ -121,6 +121,7 @@ class ToolGroups(Protocol):
         mcp_endpoint: URL | None = None,
         args: dict[str, Any] | None = None,
         mcp_server_instructions: str | None = None,
+        authorization: str | None = None,
     ) -> None:
         """Register a tool group.
 
@@ -129,6 +130,7 @@ class ToolGroups(Protocol):
         :param mcp_endpoint: The MCP endpoint to use for the tool group.
         :param args: A dictionary of arguments to pass to the tool group.
         :param mcp_server_instructions: Instructions from the MCP server (from initialize response).
+        :param authorization: (Optional) OAuth access token for authenticating with the MCP server.
         """
         ...
 
@@ -153,10 +155,13 @@ class ToolGroups(Protocol):
         ...
 
     @webmethod(route="/tools", method="GET", level=LLAMA_STACK_API_V1, deprecated=True)
-    async def list_tools(self, toolgroup_id: str | None = None) -> ListToolDefsResponse:
+    async def list_tools(
+        self, toolgroup_id: str | None = None, authorization: str | None = None
+    ) -> ListToolDefsResponse:
         """List tools with optional tool group.
 
         :param toolgroup_id: The ID of the tool group to list tools for.
+        :param authorization: (Optional) OAuth access token for authenticating with the MCP server.
         :returns: A ListToolDefsResponse.
         """
         ...

--- a/tests/unit/providers/inline/agents/meta_reference/responses/test_mcp_instructions.py
+++ b/tests/unit/providers/inline/agents/meta_reference/responses/test_mcp_instructions.py
@@ -1,0 +1,144 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import patch
+
+from llama_stack.providers.inline.agents.meta_reference.responses.streaming import (
+    MCP_INSTRUCTIONS_MAX_LENGTH,
+)
+from llama_stack_api import OpenAISystemMessageParam
+
+
+def test_mcp_instructions_concatenation():
+    """Test that MCP server instructions are properly concatenated with original instructions."""
+    original_instructions = "Original instructions"
+    mcp_instructions = ["MCP server says: Use tool carefully"]
+
+    accumulated_instructions = "\n\n".join(mcp_instructions)
+    final_instructions = f"{original_instructions}\n\n{accumulated_instructions}"
+
+    assert final_instructions == "Original instructions\n\nMCP server says: Use tool carefully"
+
+
+def test_mcp_instructions_truncation():
+    """Test that MCP server instructions are truncated when they exceed max length."""
+    # Create instructions that exceed max length
+    long_instructions = "a" * (MCP_INSTRUCTIONS_MAX_LENGTH + 100)
+
+    # Simulate the truncation logic from _process_mcp_tool
+    if len(long_instructions) > MCP_INSTRUCTIONS_MAX_LENGTH:
+        truncated = long_instructions[:MCP_INSTRUCTIONS_MAX_LENGTH] + "...[truncated]"
+    else:
+        truncated = long_instructions
+
+    assert len(truncated) == MCP_INSTRUCTIONS_MAX_LENGTH + len("...[truncated]")
+    assert truncated.endswith("...[truncated]")
+
+
+def test_mcp_instructions_opt_in_enabled():
+    """Test that by default MCP server instructions are enabled (max length > 0)."""
+    # By default, max length is 1000, so instructions should be included
+    assert MCP_INSTRUCTIONS_MAX_LENGTH > 0
+    assert MCP_INSTRUCTIONS_MAX_LENGTH == 1000
+
+
+def test_mcp_instructions_opt_in_disabled():
+    """Test that MCP server instructions can be disabled by setting max length to 0."""
+    # Test the disabled case
+    with patch("llama_stack.providers.inline.agents.meta_reference.responses.streaming.MCP_INSTRUCTIONS_MAX_LENGTH", 0):
+        # Simulate the check used in streaming.py
+        simulated_max_length = 0
+        if simulated_max_length > 0:
+            should_include = True
+        else:
+            should_include = False
+
+        assert should_include is False
+
+
+def test_mcp_instructions_no_duplicates():
+    """Test that duplicate MCP server instructions are not added twice."""
+    mcp_server_instructions = []
+    instructions = "Unique instructions"
+
+    # Add instructions first time
+    if instructions not in mcp_server_instructions:
+        mcp_server_instructions.append(instructions)
+
+    assert len(mcp_server_instructions) == 1
+
+    # Try to add same instructions again
+    if instructions not in mcp_server_instructions:
+        mcp_server_instructions.append(instructions)
+
+    # Should still only have one copy
+    assert len(mcp_server_instructions) == 1
+    assert mcp_server_instructions[0] == instructions
+
+
+def test_server_label_to_instructions_mapping():
+    """Test that server_label -> instructions mapping works correctly."""
+    server_label_to_instructions = {}
+    server_label = "test-mcp-server"
+    instructions = "These are MCP server instructions"
+
+    # Store instructions
+    server_label_to_instructions[server_label] = instructions
+
+    # Retrieve instructions
+    assert server_label in server_label_to_instructions
+    assert server_label_to_instructions[server_label] == instructions
+
+    # Test restoration logic
+    mcp_server_instructions = []
+    if server_label in server_label_to_instructions:
+        restored_instructions = server_label_to_instructions[server_label]
+        if restored_instructions and restored_instructions not in mcp_server_instructions:
+            mcp_server_instructions.append(restored_instructions)
+
+    assert instructions in mcp_server_instructions
+    assert len(mcp_server_instructions) == 1
+
+
+def test_system_message_update_with_instructions():
+    """Test that system message is properly updated with accumulated instructions."""
+    # Start with a system message
+    messages = [OpenAISystemMessageParam(content="Original system message")]
+    instructions = "Original system message\n\nMCP instructions from server"
+
+    # Simulate the update logic from streaming.py
+    if messages and isinstance(messages[0], OpenAISystemMessageParam):
+        # Update existing system message
+        updated_message = OpenAISystemMessageParam(content=instructions)
+        messages[0] = updated_message
+    else:
+        # Insert new system message
+        messages.insert(0, OpenAISystemMessageParam(content=instructions))
+
+    assert len(messages) == 1
+    assert messages[0].content == instructions
+
+
+def test_system_message_insert_when_no_system_message():
+    """Test that system message is inserted when messages don't start with one."""
+    # Start with non-system messages
+    from llama_stack_api import OpenAIUserMessageParam
+
+    messages = [OpenAIUserMessageParam(content="User message")]
+    instructions = "New system instructions"
+
+    # Simulate the insertion logic from streaming.py
+    if messages and isinstance(messages[0], OpenAISystemMessageParam):
+        # Update existing
+        messages[0] = OpenAISystemMessageParam(content=instructions)
+    else:
+        # Insert new
+        messages.insert(0, OpenAISystemMessageParam(content=instructions))
+
+    assert len(messages) == 2
+    assert isinstance(messages[0], OpenAISystemMessageParam)
+    assert messages[0].content == instructions
+    assert isinstance(messages[1], OpenAIUserMessageParam)


### PR DESCRIPTION

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
This commit modifies the ToolGroup API to allow retrieving MCP server
instructions, that are usually advertised in MCP initialization
response.
https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization

Also adds this to StreamingResponseOrchestrator.

Mostly generated by claude.

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
