### PR TITLE
fix: llama-stack function tool serialization for Gemini compatibility

### DIFF
--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -1580,9 +1580,13 @@ class StreamingResponseOrchestrator:
 
         for input_tool in tools:
             if input_tool.type == "function":
-                self.ctx.chat_tools.append(
-                    ChatCompletionToolParam(type="function", function=input_tool.model_dump(exclude_none=True))  # type: ignore[typeddict-item,arg-type]  # Dict compatible with FunctionDefinition
+                tool_param: ChatCompletionToolParam = convert_tooldef_to_openai_tool(  # type: ignore[assignment]
+                    tool_name=input_tool.name,
+                    description=input_tool.description,
+                    input_schema=input_tool.parameters,
+                    strict=input_tool.strict,
                 )
+                self.ctx.chat_tools.append(tool_param)
             elif input_tool.type in WebSearchToolTypes:
                 tool_name = "web_search"
                 # Need to access tool_groups_api from tool_executor

--- a/src/ogx/providers/utils/inference/openai_compat.py
+++ b/src/ogx/providers/utils/inference/openai_compat.py
@@ -18,6 +18,7 @@ def convert_tooldef_to_openai_tool(
     tool_name: str,
     description: str | None = None,
     input_schema: dict[str, Any] | None = None,
+    strict: bool | None = None,
 ) -> dict[str, Any]:
     """
     Convert tool parameters to an OpenAI API-compatible dictionary.
@@ -26,6 +27,7 @@ def convert_tooldef_to_openai_tool(
         tool_name: Tool name as string
         description: Optional tool description
         input_schema: Optional JSON Schema for tool parameters
+        strict: Optional flag for strict parameter validation
 
     Returns:
         OpenAI-compatible tool dictionary:
@@ -35,6 +37,7 @@ def convert_tooldef_to_openai_tool(
                 "name": tool_name,
                 "description": description,
                 "parameters": {<JSON Schema>},
+                "strict": strict,
             },
         }
 
@@ -53,6 +56,9 @@ def convert_tooldef_to_openai_tool(
 
     if input_schema:
         function["parameters"] = input_schema
+
+    if strict is not None:
+        function["strict"] = strict
 
     return out
 

--- a/tests/integration/agents/recordings/18d2f156c6911a3b5d03f25ca0ed6664a2154021521369fe17f587d6645593ee.json
+++ b/tests/integration/agents/recordings/18d2f156c6911a3b5d03f25ca0ed6664a2154021521369fe17f587d6645593ee.json
@@ -1,0 +1,135 @@
+{
+  "test_id": "tests/integration/agents/test_openai_responses.py::test_responses_store[openai_client-txt=ollama/llama3.2:3b-instruct-fp16-tools1-False]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What's the weather in Tokyo? YOU MUST USE THE get_weather function to get the weather."
+        }
+      ],
+      "parallel_tool_calls": true,
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      },
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "description": "Get the weather in a given city",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "The city to get the weather for"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16",
+    "provider_metadata": {
+      "openai_sdk_version": "2.41.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-18d2f156c691",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "id": "call_f40wbr1m",
+                    "function": {
+                      "arguments": "{\"city\":\"Tokyo\"}",
+                      "name": "get_weather"
+                    },
+                    "type": "function"
+                  }
+                ]
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-18d2f156c691",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-18d2f156c691",
+          "choices": [],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": {
+            "completion_tokens": 18,
+            "prompt_tokens": 175,
+            "total_tokens": 193,
+            "completion_tokens_details": null,
+            "prompt_tokens_details": null
+          }
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/agents/recordings/1fea50da8997d35b2b1324441017f131c5241b9ad2701db00e8144502e2315a2.json
+++ b/tests/integration/agents/recordings/1fea50da8997d35b2b1324441017f131c5241b9ad2701db00e8144502e2315a2.json
@@ -1,0 +1,126 @@
+{
+  "test_id": "tests/integration/agents/test_openai_responses.py::test_function_call_output_response_with_none_arguments[txt=ollama/llama3.2:3b-instruct-fp16]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "what's the current time? You MUST call the `get_current_time` function to find out."
+        }
+      ],
+      "parallel_tool_calls": true,
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      },
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "get_current_time",
+            "description": "Get the current time"
+          }
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16",
+    "provider_metadata": {
+      "openai_sdk_version": "2.41.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-1fea50da8997",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "id": "call_z2ftsijx",
+                    "function": {
+                      "arguments": "{}",
+                      "name": "get_current_time"
+                    },
+                    "type": "function"
+                  }
+                ]
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-1fea50da8997",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-1fea50da8997",
+          "choices": [],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": {
+            "completion_tokens": 12,
+            "prompt_tokens": 157,
+            "total_tokens": 169,
+            "completion_tokens_details": null,
+            "prompt_tokens_details": null
+          }
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/agents/recordings/6990400835c44339ca284b0c14106a09f22384f053fe1cced0527da482ba9b36.json
+++ b/tests/integration/agents/recordings/6990400835c44339ca284b0c14106a09f22384f053fe1cced0527da482ba9b36.json
@@ -1,0 +1,135 @@
+{
+  "test_id": "tests/integration/agents/test_openai_responses.py::test_responses_store[openai_client-txt=ollama/llama3.2:3b-instruct-fp16-tools1-True]",
+  "request": {
+    "method": "POST",
+    "url": "http://0.0.0.0:11434/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "llama3.2:3b-instruct-fp16",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What's the weather in Tokyo? YOU MUST USE THE get_weather function to get the weather."
+        }
+      ],
+      "parallel_tool_calls": true,
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      },
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "description": "Get the weather in a given city",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "The city to get the weather for"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "llama3.2:3b-instruct-fp16",
+    "provider_metadata": {
+      "openai_sdk_version": "2.41.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-6990400835c4",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "id": "call_gd6snh3f",
+                    "function": {
+                      "arguments": "{\"city\":\"Tokyo\"}",
+                      "name": "get_weather"
+                    },
+                    "type": "function"
+                  }
+                ]
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-6990400835c4",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": "tool_calls",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-6990400835c4",
+          "choices": [],
+          "created": 0,
+          "model": "llama3.2:3b-instruct-fp16",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": "fp_ollama",
+          "usage": {
+            "completion_tokens": 18,
+            "prompt_tokens": 175,
+            "total_tokens": 193,
+            "completion_tokens_details": null,
+            "prompt_tokens_details": null
+          }
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import json
 from unittest.mock import patch
 
 from openai.types.chat.chat_completion_chunk import (
@@ -678,9 +679,6 @@ async def test_tool_call_arguments_arrive_in_subsequent_delta(openai_responses_i
     assert len(completed_chunk.response.output) == 1
     assert completed_chunk.response.output[0].type == "function_call"
     assert completed_chunk.response.output[0].name == "get_weather"
-    # Arguments must be valid JSON — not '{}{"location": "..."}' which was the bug
-    import json
-
     parsed = json.loads(completed_chunk.response.output[0].arguments)
     assert parsed == {"location": "San Francisco"}
 
@@ -781,8 +779,6 @@ async def test_tool_call_arguments_split_across_multiple_deltas(openai_responses
     assert completed_chunk.response.output[0].type == "function_call"
     assert completed_chunk.response.output[0].name == "get_weather"
 
-    import json
-
     parsed = json.loads(completed_chunk.response.output[0].arguments)
     assert parsed == {"location": "Boston"}
 
@@ -837,9 +833,6 @@ async def test_tool_call_no_parameters_still_returns_empty_json(openai_responses
     assert completed_chunk.type == "response.completed"
     assert completed_chunk.response.output[0].type == "function_call"
     assert completed_chunk.response.output[0].name == "get_current_time"
-    # No-parameter functions should produce valid empty JSON
-    import json
-
     parsed = json.loads(completed_chunk.response.output[0].arguments)
     assert parsed == {}
 
@@ -963,3 +956,42 @@ async def test_function_tool_strict_false_included(openai_responses_impl, mock_i
     tool_function = params.tools[0]["function"]
     assert "strict" in tool_function, "strict field should be included when explicitly set to False"
     assert tool_function["strict"] is False, "strict field should be False"
+
+
+async def test_function_tool_type_field_excluded_from_function_dict(openai_responses_impl, mock_inference_api):
+    """Test that the 'type' field from the input tool is excluded from the function dict.
+
+    The function dict inside ChatCompletionToolParam should only contain function-specific
+    fields (name, description, parameters, strict) and not the top-level 'type' field,
+    which belongs on the outer tool param.
+    """
+    input_text = "What is the weather?"
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        input=input_text,
+        model=model,
+        stream=False,
+        tools=[
+            OpenAIResponseInputToolFunction(
+                type="function",
+                name="get_weather",
+                description="Get weather information",
+                parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
+            )
+        ],
+    )
+
+    assert mock_inference_api.openai_chat_completion.call_count == 1
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+
+    assert len(params.tools) == 1
+    # The outer tool param should have type="function"
+    assert params.tools[0]["type"] == "function"
+    # The inner function dict should NOT contain 'type'
+    tool_function = params.tools[0]["function"]
+    assert "type" not in tool_function, "The input tool 'type' field should be excluded from the function dict"
+    assert tool_function["name"] == "get_weather"
+    assert tool_function["description"] == "Get weather information"


### PR DESCRIPTION
# What does this PR do?
llama-stack's Responses API to Chat Completions conversion in streaming.py leaks a "type" field into the function tool dict via model_dump(). The OpenAI Chat Completions FunctionDefinition schema only allows name, description, parameters, and strict — not type. OpenAI silently ignores the extra field, but Gemini's OpenAI-compatible endpoint strictly validates and rejects it with:
"Unknown name 'type' at 'tools[N].function': Cannot find field."

Fix: exclude type from serialization in streaming.py:
 function=input_tool.model_dump(exclude={"type"})

## Test Plan
unit tests included