### PR TITLE
feat(inference): add reasoning support to vertexai provider

### DIFF
--- a/src/llama_stack/providers/remote/inference/vertexai/converters.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/converters.py
@@ -250,8 +250,22 @@ def _convert_assistant_message(msg: dict[str, Any]) -> dict[str, Any] | None:
     """Convert an OpenAI assistant message to a Gemini Content dict.
 
     Returns ``None`` when the message has no text content and no tool calls.
+
+    When the message carries ``reasoning_content`` (from a prior turn with
+    thinking enabled), emit it as a Gemini thinking part (``thought: True``)
+    so the model treats it as prior reasoning rather than regular text.
     """
     parts: list[dict[str, Any]] = []
+
+    # Limitation: Gemini's thinking API supports opaque ``thought_signature``
+    # tokens for faithful reasoning replay, but the llama-stack Responses
+    # layer does not capture or propagate them.  We replay reasoning as
+    # plain text with ``thought: True``, which is a lossy approximation.
+    # This matches what other providers (bedrock, ollama, vllm) do with
+    # their own reasoning fields.
+    reasoning = msg.get("reasoning_content")
+    if reasoning:
+        parts.append({"text": reasoning, "thought": True})
 
     text = _extract_text_content(msg.get("content"))
     if text:

--- a/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
@@ -44,6 +44,10 @@ from llama_stack_api import (
     validate_embeddings_input_is_text,
 )
 from llama_stack_api.inference import RerankRequest
+from llama_stack_api.inference.models import (
+    OpenAIChatCompletionChunkWithReasoning,
+    OpenAIChatCompletionWithReasoning,
+)
 
 logger = get_logger(__name__, category="inference")
 
@@ -652,6 +656,44 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             tool_choice = converters.convert_deprecated_function_call_to_tool_choice(params.function_call)
 
         return tools, tool_choice
+
+    async def openai_chat_completions_with_reasoning(
+        self,
+        params: OpenAIChatCompletionRequestWithExtraBody,
+    ) -> OpenAIChatCompletionWithReasoning | AsyncIterator[OpenAIChatCompletionChunkWithReasoning]:
+        """Chat completion with reasoning support for Vertex AI.
+
+        Delegates to the regular chat completion flow (which already maps
+        ``reasoning_effort`` to Gemini's ``ThinkingConfig`` and extracts
+        thinking parts from responses).  The returned streaming chunks are
+        wrapped in the internal reasoning types so the Responses layer can
+        read ``reasoning_content`` as a typed field.
+
+        Non-streaming is not supported because the non-streaming converter
+        merges thinking text into the ``content`` field (the standard
+        ``OpenAIChatCompletionResponseMessage`` has no ``reasoning_content``
+        attribute).  The Responses layer always calls this method with
+        streaming enabled.
+        """
+        if not params.stream:
+            raise NotImplementedError("Non-streaming reasoning is not yet supported for VertexAI")
+
+        result = await self.openai_chat_completion(params)
+
+        async def _wrap_chunks() -> AsyncIterator[OpenAIChatCompletionChunkWithReasoning]:
+            async for chunk in result:  # type: ignore[union-attr]
+                # NOTE: When n>1, this keeps only the last choice's reasoning.
+                # This matches bedrock/ollama/vllm behavior. The Responses
+                # layer does not request n>1.
+                reasoning = None
+                for choice in chunk.choices or []:
+                    reasoning = getattr(choice.delta, "reasoning_content", None)
+                yield OpenAIChatCompletionChunkWithReasoning(
+                    chunk=chunk,
+                    reasoning_content=reasoning,
+                )
+
+        return _wrap_chunks()
 
     async def openai_chat_completion(
         self,

--- a/tests/unit/providers/inference/vertexai/test_adapter_reasoning.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_reasoning.py
@@ -1,0 +1,147 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for VertexAI openai_chat_completions_with_reasoning()."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from llama_stack_api.inference.models import (
+    OpenAIChatCompletionChunkWithReasoning,
+    OpenAIChatCompletionRequestWithExtraBody,
+)
+
+from .conftest import _make_fake_streaming_chunk
+
+
+def _make_thinking_streaming_chunk(
+    text: str = "answer",
+    thinking_text: str = "let me think",
+) -> SimpleNamespace:
+    """Build a fake streaming chunk with both a thinking part and a text part."""
+    thinking_part = SimpleNamespace(text=thinking_text, thought=True, function_call=None)
+    text_part = SimpleNamespace(text=text, thought=None, function_call=None)
+    content = SimpleNamespace(parts=[thinking_part, text_part])
+    candidate = SimpleNamespace(content=content, finish_reason="STOP", index=0, logprobs_result=None)
+    return SimpleNamespace(candidates=[candidate], usage_metadata=None)
+
+
+@pytest.fixture
+def streaming_adapter(adapter, monkeypatch):
+    """Adapter wired to stream from a list of fake Gemini chunks.
+
+    Returns a callable: ``streaming_adapter(chunks)`` patches the adapter
+    and returns it ready for ``openai_chat_completions_with_reasoning()``.
+    """
+
+    def _configure(chunks: list[SimpleNamespace]):
+        async def fake_stream(**kwargs):
+            """Yield predefined fake stream chunks."""
+            for c in chunks:
+                yield c
+
+        fake_client = SimpleNamespace(
+            aio=SimpleNamespace(models=SimpleNamespace(generate_content_stream=AsyncMock(return_value=fake_stream())))
+        )
+
+        async def _provider_model_id(_: str) -> str:
+            """Return a fixed provider model identifier."""
+            return "gemini-2.5-flash"
+
+        monkeypatch.setattr(adapter, "_get_provider_model_id", _provider_model_id)
+        monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
+        monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
+        return adapter
+
+    return _configure
+
+
+def _make_streaming_params(**overrides: Any) -> OpenAIChatCompletionRequestWithExtraBody:
+    """Build a minimal streaming chat completion request."""
+    defaults = {
+        "model": "google/gemini-2.5-flash",
+        "messages": cast(Any, [{"role": "user", "content": "hi"}]),
+        "stream": True,
+    }
+    defaults.update(overrides)
+    return OpenAIChatCompletionRequestWithExtraBody(**defaults)
+
+
+class TestOpenAIChatCompletionsWithReasoning:
+    """Test the openai_chat_completions_with_reasoning method."""
+
+    async def test_non_streaming_raises_not_implemented(self, adapter, patch_chat_completion_dependencies):
+        """Non-streaming reasoning raises NotImplementedError."""
+        patch_chat_completion_dependencies(adapter)
+        params = _make_streaming_params(stream=False, reasoning_effort="medium")
+        with pytest.raises(NotImplementedError, match="Non-streaming reasoning"):
+            await adapter.openai_chat_completions_with_reasoning(params)
+
+    async def test_all_chunks_wrapped(self, streaming_adapter):
+        """Every yielded chunk is an OpenAIChatCompletionChunkWithReasoning."""
+        adapter = streaming_adapter(
+            [
+                _make_thinking_streaming_chunk(text="Hello", thinking_text="Planning"),
+                _make_fake_streaming_chunk("world"),
+            ]
+        )
+
+        result = await adapter.openai_chat_completions_with_reasoning(
+            _make_streaming_params(reasoning_effort="high"),
+        )
+        chunks = [c async for c in result]
+
+        assert len(chunks) == 2
+        assert all(isinstance(c, OpenAIChatCompletionChunkWithReasoning) for c in chunks)
+
+    @pytest.mark.parametrize(
+        "gemini_chunks, expected_reasoning",
+        [
+            pytest.param(
+                [_make_thinking_streaming_chunk(text="Hi", thinking_text="Planning response")],
+                ["Planning response"],
+                id="thinking_part_extracted",
+            ),
+            pytest.param(
+                [_make_fake_streaming_chunk("just text")],
+                [None],
+                id="no_thinking_yields_none",
+            ),
+            pytest.param(
+                [
+                    _make_thinking_streaming_chunk(text="a", thinking_text="thought1"),
+                    _make_fake_streaming_chunk("b"),
+                    _make_thinking_streaming_chunk(text="c", thinking_text="thought2"),
+                ],
+                ["thought1", None, "thought2"],
+                id="mixed_thinking_and_plain",
+            ),
+        ],
+    )
+    async def test_reasoning_content_extraction(self, streaming_adapter, gemini_chunks, expected_reasoning):
+        """Reasoning content is correctly extracted (or None) per chunk."""
+        adapter = streaming_adapter(gemini_chunks)
+
+        result = await adapter.openai_chat_completions_with_reasoning(_make_streaming_params())
+        chunks = [c async for c in result]
+
+        actual = [c.reasoning_content for c in chunks]
+        assert actual == expected_reasoning
+
+    async def test_inner_chunk_preserves_model_and_role(self, streaming_adapter):
+        """The .chunk attribute contains the original OpenAIChatCompletionChunk unchanged."""
+        adapter = streaming_adapter([_make_thinking_streaming_chunk(text="answer", thinking_text="thinking")])
+
+        result = await adapter.openai_chat_completions_with_reasoning(_make_streaming_params())
+        wrapped = [c async for c in result]
+
+        inner = wrapped[0].chunk
+        assert inner.model == "google/gemini-2.5-flash"
+        assert inner.choices[0].delta.role == "assistant"
+        assert inner.choices[0].delta.content == "answer"

--- a/tests/unit/providers/inference/vertexai/test_converters_requests.py
+++ b/tests/unit/providers/inference/vertexai/test_converters_requests.py
@@ -594,6 +594,47 @@ class TestConvertOpenAIMessagesToGemini:
         assert model_msg["parts"][0] == {"text": "Let me check."}
         assert "function_call" in model_msg["parts"][1]
 
+    def test_assistant_with_reasoning_content_creates_thinking_part(self):
+        """Assistant message with reasoning_content emits a Gemini thinking part."""
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "The answer is 42.",
+                "reasoning_content": "I need to think about this carefully.",
+            },
+        ]
+        system, contents = convert_openai_messages_to_gemini(messages)
+        assert len(contents) == 2
+        model_msg = contents[1]
+        assert model_msg["role"] == "model"
+        # Thinking part comes first, then text part
+        assert len(model_msg["parts"]) == 2
+        assert model_msg["parts"][0] == {"text": "I need to think about this carefully.", "thought": True}
+        assert model_msg["parts"][1] == {"text": "The answer is 42."}
+
+    def test_assistant_with_reasoning_content_only(self):
+        """Assistant message with only reasoning_content and no text content."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "Deep thinking here.",
+            },
+        ]
+        system, contents = convert_openai_messages_to_gemini(messages)
+        assert len(contents) == 1
+        model_msg = contents[0]
+        assert model_msg["parts"] == [{"text": "Deep thinking here.", "thought": True}]
+
+    def test_assistant_without_reasoning_content_unchanged(self):
+        """Regular assistant message without reasoning_content works as before."""
+        messages = [
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        system, contents = convert_openai_messages_to_gemini(messages)
+        assert contents[0]["parts"] == [{"text": "Hello!"}]
+
     def test_tool_call_id_not_found(self):
         """When tool_call_id doesn't match any assistant message, use 'unknown' as name."""
         messages = [


### PR DESCRIPTION
# What does this PR do?

Implements `openai_chat_completions_with_reasoning()` for the `remote::vertexai` inference provider so the Responses API can extract reasoning content when thinking is enabled on Gemini models.

Changes:
- New `openai_chat_completions_with_reasoning()` method on `VertexAIInferenceAdapter` that wraps streaming chunks in `OpenAIChatCompletionChunkWithReasoning`
- Converter now emits prior-turn `reasoning_content` as Gemini thinking parts (`thought: True`) for multi-turn reasoning conversations
- Unit tests for the new method (parameterized streaming scenarios, non-streaming error, chunk preservation)
- Converter tests for reasoning on assistant input messages

Closes #5448

## Test Plan

Unit tests covering the new functionality:

```bash
uv run pytest tests/unit/providers/inference/vertexai/ -x --tb=short -q
```

Output:
```
266 passed in 0.28s
```

All pre-commit hooks pass.