### PR TITLE
fix: fallback to allowed_models when /v1/models call fails

### DIFF
--- a/src/llama_stack/providers/utils/inference/openai_mixin.py
+++ b/src/llama_stack/providers/utils/inference/openai_mixin.py
@@ -181,10 +181,15 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
 
         :return: An iterable of model IDs or None if not implemented
         """
-        client = self.client
-        async with client:
-            model_ids = [m.id async for m in client.models.list()]
-        return model_ids
+        try:
+            client = self.client
+            async with client:
+                model_ids = [m.id async for m in client.models.list()]
+            return model_ids
+        except Exception:
+            if self.config.allowed_models is not None:
+                return list(self.config.allowed_models)
+            raise
 
     async def initialize(self) -> None:
         """


### PR DESCRIPTION

When `list_provider_model_ids()` fails to reach the provider's `/v1/models` endpoint (e.g., 401/404 from providers that don't support model listing), fall back to the configured `allowed_models` list instead of crashing startup. If `allowed_models` is not configured, the error is re-raised as before.

This fixes startup failures for OpenAI-compatible providers that:
- Don't support the `/v1/models` endpoint (returns 401/404)
- Return model IDs in a different format (e.g., `models/gemini-2.5-pro` vs `gemini-2.5-pro`), causing the allowed_models filter to skip all models and fail with "Model X is not available from provider Y"
