### PR TITLE
fix: add WAL mode and busy_timeout to sqlite-vec vector store connections

### DIFF
--- a/src/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/src/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -113,6 +113,9 @@ def _create_sqlite_connection(db_path: str):
     connection.enable_load_extension(True)
     _get_sqlite_vec().load(connection)
     connection.enable_load_extension(False)
+    # Enable WAL mode and busy timeout for concurrent access (consistent with sqlalchemy_sqlstore)
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA busy_timeout=5000")
     return connection
 
 


### PR DESCRIPTION
## Summary

- Adds `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000` to the sqlite-vec vector store's `_create_sqlite_connection()` function
- These PRAGMAs are already set in the KV store (`sqlalchemy_sqlstore.py:140-148`) but were missing from the vector store, causing `sqlite3.OperationalError: database is locked` under concurrent access with multiple uvicorn workers

## Root cause

The `_create_sqlite_connection()` helper in `sqlite_vec.py` creates every SQLite connection used by the vector store (for table init, chunk insertion, querying, and deletion). It was missing the WAL mode and busy_timeout PRAGMAs that the KV store already sets, so concurrent writes from multiple workers would fail immediately instead of waiting and retrying.

## Changes

**`src/llama_stack/providers/inline/vector_io/sqlite_vec/sqlite_vec.py`**

Added two PRAGMAs to `_create_sqlite_connection()` after loading the sqlite-vec extension:

```python
connection.execute("PRAGMA journal_mode=WAL")
connection.execute("PRAGMA busy_timeout=5000")
```

This is consistent with the existing pattern in `sqlalchemy_sqlstore.py` (lines 143-146).

Fixes #5344

🤖 Generated with [Claude Code](https://claude.com/claude-code)