### PR TITLE
chore(ci): update vLLM image to quay.io/opendatahub/vllm-cpu

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -11,13 +11,13 @@ runs:
           --name vllm \
           -p 8000:8000 \
           --privileged=true \
-          quay.io/higginsd/vllm-cpu:65393ee064-qwen3 \
+          quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english \
           --host 0.0.0.0 \
           --port 8000 \
           --enable-auto-tool-choice \
           --tool-call-parser hermes \
           --reasoning-parser deepseek_r1 \
-          --model /root/.cache/Qwen3-0.6B \
+          --model /root/.cache/Qwen/Qwen3-0.6B \
           --served-model-name Qwen/Qwen3-0.6B \
           --max-model-len 8192
 


### PR DESCRIPTION
Use the OpenDataHub vLLM CPU image instead of a personal account image. While not the official vLLM image, it's more appropriate for the project.

Also fix model path from /root/.cache/Qwen3-0.6B to /root/.cache/Qwen/Qwen3-0.6B to match how models are stored in the new image.
