### PR TITLE
fix: emit response.output_text.done streaming event per OpenAI spec

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -8476,6 +8476,13 @@ components:
         sequence_number:
           title: Sequence Number
           type: integer
+        logprobs:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/OpenAITokenLogProb'
+            type: array
+          - type: 'null'
+          nullable: true
         type:
           const: response.output_text.done
           default: response.output_text.done

--- a/docs/static/deprecated-llama-stack-spec.yaml
+++ b/docs/static/deprecated-llama-stack-spec.yaml
@@ -5177,6 +5177,13 @@ components:
         sequence_number:
           title: Sequence Number
           type: integer
+        logprobs:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/OpenAITokenLogProb'
+            type: array
+          - type: 'null'
+          nullable: true
         type:
           const: response.output_text.done
           default: response.output_text.done

--- a/docs/static/experimental-llama-stack-spec.yaml
+++ b/docs/static/experimental-llama-stack-spec.yaml
@@ -5358,6 +5358,13 @@ components:
         sequence_number:
           title: Sequence Number
           type: integer
+        logprobs:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/OpenAITokenLogProb'
+            type: array
+          - type: 'null'
+          nullable: true
         type:
           const: response.output_text.done
           default: response.output_text.done

--- a/docs/static/llama-stack-spec.yaml
+++ b/docs/static/llama-stack-spec.yaml
@@ -7361,6 +7361,13 @@ components:
         sequence_number:
           title: Sequence Number
           type: integer
+        logprobs:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/OpenAITokenLogProb'
+            type: array
+          - type: 'null'
+          nullable: true
         type:
           const: response.output_text.done
           default: response.output_text.done

--- a/docs/static/stainless-llama-stack-spec.yaml
+++ b/docs/static/stainless-llama-stack-spec.yaml
@@ -8476,6 +8476,13 @@ components:
         sequence_number:
           title: Sequence Number
           type: integer
+        logprobs:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/OpenAITokenLogProb'
+            type: array
+          - type: 'null'
+          nullable: true
         type:
           const: response.output_text.done
           default: response.output_text.done

--- a/src/llama_stack/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/llama_stack/providers/inline/responses/builtin/responses/streaming.py
@@ -74,6 +74,7 @@ from llama_stack_api import (
     OpenAIResponseObjectStreamResponseOutputItemAdded,
     OpenAIResponseObjectStreamResponseOutputItemDone,
     OpenAIResponseObjectStreamResponseOutputTextDelta,
+    OpenAIResponseObjectStreamResponseOutputTextDone,
     OpenAIResponseObjectStreamResponseReasoningTextDelta,
     OpenAIResponseObjectStreamResponseReasoningTextDone,
     OpenAIResponseObjectStreamResponseRefusalDelta,
@@ -1145,9 +1146,19 @@ class StreamingResponseOrchestrator:
                 sequence_number=self.sequence_number,
             )
 
-        # Emit content_part.done event if text content was streamed (before content gets cleared)
+        # Emit output_text.done and content_part.done events if text content was streamed
         if content_part_emitted:
             final_text = "".join(chat_response_content)
+            # Emit output_text.done with the final accumulated text (per OpenAI protocol)
+            self.sequence_number += 1
+            yield OpenAIResponseObjectStreamResponseOutputTextDone(
+                content_index=content_index,
+                text=final_text,
+                item_id=message_item_id,
+                output_index=message_output_index,
+                sequence_number=self.sequence_number,
+                logprobs=chat_response_logprobs if chat_response_logprobs else [],
+            )
             self.sequence_number += 1
             yield OpenAIResponseObjectStreamResponseContentPartDone(
                 content_index=content_index,

--- a/src/llama_stack_api/openai_responses.py
+++ b/src/llama_stack_api/openai_responses.py
@@ -928,6 +928,7 @@ class OpenAIResponseObjectStreamResponseOutputTextDone(BaseModel):
     :param item_id: Unique identifier of the completed output item
     :param output_index: Index position of the item in the output list
     :param sequence_number: Sequential number for ordering streaming events
+    :param logprobs: Token log probability details for the completed text
     :param type: Event type identifier, always "response.output_text.done"
     """
 
@@ -936,6 +937,7 @@ class OpenAIResponseObjectStreamResponseOutputTextDone(BaseModel):
     item_id: str
     output_index: int
     sequence_number: int
+    logprobs: list[OpenAITokenLogProb] | None = None
     type: Literal["response.output_text.done"] = "response.output_text.done"
 
 

--- a/tests/unit/providers/responses/builtin/test_openai_responses.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses.py
@@ -241,7 +241,8 @@ async def test_create_openai_response_with_string_input(openai_responses_impl, m
     )
 
     # Should have content part events for text streaming
-    # Expected: response.created, response.in_progress, content_part.added, output_text.delta, content_part.done, response.completed
+    # Expected: response.created, response.in_progress, output_item.added, content_part.added,
+    #           output_text.delta, output_text.done, content_part.done, output_item.done, response.completed
     assert len(chunks) >= 5
     assert chunks[0].type == "response.created"
     assert any(chunk.type == "response.in_progress" for chunk in chunks)
@@ -250,10 +251,12 @@ async def test_create_openai_response_with_string_input(openai_responses_impl, m
     content_part_added_events = [c for c in chunks if c.type == "response.content_part.added"]
     content_part_done_events = [c for c in chunks if c.type == "response.content_part.done"]
     text_delta_events = [c for c in chunks if c.type == "response.output_text.delta"]
+    text_done_events = [c for c in chunks if c.type == "response.output_text.done"]
 
     assert len(content_part_added_events) >= 1, "Should have content_part.added event for text"
     assert len(content_part_done_events) >= 1, "Should have content_part.done event for text"
     assert len(text_delta_events) >= 1, "Should have text delta events"
+    assert len(text_done_events) >= 1, "Should have output_text.done event with final accumulated text"
 
     added_event = content_part_added_events[0]
     done_event = content_part_done_events[0]
@@ -262,6 +265,20 @@ async def test_create_openai_response_with_string_input(openai_responses_impl, m
     assert added_event.output_index == done_event.output_index == 0
     assert added_event.item_id == done_event.item_id
     assert added_event.response_id == done_event.response_id
+
+    # Verify output_text.done contains the final accumulated text and correct indices
+    text_done_event = text_done_events[0]
+    assert text_done_event.content_index == 0
+    assert text_done_event.output_index == 0
+    assert text_done_event.item_id == added_event.item_id
+    assert isinstance(text_done_event.text, str)
+    assert len(text_done_event.text) > 0, "output_text.done should contain the final text"
+
+    # Verify output_text.done comes before content_part.done (per OpenAI protocol)
+    chunk_types = [c.type for c in chunks]
+    text_done_idx = chunk_types.index("response.output_text.done")
+    content_done_idx = chunk_types.index("response.content_part.done")
+    assert text_done_idx < content_done_idx, "output_text.done must precede content_part.done"
 
     # Verify final event is completion
     assert chunks[-1].type == "response.completed"


### PR DESCRIPTION
## Summary

The LlamaStack server was missing the `response.output_text.done` streaming event, which the OpenAI Responses API spec requires between `output_text.delta` events and `content_part.done`.

Discovered by comparing streaming event sequences between OpenAI's `gpt-5.1` (ground truth) and LlamaStack server output using the OpenAI Python client.

Fixes #5309

## Changes

- **`streaming.py`**: Import and emit `OutputTextDone` with final accumulated text and logprobs, before `content_part.done`
- **`openai_responses.py`**: Add `logprobs` field to `OutputTextDone` type definition (per OpenAI spec)
- **`test_openai_responses.py`**: Verify `output_text.done` is emitted with correct fields and ordering

## Test plan

### Reproduce with this snippet

Prerequisites: LlamaStack server running at `localhost:8321` with a registered model.

```python
from openai import OpenAI

client = OpenAI(base_url="http://127.0.0.1:8321/v1", api_key="fake")

events = list(client.responses.create(
    model="ollama/gpt-oss:20b",  # or any registered model
    input="What is 2 + 2?",
    stream=True,
))

for e in events:
    item = getattr(e, 'item', None)
    if item and hasattr(item, 'type'):
        print(f"{e.type:<50} item.type={item.type}")
    elif e.type == "response.output_text.done":
        print(f"{e.type:<50} text={e.text!r}")
    elif e.type == "response.content_part.done":
        print(f"{e.type:<50} part.type={e.part.type}")
    else:
        print(e.type)

has_done = any(e.type == "response.output_text.done" for e in events)
print(f"\nHas response.output_text.done: {has_done}")
```

### Ground truth (OpenAI `gpt-5.1` directly)

```
response.created
response.in_progress
response.output_item.added                         item.type=message
response.content_part.added
response.output_text.delta                         (x N)
response.output_text.done                          text='2 + 2 = 4.'    <-- present
response.content_part.done
response.output_item.done                          item.type=message
response.completed
```

### Before this PR 

```
response.created
response.in_progress
response.content_part.added
response.reasoning_text.delta                      (x N)
response.output_item.added
response.content_part.added
response.output_text.delta                         (x N)
                                                   <-- output_text.done MISSING
response.content_part.done                         part.type=output_text
response.reasoning_text.done
response.content_part.done                         part.type=reasoning_text
response.output_item.done
response.completed
```

### After this PR

```
response.created
response.in_progress
response.content_part.added
response.reasoning_text.delta                      (x N)
response.output_item.added
response.content_part.added
response.output_text.delta                         (x N)
response.output_text.done                          <-- NOW PRESENT
response.content_part.done                         part.type=output_text
response.reasoning_text.done
response.content_part.done                         part.type=reasoning_text
response.output_item.done
response.completed
```

**Note:** Reasoning streaming events are not fully spec-compliant yet (e.g. incorrect ordering, missing `output_item.added/done` for reasoning items). That will be addressed in a follow-up PR. This PR focuses solely on the missing `output_text.done` event.

**Unit tests:** 223 passing (`uv run pytest tests/unit/providers/responses/builtin/ -q`)