### PR TITLE
fix(docs): fix Ollama commands in Quick Start Guide

### DIFF
--- a/docs/docs/distributions/self_hosted_distro/starter.md
+++ b/docs/docs/distributions/self_hosted_distro/starter.md
@@ -133,7 +133,7 @@ You can enable specific providers by setting appropriate environment variables. 
 
 ```bash
 # self-hosted
-export OLLAMA_URL=http://localhost:11434   # enables the Ollama inference provider
+export OLLAMA_URL=http://localhost:11434/v1   # enables the Ollama inference provider
 export VLLM_URL=http://localhost:8000/v1   # enables the vLLM inference provider
 export TGI_URL=http://localhost:8000/v1   # enables the TGI inference provider
 

--- a/docs/docs/getting_started/quickstart.mdx
+++ b/docs/docs/getting_started/quickstart.mdx
@@ -19,6 +19,7 @@ Install [Ollama](https://ollama.com/download), then pull a model and start the s
 
 ```bash
 ollama pull llama3.2:3b
+export OLLAMA_URL=http://localhost:11434/v1
 uvx --from 'llama-stack[starter]' llama stack run starter
 ```
 
@@ -39,6 +40,7 @@ The `uvx` command above is great for trying things out. For a real project, inst
 ```bash
 uv init my-ai-app && cd my-ai-app
 uv add 'llama-stack[starter]' openai
+export OLLAMA_URL=http://localhost:11434/v1
 uv run llama stack run starter
 ```
 :::

--- a/docs/docs/getting_started/quickstart.mdx
+++ b/docs/docs/getting_started/quickstart.mdx
@@ -79,9 +79,9 @@ You should see output listing available models, for example:
 {
     "data": [
         {
-            "id": "llama3.2:3b",
+            "id": "ollama/llama3.2:3b",
             "object": "model",
-            "owned_by": "ollama",
+            "owned_by": "llama_stack",
             ...
         }
     ]
@@ -100,7 +100,7 @@ from openai import OpenAI
 client = OpenAI(base_url="http://localhost:8321/v1", api_key="fake")
 
 response = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="What is Llama Stack?",
 )
 print(response.output_text)
@@ -133,7 +133,7 @@ vector_store = client.vector_stores.create(
 
 # Ask questions with file search
 response = client.responses.create(
-    model="llama3.2:3b",
+    model="ollama/llama3.2:3b",
     input="Summarize the key points",
     tools=[{
         "type": "file_search",


### PR DESCRIPTION
# What does this PR do?
The starter distro needs OLLAMA_URL to be set to enable the provider, per https://llamastack.github.io/docs/distributions/self_hosted_distro/starter#enabling-providers

Also update starter distro enable section to include updated Ollama url present in the starter config.yaml

Closes #5551

## Test Plan
Run locally - results without changes can be observed in logs shared in the attached bug