### PR TITLE
fix(vertexai): Prevent event loop mismatch with network config by lazy-initializing httpx client

### DIFF
--- a/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
+++ b/src/llama_stack/providers/remote/inference/vertexai/vertexai.py
@@ -145,6 +145,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
     config: VertexAIConfig
     _default_client: Client | None = PrivateAttr(default=None)
     _http_options: genai_types.HttpOptions | None = PrivateAttr(default=None)
+    _http_options_initialized: bool = PrivateAttr(default=False)
     _model_cache: dict[str, Model] = PrivateAttr(default_factory=dict)
     embedding_model_metadata: dict[str, dict[str, int]] = {
         "publishers/google/models/text-embedding-004": {"embedding_dimension": 768, "context_length": 2048},
@@ -162,31 +163,48 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         if client is not None:
             await client.aclose()
 
+    def _ensure_http_options(self) -> None:
+        """Lazily initialize HTTP options in the current event loop.
+
+        This defers httpx.AsyncClient creation from initialize() to first use,
+        avoiding event loop mismatch when the server creates providers in a
+        temporary event loop during startup.
+        """
+        if self._http_options_initialized:
+            return
+
+        self._http_options = _build_http_options(self.config.network)
+        self._http_options_initialized = True
+
     async def initialize(self) -> None:
+        """Initialize the provider without creating httpx clients.
+
+        HTTP options (including httpx.AsyncClient) are created lazily on first
+        use to avoid event loop mismatch issues when initialization happens in
+        a temporary event loop during server startup.
+
+        We don't create the default client here because that would trigger
+        _ensure_http_options() and create httpx.AsyncClient in the wrong event loop.
+        The client will be created on first use via _get_client().
+        """
         try:
-            await self._close_managed_httpx_client()
-            self._http_options = _build_http_options(self.config.network)
-            access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
-            self._default_client = self._create_client(
-                project=self.config.project,
-                location=self.config.location,
-                access_token=access_token,
-            )
+            # Don't create the client here - it will be created lazily on first use
+            # This avoids calling _ensure_http_options() in the temporary startup event loop
             logger.info(
-                "VertexAI client initialized for project=%s location=%s",
+                "VertexAI provider initialized for project=%s location=%s (client will be created on first use)",
                 self.config.project,
                 self.config.location,
             )
         except Exception:
             logger.warning(
-                "Failed to initialize default VertexAI client. Requests will require explicit credentials.",
+                "Failed to initialize VertexAI provider configuration.",
                 exc_info=True,
             )
-            self._default_client = None
 
     async def shutdown(self) -> None:
         await self._close_managed_httpx_client()
         self._http_options = None
+        self._http_options_initialized = False
         self._default_client = None
 
     async def register_model(self, model: Model) -> Model:
@@ -201,7 +219,12 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         pass
 
     def _create_adc_client(self, project: str, location: str) -> Client:
-        """Create a client using Application Default Credentials."""
+        """Create a client using Application Default Credentials.
+
+        Ensures HTTP options are initialized in the current event loop before
+        creating the client.
+        """
+        self._ensure_http_options()
         kwargs: dict[str, Any] = dict(vertexai=True, project=project, location=location)
         if self._http_options is not None:
             kwargs["http_options"] = self._http_options
@@ -215,7 +238,11 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         auth failures after expiry.  ADC clients are not cached either because
         network configuration is instance-specific and not hashable for
         use as an lru_cache key.
+
+        Ensures HTTP options are initialized in the current event loop before
+        creating the client.
         """
+        self._ensure_http_options()
         if access_token:
             credentials = Credentials(token=access_token)
             kwargs: dict[str, Any] = dict(vertexai=True, project=project, location=location, credentials=credentials)
@@ -287,11 +314,30 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
                 return self._create_client(project=project, location=location, access_token=access_token)
 
+        # Lazily create the default client on first use
         if self._default_client is None:
-            raise ValueError(
-                "Pass Vertex AI access token in the header X-LlamaStack-Provider-Data"
-                ' as { "vertex_access_token": <your access token> }'
-            )
+            access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
+            try:
+                self._default_client = self._create_client(
+                    project=self.config.project,
+                    location=self.config.location,
+                    access_token=access_token,
+                )
+                logger.info(
+                    "Created default VertexAI client on first use",
+                    project=self.config.project,
+                    location=self.config.location,
+                )
+            except Exception:
+                logger.error(
+                    "Failed to create default VertexAI client. Pass credentials via X-LlamaStack-Provider-Data header.",
+                    exc_info=True,
+                )
+                raise ValueError(
+                    "Failed to create default Vertex AI client. "
+                    "Pass Vertex AI access token in the header X-LlamaStack-Provider-Data "
+                    'as { "vertex_access_token": <your access token> }'
+                ) from None
         return self._default_client
 
     async def _get_provider_model_id(self, model: str) -> str:

--- a/tests/unit/providers/inference/vertexai/test_adapter_chat.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_chat.py
@@ -339,32 +339,34 @@ class TestVertexAIClientWithNetworkConfig:
     """Tests that client factory methods thread http_options into Client() calls."""
 
     def test_create_client_with_token_passes_http_options(self, monkeypatch):
-        """Test that create client with token passes http options."""
+        """Test that create client with token passes http options (lazy initialization)."""
         client_ctor = MagicMock(return_value=object())
         monkeypatch.setattr("llama_stack.providers.remote.inference.vertexai.vertexai.Client", client_ctor)
 
-        adapter = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
-        http_opts = _build_http_options(NetworkConfig(headers={"X-Test": "1"}))
-        adapter._http_options = http_opts
-
+        adapter = VertexAIInferenceAdapter(
+            config=VertexAIConfig(project="p", location="l", network=NetworkConfig(headers={"X-Test": "1"}))
+        )
+        # _create_client triggers _ensure_http_options which builds from config.network
         adapter._create_client(project="p", location="l", access_token="tok")
 
         kwargs = client_ctor.call_args.kwargs
-        assert kwargs.get("http_options") is http_opts
+        assert "http_options" in kwargs
+        assert kwargs["http_options"].headers == {"X-Test": "1"}
 
     def test_create_adc_client_passes_http_options(self, monkeypatch):
-        """Test that create adc client passes http options."""
+        """Test that create adc client passes http options (lazy initialization)."""
         client_ctor = MagicMock(return_value=object())
         monkeypatch.setattr("llama_stack.providers.remote.inference.vertexai.vertexai.Client", client_ctor)
 
-        adapter = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
-        http_opts = _build_http_options(NetworkConfig(headers={"X-Test": "1"}))
-        adapter._http_options = http_opts
-
+        adapter = VertexAIInferenceAdapter(
+            config=VertexAIConfig(project="p", location="l", network=NetworkConfig(headers={"X-Test": "1"}))
+        )
+        # _create_adc_client triggers _ensure_http_options which builds from config.network
         adapter._create_adc_client(project="p", location="l")
 
         kwargs = client_ctor.call_args.kwargs
-        assert kwargs.get("http_options") is http_opts
+        assert "http_options" in kwargs
+        assert kwargs["http_options"].headers == {"X-Test": "1"}
 
     def test_create_client_no_network_config_no_http_options(self, monkeypatch):
         """Test that create client no network config no http options."""
@@ -381,8 +383,8 @@ class TestVertexAIClientWithNetworkConfig:
         # http_options should not be in kwargs when network config is not set
         assert "http_options" not in kwargs
 
-    async def test_initialize_builds_http_options_from_config(self, monkeypatch):
-        """Test that initialize builds http options from config."""
+    async def test_initialize_does_not_build_http_options(self, monkeypatch):
+        """Test that initialize does NOT build http options (lazy initialization)."""
         adapter = VertexAIInferenceAdapter(
             config=VertexAIConfig(
                 project="p",
@@ -395,9 +397,9 @@ class TestVertexAIClientWithNetworkConfig:
 
         await adapter.initialize()
 
-        # After initialize(), _http_options should be populated from config.network
-        assert adapter._http_options is not None
-        assert adapter._http_options.headers == {"X-Custom": "val"}
+        # With lazy initialization, _http_options should NOT be populated during initialize()
+        assert adapter._http_options is None
+        assert adapter._http_options_initialized is False
 
     async def test_shutdown_closes_managed_httpx_async_client(self, monkeypatch):
         """Test that shutdown closes managed httpx async client."""
@@ -421,28 +423,28 @@ class TestVertexAIClientWithNetworkConfig:
         assert adapter._http_options is None
         assert adapter._default_client is None
 
-    async def test_initialize_closes_existing_managed_httpx_async_client(self, monkeypatch):
-        """Test that initialize closes existing managed httpx async client."""
+    async def test_ensure_http_options_is_idempotent(self, monkeypatch):
+        """Test that _ensure_http_options() is idempotent (only initializes once)."""
         adapter = VertexAIInferenceAdapter(
             config=VertexAIConfig(
                 project="p",
                 location="l",
-                network=NetworkConfig(headers={"X-New": "1"}),
+                network=NetworkConfig(headers={"X-Test": "1"}),
             )
         )
-        adapter._http_options = _build_http_options(NetworkConfig(tls=TLSConfig(verify=False)))
-        assert adapter._http_options is not None
-        old_client = adapter._http_options.httpx_async_client
-        assert old_client is not None
-        aclose_mock = AsyncMock()
-        monkeypatch.setattr(old_client, "aclose", aclose_mock)
-        monkeypatch.setattr(adapter, "_create_client", lambda **kw: object())
 
-        await adapter.initialize()
+        # First call should initialize
+        adapter._ensure_http_options()
+        assert adapter._http_options_initialized is True
+        first_options = adapter._http_options
 
-        aclose_mock.assert_awaited_once()
-        assert adapter._http_options is not None
-        assert adapter._http_options.headers == {"X-New": "1"}
+        # Second call should not reinitialize
+        adapter._ensure_http_options()
+        assert adapter._http_options is first_options  # Same object
+
+        # Third call should also not reinitialize
+        adapter._ensure_http_options()
+        assert adapter._http_options is first_options  # Still same object
 
 
 class TestBuildThinkingConfig:

--- a/tests/unit/providers/inference/vertexai/test_adapter_core.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_core.py
@@ -26,18 +26,21 @@ class TestVertexAIAdapterInit:
         assert adapter.config == vertex_config
         assert adapter._default_client is None
 
-    async def test_initialize_sets_default_client(self, monkeypatch, adapter: VertexAIInferenceAdapter):
-        """Test that initialize sets default client."""
+    async def test_initialize_does_not_create_client(self, monkeypatch, adapter: VertexAIInferenceAdapter):
+        """Test that initialize does NOT create default client (lazy initialization)."""
         client = object()
 
         monkeypatch.setattr(adapter, "_create_client", lambda **kwargs: client)
 
         await adapter.initialize()
 
-        assert adapter._default_client is client
+        # With lazy initialization, client is NOT created during initialize()
+        assert adapter._default_client is None
 
-    async def test_initialize_failure_keeps_default_client_unset(self, monkeypatch, adapter: VertexAIInferenceAdapter):
-        """Test that initialize failure keeps default client unset."""
+    async def test_initialize_does_not_fail_on_client_creation_error(
+        self, monkeypatch, adapter: VertexAIInferenceAdapter
+    ):
+        """Test that initialize does not fail even if client creation would fail (lazy initialization)."""
 
         def _raise(**kwargs):
             """Raise a runtime error for failure-path testing."""
@@ -45,6 +48,7 @@ class TestVertexAIAdapterInit:
 
         monkeypatch.setattr(adapter, "_create_client", _raise)
 
+        # Should not raise because client is not created during initialize()
         await adapter.initialize()
 
         assert adapter._default_client is None
@@ -125,13 +129,25 @@ class TestVertexAIClientManagement:
             access_token="config-token",
         )
 
-    def test_get_client_raises_when_no_client_available(self, monkeypatch):
-        """Test that get client raises when no client available."""
+    def test_get_client_creates_default_client_lazily(self, monkeypatch):
+        """Test that get client creates default client lazily when not available."""
         adapter = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
         monkeypatch.setattr(adapter, "_get_request_provider_overrides", lambda: None)
 
-        with pytest.raises(ValueError, match="Pass Vertex AI access token in the header"):
-            adapter._get_client()
+        client = object()
+        create_client = MagicMock(return_value=client)
+        monkeypatch.setattr(adapter, "_create_client", create_client)
+
+        # First call should create the client
+        result = adapter._get_client()
+        assert result is client
+        assert adapter._default_client is client
+        create_client.assert_called_once()
+
+        # Second call should reuse the same client
+        result2 = adapter._get_client()
+        assert result2 is client
+        assert create_client.call_count == 1  # Still only called once
 
 
 class TestVertexAIModelListing:


### PR DESCRIPTION
# What does this PR do?

Fixes event loop mismatch bug in VertexAI provider that caused `RuntimeError: Event loop is closed` when network settings (TLS certificates or proxy) were configured.

Closes #5466 
