### PR TITLE
fix(vector_io): Require explicit embedding_dimension instead of defaulting to 768

### DIFF
--- a/src/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
@@ -473,9 +473,7 @@ class OpenAIVectorStoreMixin(ABC):
         if metadata.get("embedding_model"):
             # If either is in metadata, use metadata as source
             embedding_model = metadata.get("embedding_model")
-            embedding_dimension = (
-                int(metadata["embedding_dimension"]) if metadata.get("embedding_dimension") else None
-            )
+            embedding_dimension = int(metadata["embedding_dimension"]) if metadata.get("embedding_dimension") else None
             logger.debug(
                 "Using embedding config from metadata (takes precedence over extra_body): model=, dimension",
                 embedding_model=embedding_model,

--- a/src/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/llama_stack/providers/utils/memory/openai_vector_store_mixin.py
@@ -474,7 +474,7 @@ class OpenAIVectorStoreMixin(ABC):
             # If either is in metadata, use metadata as source
             embedding_model = metadata.get("embedding_model")
             embedding_dimension = (
-                int(metadata["embedding_dimension"]) if metadata.get("embedding_dimension") else EMBEDDING_DIMENSION
+                int(metadata["embedding_dimension"]) if metadata.get("embedding_dimension") else None
             )
             logger.debug(
                 "Using embedding config from metadata (takes precedence over extra_body): model=, dimension",
@@ -483,7 +483,7 @@ class OpenAIVectorStoreMixin(ABC):
             )
         else:
             embedding_model = extra_body.get("embedding_model")
-            embedding_dimension = extra_body.get("embedding_dimension", EMBEDDING_DIMENSION)
+            embedding_dimension = extra_body.get("embedding_dimension")
             logger.debug(
                 "Using embedding config from extra_body: model=, dimension",
                 embedding_model=embedding_model,
@@ -499,7 +499,10 @@ class OpenAIVectorStoreMixin(ABC):
             raise ValueError("embedding_model is required")
 
         if embedding_dimension is None:
-            raise ValueError("Embedding dimension is required")
+            raise ValueError(
+                "Embedding dimension is required. Please provide 'embedding_dimension' in the request, "
+                "or ensure the request goes through the router which can look it up from model metadata."
+            )
 
         if provider_id is None:
             raise ValueError("Provider ID is required but was not provided")

--- a/tests/unit/providers/vector_io/test_vector_io_stores_config.py
+++ b/tests/unit/providers/vector_io/test_vector_io_stores_config.py
@@ -111,8 +111,8 @@ async def test_embedding_config_consistency_check_passes(vector_io_adapter):
     assert vector_store["metadata"]["embedding_dimension"] == "768"
 
 
-async def test_embedding_config_defaults_when_missing(vector_io_adapter):
-    """Test that embedding dimension defaults to 768 when not provided."""
+async def test_embedding_config_dimension_required(vector_io_adapter):
+    """Test that embedding dimension is required when not provided."""
 
     # Set provider_id attribute for the adapter
     vector_io_adapter.__provider_id__ = "test_provider"
@@ -126,12 +126,9 @@ async def test_embedding_config_defaults_when_missing(vector_io_adapter):
         },
     )
 
-    result = await vector_io_adapter.openai_create_vector_store(params)
-
-    # Should default to 768 dimensions
-    vector_store = vector_io_adapter.openai_vector_stores[result.id]
-    assert vector_store["metadata"]["embedding_model"] == "model-without-dimension"
-    assert vector_store["metadata"]["embedding_dimension"] == "768"
+    # Should raise ValueError because embedding_dimension is not provided
+    with pytest.raises(ValueError, match="Embedding dimension is required"):
+        await vector_io_adapter.openai_create_vector_store(params)
 
 
 async def test_embedding_config_required_model_missing(vector_io_adapter):


### PR DESCRIPTION
# What does this PR do?

Change the default from EMBEDDING_DIMENSION to None so the model metadata lookup runs when dimension is not explicitly provided:

Closes #5585 

