### PR TITLE
feat(letsgo): add llama stack letsgo command

### DIFF
--- a/src/llama_stack/cli/stack/lets_go.py
+++ b/src/llama_stack/cli/stack/lets_go.py
@@ -1,0 +1,290 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import argparse
+import enum
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urljoin
+
+import httpx
+import yaml
+from termcolor import cprint
+
+from llama_stack.cli.stack.run import StackRun
+from llama_stack.cli.subcommand import Subcommand
+from llama_stack.core.build import get_provider_dependencies
+from llama_stack.core.stack import run_config_from_dynamic_config_spec
+from llama_stack.core.utils.config_dirs import DISTRIBS_BASE_DIR
+from llama_stack.log import get_logger
+
+logger = get_logger(name=__name__, category="cli")
+
+
+class _ProbeStatus(enum.Enum):
+    OK = "ok"
+    NO_KEY = "no_key"
+    AUTH = "auth"
+    UNREACHABLE = "unreachable"
+
+
+class StackLetsGo(Subcommand):
+    """Auto-detect providers, generate runtime config, and start the stack.
+
+    Providers fall into three categories:
+
+    - Inline providers (files=inline::localfs, vector_io=inline::faiss,
+      tool_runtime=inline::file-search, file_processors=inline::pypdf,
+      responses=inline::builtin): require no external service and are always
+      included.
+    - Key-free providers (Ollama, vLLM, llama-cpp-server): included when a
+      lightweight HTTP probe to their endpoint succeeds.
+    - API-key providers (OpenAI, Anthropic, ...): included only when the
+      required API key environment variable is set *and* the probe succeeds.
+      A missing key is reported without making a network request.
+    """
+
+    def __init__(self, subparsers: Any) -> None:
+        super().__init__()
+        self.parser = subparsers.add_parser(
+            "letsgo",
+            prog="llama stack letsgo",
+            description="Auto-detect providers and start the stack",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        self._add_arguments()
+        self.parser.set_defaults(func=self._run_stack_lets_go_cmd)
+
+    def _add_arguments(self) -> None:
+        self.parser.add_argument(
+            "--port",
+            type=int,
+            help="Port to run the server on. It can also be passed via the env var LLAMA_STACK_PORT.",
+            default=int(os.getenv("LLAMA_STACK_PORT", 8321)),
+        )
+        self.parser.add_argument(
+            "--enable-ui",
+            action="store_true",
+            help="Start the UI server",
+        )
+        self.parser.add_argument(
+            "--persist-config",
+            action="store_true",
+            help="Persist generated runtime config to the distro directory",
+        )
+        self.parser.add_argument(
+            "--providers-override",
+            type=str,
+            default=None,
+            help="Explicit providers spec to use instead of auto-detection (e.g. inference=remote::ollama)",
+        )
+        self.parser.add_argument(
+            "--skip-install-deps",
+            action="store_true",
+            help="Skip automatic installation of provider pip dependencies before starting the server.",
+        )
+
+    def _run_stack_lets_go_cmd(self, args: argparse.Namespace) -> None:
+        # If user asked to start the UI, attempt to start it (best-effort)
+        if args.enable_ui:
+            try:
+                stack_run = StackRun(argparse.ArgumentParser().add_subparsers())
+                stack_run._start_ui_development_server(args.port)
+            except Exception:
+                # UI is best-effort; do not fail the whole command
+                logger.warning("Failed to start UI development server", exc_info=True)
+
+        # Determine providers spec (either overridden or auto-detected)
+        if args.providers_override:
+            providers_spec = args.providers_override
+        else:
+            providers_spec = self._autodetect_providers()
+
+        has_inference = any(p.startswith("inference=") for p in (providers_spec or "").split(","))
+        if not has_inference:
+            self.parser.error("No inference providers detected. Nothing to run.")
+
+        distro_dir = DISTRIBS_BASE_DIR / "letsgo-run" if args.persist_config else Path(tempfile.mkdtemp())
+        os.makedirs(distro_dir, exist_ok=True)
+
+        try:
+            run_config = run_config_from_dynamic_config_spec(
+                dynamic_config_spec=providers_spec,
+                distro_dir=distro_dir,
+                distro_name="letsgo-run",
+            )
+        except ValueError as e:
+            cprint(str(e), color="red", file=sys.stderr)
+            sys.exit(1)
+
+        if not args.skip_install_deps:
+            normal_deps, special_deps, _ = get_provider_dependencies(run_config)
+            self._install_provider_deps(normal_deps, special_deps)
+
+        config_dict = run_config.model_dump(mode="json")
+
+        config_file = distro_dir / "config.yaml"
+        logger.info("Writing generated config to", config_file=config_file)
+        with open(config_file, "w") as f:
+            yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+
+        # Reuse StackRun's uvicorn startup
+        try:
+            stack_run = StackRun(argparse.ArgumentParser().add_subparsers())
+            # Build args similar to stack run
+            stack_args = argparse.Namespace()
+            stack_args.port = args.port
+            stack_args.enable_ui = args.enable_ui
+            stack_args.providers = None
+            stack_run._uvicorn_run(config_file, stack_args)
+        except Exception:
+            logger.exception("Failed to start the stack server")
+            raise
+
+    def _install_provider_deps(self, normal_deps: list[str], special_deps: list[str]) -> None:
+        """Install provider pip dependencies into the current environment.
+
+        Uses `uv pip install` when uv is available, falling back to `pip install`.
+        A non-zero exit is logged as a warning rather than aborting startup,
+        since packages may already satisfy the declared constraints.
+        """
+        if shutil.which("uv"):
+            installer = ["uv", "pip", "install"]
+        else:
+            installer = [sys.executable, "-m", "pip", "install"]
+
+        if normal_deps:
+            cprint("Installing provider dependencies...", color="cyan")
+            result = subprocess.run([*installer, *normal_deps])
+            if result.returncode != 0:
+                logger.warning("Failed to install provider dependencies", returncode=result.returncode)
+
+        for special_dep in special_deps:
+            result = subprocess.run([*installer, *special_dep.split()])
+            if result.returncode != 0:
+                logger.warning(
+                    "Failed to install special provider dependency", dep=special_dep, returncode=result.returncode
+                )
+
+    def _autodetect_providers(self) -> str:
+        """Probe all candidate providers and return a comma-separated providers spec string.
+
+        Each provider is probed independently; all that pass are included in the
+        result. Providers that require an API key skip the network probe entirely
+        when the key environment variable is not set.
+        """
+        candidates = [
+            # provider_type, env_for_base_url, default_base_url, probe_path, requires_api_key, api_key_env, extra_headers
+            ("remote::ollama", "OLLAMA_URL", "http://localhost:11434/v1", "models", False, None, {}),
+            ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", "health", False, None, {}),
+            ("remote::llama-cpp-server", "LLAMA_CPP_SERVER_URL", "http://localhost:8080/v1", "models", False, None, {}),
+            ("remote::openai", "OPENAI_BASE_URL", "https://api.openai.com/v1", "models", True, "OPENAI_API_KEY", {}),
+            (
+                "remote::llama-openai-compat",
+                "LLAMA_API_BASE_URL",
+                "https://api.llama.com/compat/v1/",
+                "models",
+                True,
+                "LLAMA_API_KEY",
+                {},
+            ),
+            (
+                "remote::anthropic",
+                None,
+                "https://api.anthropic.com/v1",
+                "models",
+                True,
+                "ANTHROPIC_API_KEY",
+                {"anthropic-version": "2023-06-01"},
+            ),
+        ]
+
+        passed: list[str] = []
+        cprint("Scanning for available providers...", color="cyan")
+        for provider_type, base_env, default_base, probe_path, requires_key, key_env, extra_headers in candidates:
+            env_val: str | None = os.getenv(base_env) if base_env else None
+            if env_val:
+                base = env_val
+                base_source = f"from {base_env}"
+            else:
+                base = default_base
+                base_source = "default"
+
+            status = self._probe_endpoint(base, probe_path, requires_key, key_env, extra_headers)
+
+            # Build annotation parts
+            parts = [f"{base}, {base_source}"]
+            if requires_key and key_env:
+                parts.append(f"{key_env} {'set' if os.getenv(key_env) else 'not set'}")
+
+            annotation = ", ".join(parts)
+
+            if status == _ProbeStatus.OK:
+                passed.append(f"inference={provider_type}")
+                cprint(f"  ✓ {provider_type} ({annotation})", color="green")
+            elif status == _ProbeStatus.NO_KEY:
+                cprint(f"  ✗ {provider_type} ({annotation})", color="yellow")
+            elif status == _ProbeStatus.AUTH:
+                cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
+            else:
+                cprint(f"  ✗ {provider_type} ({annotation}) — unreachable", color="yellow")
+
+        # Inline providers require no external service — always include them.
+        inline_providers = [
+            "files=inline::localfs",
+            "vector_io=inline::faiss",
+            "tool_runtime=inline::file-search",
+            "file_processors=inline::pypdf",
+            "responses=inline::builtin",
+        ]
+        cprint("  ✓ inline::localfs (built-in)", color="green")
+        cprint("  ✓ inline::faiss (built-in)", color="green")
+        cprint("  ✓ inline::file-search (built-in)", color="green")
+        cprint("  ✓ inline::pypdf (built-in)", color="green")
+        cprint("  ✓ inline::builtin responses (built-in)", color="green")
+
+        if passed:
+            cprint(f"\nDetected {len(passed)} inference provider(s). Starting stack...", color="cyan")
+        else:
+            cprint("\nDetected no inference providers, not starting stack.", color="red")
+        return ",".join(passed + inline_providers)
+
+    def _probe_endpoint(
+        self,
+        base_url: str,
+        probe_path: str,
+        requires_key: bool,
+        key_env: str | None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> _ProbeStatus:
+        """Perform a lightweight HTTP probe for a provider."""
+        if not base_url:
+            return _ProbeStatus.UNREACHABLE
+
+        url = urljoin(base_url.rstrip("/") + "/", probe_path)
+
+        headers: dict[str, str] = dict(extra_headers or {})
+        if requires_key:
+            if not key_env or not os.getenv(key_env):
+                return _ProbeStatus.NO_KEY
+            key: str = os.getenv(key_env, "")
+            headers["Authorization"] = f"Bearer {key}"
+            headers["x-api-key"] = key
+
+        try:
+            resp = cast(httpx.Response, httpx.get(url, headers=headers, timeout=2.0))
+            if resp.status_code in (401, 403):
+                return _ProbeStatus.AUTH
+            if resp.status_code < 400:
+                return _ProbeStatus.OK
+            return _ProbeStatus.UNREACHABLE
+        except Exception:
+            return _ProbeStatus.UNREACHABLE

--- a/src/llama_stack/cli/stack/stack.py
+++ b/src/llama_stack/cli/stack/stack.py
@@ -11,6 +11,7 @@ from llama_stack.cli.stack.list_stacks import StackListBuilds
 from llama_stack.cli.stack.utils import print_subcommand_description
 from llama_stack.cli.subcommand import Subcommand
 
+from .lets_go import StackLetsGo
 from .list_apis import StackListApis
 from .list_deps import StackListDeps
 from .list_providers import StackListProviders
@@ -45,6 +46,7 @@ class StackParser(Subcommand):
         StackListApis.create(subparsers)
         StackListProviders.create(subparsers)
         StackRun.create(subparsers)
+        StackLetsGo.create(subparsers)
         StackRemove.create(subparsers)
         StackListBuilds.create(subparsers)
         print_subcommand_description(self.parser, subparsers)

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -1,0 +1,365 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for `llama stack letsgo` CLI command."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from llama_stack.cli.stack.lets_go import StackLetsGo, _ProbeStatus
+
+
+@pytest.fixture
+def lets_go() -> StackLetsGo:
+    subparsers = argparse.ArgumentParser().add_subparsers()
+    return StackLetsGo(subparsers)
+
+
+class TestArguments:
+    def test_defaults(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args([])
+        assert args.port == 8321
+        assert args.enable_ui is False
+        assert args.persist_config is False
+        assert args.providers_override is None
+
+    def test_port_override(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args(["--port", "9000"])
+        assert args.port == 9000
+
+    def test_enable_ui_flag(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args(["--enable-ui"])
+        assert args.enable_ui is True
+
+    def test_persist_config_flag(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args(["--persist-config"])
+        assert args.persist_config is True
+
+    def test_providers_override_flag(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args(["--providers-override", "inference=remote::ollama"])
+        assert args.providers_override == "inference=remote::ollama"
+
+    def test_skip_install_deps_default(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args([])
+        assert args.skip_install_deps is False
+
+    def test_skip_install_deps_flag(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args(["--skip-install-deps"])
+        assert args.skip_install_deps is True
+
+    def test_port_from_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("LLAMA_STACK_PORT", "9999")
+        subparsers = argparse.ArgumentParser().add_subparsers()
+        instance = StackLetsGo(subparsers)
+        args = instance.parser.parse_args([])
+        assert args.port == 9999
+
+
+class TestProbeEndpoint:
+    def test_empty_base_url_returns_unreachable(self, lets_go: StackLetsGo):
+        assert lets_go._probe_endpoint("", "models", False, None) == _ProbeStatus.UNREACHABLE
+
+    def test_url_construction_preserves_v1_path(self, lets_go: StackLetsGo):
+        """Without a trailing slash urljoin strips the last path segment."""
+        captured: list[str] = []
+
+        def fake_get(url: str, **kwargs: object) -> None:
+            captured.append(url)
+            raise OSError("offline")
+
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", side_effect=fake_get):
+            lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None)
+
+        assert captured[0] == "http://localhost:11434/v1/models"
+
+    def test_ok_on_200(self, lets_go: StackLetsGo):
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            assert lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.OK
+
+    def test_ok_on_204(self, lets_go: StackLetsGo):
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 204
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            assert lets_go._probe_endpoint("http://localhost:8000/v1", "health", False, None) == _ProbeStatus.OK
+
+    def test_no_key_when_env_var_unset(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        result = lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
+        assert result == _ProbeStatus.NO_KEY
+
+    def test_no_key_when_key_env_is_none(self, lets_go: StackLetsGo):
+        result = lets_go._probe_endpoint("https://example.com/v1", "models", True, None)
+        assert result == _ProbeStatus.NO_KEY
+
+    def test_auth_on_401(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 401
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            assert (
+                lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
+                == _ProbeStatus.AUTH
+            )
+
+    def test_auth_on_403(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 403
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            assert (
+                lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
+                == _ProbeStatus.AUTH
+            )
+
+    def test_unreachable_on_400(self, lets_go: StackLetsGo):
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 400
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            assert (
+                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
+            )
+
+    def test_unreachable_on_500(self, lets_go: StackLetsGo):
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 500
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            assert (
+                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
+            )
+
+    def test_unreachable_on_connection_error(self, lets_go: StackLetsGo):
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", side_effect=OSError("connection refused")):
+            assert (
+                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
+            )
+
+    def test_unreachable_on_timeout(self, lets_go: StackLetsGo):
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", side_effect=httpx.TimeoutException("timeout")):
+            assert (
+                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
+            )
+
+    def test_extra_headers_forwarded(self, lets_go: StackLetsGo):
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
+            lets_go._probe_endpoint(
+                "https://api.anthropic.com/v1",
+                "models",
+                False,
+                None,
+                {"anthropic-version": "2023-06-01"},
+            )
+        assert mock_get.call_args.kwargs["headers"].get("anthropic-version") == "2023-06-01"
+
+    def test_auth_headers_set_when_key_present(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        with patch("llama_stack.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
+            lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer sk-secret"
+        assert headers["x-api-key"] == "sk-secret"
+
+
+class TestAutodetect:
+    @patch("llama_stack.cli.stack.lets_go.StackLetsGo._probe_endpoint", return_value=_ProbeStatus.UNREACHABLE)
+    def test_autodetect_no_providers(self, mock_probe: MagicMock, lets_go: StackLetsGo):
+        # inline providers are always included even when all probes fail
+        parts = lets_go._autodetect_providers().split(",")
+        assert "files=inline::localfs" in parts
+        assert "vector_io=inline::faiss" in parts
+        assert "tool_runtime=inline::file-search" in parts
+        assert "responses=inline::builtin" in parts
+
+    @patch("llama_stack.cli.stack.lets_go.StackLetsGo._probe_endpoint", return_value=_ProbeStatus.NO_KEY)
+    def test_no_key_providers_excluded(self, mock_probe: MagicMock, lets_go: StackLetsGo):
+        parts = lets_go._autodetect_providers().split(",")
+        assert "files=inline::localfs" in parts
+        assert "vector_io=inline::faiss" in parts
+        assert "tool_runtime=inline::file-search" in parts
+        assert "responses=inline::builtin" in parts
+
+    @patch("llama_stack.cli.stack.lets_go.StackLetsGo._probe_endpoint", return_value=_ProbeStatus.OK)
+    def test_autodetect_all_ok(self, mock_probe: MagicMock, lets_go: StackLetsGo):
+        result = lets_go._autodetect_providers()
+        parts = result.split(",")
+        assert "inference=remote::ollama" in parts
+        assert "inference=remote::anthropic" in parts
+        assert "files=inline::localfs" in parts
+        assert "responses=inline::builtin" in parts
+        assert len(parts) == 11  # 6 probed + 5 inline
+
+    @patch("llama_stack.cli.stack.lets_go.StackLetsGo._probe_endpoint")
+    def test_autodetect_only_ollama(self, mock_probe: MagicMock, lets_go: StackLetsGo):
+        def side_effect(
+            base_url: str, probe_path: str, requires_key: bool, key_env: object, extra_headers: object = None
+        ) -> _ProbeStatus:
+            if "11434" in base_url:
+                return _ProbeStatus.OK
+            return _ProbeStatus.UNREACHABLE
+
+        mock_probe.side_effect = side_effect
+        parts = lets_go._autodetect_providers().split(",")
+        assert "inference=remote::ollama" in parts
+        assert "files=inline::localfs" in parts
+        assert "responses=inline::builtin" in parts
+        assert len(parts) == 6  # 1 inference + 5 inline
+
+    @patch("llama_stack.cli.stack.lets_go.StackLetsGo._probe_endpoint")
+    def test_autodetect_uses_env_var_base_url(
+        self, mock_probe: MagicMock, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("OLLAMA_URL", "http://myhost:11434/v1")
+        captured: list[str] = []
+
+        def side_effect(
+            base_url: str, probe_path: str, requires_key: bool, key_env: object, extra_headers: object = None
+        ) -> _ProbeStatus:
+            captured.append(base_url)
+            return _ProbeStatus.UNREACHABLE
+
+        mock_probe.side_effect = side_effect
+        lets_go._autodetect_providers()
+        assert captured[0] == "http://myhost:11434/v1"
+
+    @patch("llama_stack.cli.stack.lets_go.StackLetsGo._probe_endpoint")
+    def test_autodetect_result_order_matches_candidate_order(
+        self, mock_probe: MagicMock, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        def side_effect(
+            base_url: str, probe_path: str, requires_key: bool, key_env: object, extra_headers: object = None
+        ) -> _ProbeStatus:
+            if "11434" in base_url or "openai.com" in base_url:
+                return _ProbeStatus.OK
+            return _ProbeStatus.UNREACHABLE
+
+        mock_probe.side_effect = side_effect
+        parts = lets_go._autodetect_providers().split(",")
+        assert parts.index("inference=remote::ollama") < parts.index("inference=remote::openai")
+
+
+class TestRunCommand:
+    def test_no_inference_provider_exits(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args([])
+        # files-only spec has no inference provider — should exit
+        with patch.object(
+            lets_go,
+            "_autodetect_providers",
+            return_value="files=inline::localfs,vector_io=inline::faiss,tool_runtime=inline::file-search,responses=inline::builtin",
+        ):
+            with pytest.raises(SystemExit):
+                lets_go._run_stack_lets_go_cmd(args)
+
+    def test_empty_spec_exits(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args([])
+        with patch.object(lets_go, "_autodetect_providers", return_value=""):
+            with pytest.raises(SystemExit):
+                lets_go._run_stack_lets_go_cmd(args)
+
+    @patch("llama_stack.cli.stack.lets_go.StackRun")
+    @patch("llama_stack.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
+    @patch("llama_stack.cli.stack.lets_go.run_config_from_dynamic_config_spec")
+    def test_providers_override_skips_autodetect(
+        self,
+        mock_build_config: MagicMock,
+        mock_get_deps: MagicMock,
+        mock_stack_run_cls: MagicMock,
+        lets_go: StackLetsGo,
+    ):
+        args = lets_go.parser.parse_args(["--providers-override", "inference=remote::ollama"])
+        mock_cfg = MagicMock()
+        mock_cfg.model_dump.return_value = {}
+        mock_build_config.return_value = mock_cfg
+
+        with patch.object(lets_go, "_autodetect_providers") as mock_detect:
+            with patch("builtins.open", MagicMock()):
+                with patch("llama_stack.cli.stack.lets_go.yaml.dump"):
+                    lets_go._run_stack_lets_go_cmd(args)
+        mock_detect.assert_not_called()
+
+    @patch("llama_stack.cli.stack.lets_go.StackRun")
+    @patch("llama_stack.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
+    @patch("llama_stack.cli.stack.lets_go.run_config_from_dynamic_config_spec")
+    def test_run_command_uses_autodetected_providers(
+        self,
+        mock_build_config: MagicMock,
+        mock_get_deps: MagicMock,
+        mock_stack_run_cls: MagicMock,
+        lets_go: StackLetsGo,
+    ):
+        args = lets_go.parser.parse_args([])
+        mock_cfg = MagicMock()
+        mock_cfg.model_dump.return_value = {}
+        mock_build_config.return_value = mock_cfg
+
+        with patch.object(lets_go, "_autodetect_providers", return_value="inference=remote::ollama"):
+            with patch("builtins.open", MagicMock()):
+                with patch("llama_stack.cli.stack.lets_go.yaml.dump"):
+                    lets_go._run_stack_lets_go_cmd(args)
+
+        mock_build_config.assert_called_once()
+        assert mock_build_config.call_args.kwargs["dynamic_config_spec"] == "inference=remote::ollama"
+
+    @patch("llama_stack.cli.stack.lets_go.StackRun")
+    @patch("llama_stack.cli.stack.lets_go.subprocess.run")
+    @patch("llama_stack.cli.stack.lets_go.get_provider_dependencies", return_value=(["httpx", "faiss-cpu"], [], []))
+    @patch("llama_stack.cli.stack.lets_go.run_config_from_dynamic_config_spec")
+    def test_install_deps_called_by_default(
+        self,
+        mock_build_config: MagicMock,
+        mock_get_deps: MagicMock,
+        mock_subprocess: MagicMock,
+        mock_stack_run_cls: MagicMock,
+        lets_go: StackLetsGo,
+    ):
+        args = lets_go.parser.parse_args([])
+        mock_cfg = MagicMock()
+        mock_cfg.model_dump.return_value = {}
+        mock_build_config.return_value = mock_cfg
+        mock_subprocess.return_value = MagicMock(returncode=0)
+
+        with patch.object(lets_go, "_autodetect_providers", return_value="inference=remote::ollama"):
+            with patch("builtins.open", MagicMock()):
+                with patch("llama_stack.cli.stack.lets_go.yaml.dump"):
+                    lets_go._run_stack_lets_go_cmd(args)
+
+        mock_subprocess.assert_called_once()
+        call_args = mock_subprocess.call_args[0][0]
+        assert "httpx" in call_args
+        assert "faiss-cpu" in call_args
+
+    @patch("llama_stack.cli.stack.lets_go.StackRun")
+    @patch("llama_stack.cli.stack.lets_go.subprocess.run")
+    @patch("llama_stack.cli.stack.lets_go.get_provider_dependencies", return_value=(["httpx"], [], []))
+    @patch("llama_stack.cli.stack.lets_go.run_config_from_dynamic_config_spec")
+    def test_install_deps_skipped_with_flag(
+        self,
+        mock_build_config: MagicMock,
+        mock_get_deps: MagicMock,
+        mock_subprocess: MagicMock,
+        mock_stack_run_cls: MagicMock,
+        lets_go: StackLetsGo,
+    ):
+        args = lets_go.parser.parse_args(["--skip-install-deps"])
+        mock_cfg = MagicMock()
+        mock_cfg.model_dump.return_value = {}
+        mock_build_config.return_value = mock_cfg
+
+        with patch.object(lets_go, "_autodetect_providers", return_value="inference=remote::ollama"):
+            with patch("builtins.open", MagicMock()):
+                with patch("llama_stack.cli.stack.lets_go.yaml.dump"):
+                    lets_go._run_stack_lets_go_cmd(args)
+
+        mock_subprocess.assert_not_called()


### PR DESCRIPTION
Add a new `llama stack letsgo` subcommand that auto-detects available inference providers and starts the stack without requiring manual configuration.

Provider detection:
- Key-free providers (Ollama, vLLM, llama-cpp-server): probed by making a lightweight HTTP request to their default endpoint. Included when the probe succeeds.
- API-key providers (OpenAI, llama-openai-compat, Anthropic): included only when the required API key environment variable is set and the probe succeeds. A missing key is reported without making a network request.
- Inline providers (always included, require no external service): files=inline::localfs, vector_io=inline::faiss, tool_runtime=inline::file-search, file_processors=inline::pypdf, responses=inline::builtin.

Before starting the server, provider pip dependencies are resolved and installed into the current environment using `uv pip install` (falling back to `pip install`). Pass --skip-install-deps to opt out.

The command exits with an error if no inference provider is detected, since the inline-only set is not sufficient to serve useful requests.

Missing features:
- Vector store query rewriting, needs rewrite_query_params.model on a vector_store config
- Vector store contextual chunking, needs contextual_retrieval_params.model in vector_store config
- No web_search tool configured