### PR TITLE
fix(responses): drop reasoning_effort in fall back branch

### DIFF
--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -562,12 +562,21 @@ class StreamingResponseOrchestrator:
                         completion_result = await self.inference_api.openai_chat_completions_with_reasoning(
                             params.model_copy()
                         )
-                    except (NotImplementedError, AttributeError, ValueError):
-                        logger.critical(
+                    except (NotImplementedError, ValueError):
+                        logger.warning(
                             "Provider does not support reasoning in chat completions. "
                             "Falling back to regular chat completion."
                         )
                         completion_result = await self.inference_api.openai_chat_completion(params)
+                    except AttributeError:
+                        logger.warning("Model does not support reasoning_effort parameter")
+                        # Temporary workaround: https://github.com/ogx-ai/ogx/issues/5636
+                        if params.model.startswith("ollama/"):
+                            completion_result = await self.inference_api.openai_chat_completion(params)
+                        else:
+                            completion_result = await self.inference_api.openai_chat_completion(
+                                params.model_copy(update={"reasoning_effort": None})
+                            )
                 else:
                     completion_result = await self.inference_api.openai_chat_completion(params)
 


### PR DESCRIPTION
# What does this PR do?
When the Responses path tries `openai_chat_completions_with_reasoning` and the provider rejects reasoning, it falls back to `openai_chat_completion`. The fallback reused the same `params`, so `reasoning_effort` was still sent and the plain chat call failed with the same “unsupported reasoning” style error instead of succeeding.

This change clears `reasoning_effort` on that fallback only, so the non-reasoning chat completion is a valid plain request.

Closes #5607

## Test Plan
Request:
```bash
curl -sS -X POST "http://localhost:8321/v1/responses" \
  -H "Content-Type: application/json" \
  -d '{
    "input": "Say hello in one short sentence.",
    "model": "openai/gpt-4o-mini",
    "stream": false,
    "reasoning": {
      "effort": "low"
    }
  }'
  ```
  
  Response:
```bash
{
  "background": false,
  "created_at": 1776950444,
  "completed_at": 1776950445,
  "error": null,
  "frequency_penalty": 0.0,
  "id": "resp_f892dba8-4f0a-452a-aa2f-90f5d73d97d7",
  "incomplete_details": null,
  "model": "openai/gpt-4o-mini",
  "object": "response",
  "output": [
    {
      "content": [
        {
          "text": "Hello!",
          "type": "output_text",
          "annotations": [],
          "logprobs": []
        }
      ],
      "role": "assistant",
      "type": "message",
      "id": "msg_e30172d5-5007-4298-8b0e-28aeac2def73",
      "status": "completed"
    }
  ],
  "parallel_tool_calls": true,
  "previous_response_id": null,
  "prompt_cache_key": null,
  "prompt": null,
  "status": "completed",
  "temperature": 1.0,
  "text": {
    "format": {
      "type": "text"
    }
  },
  "top_p": 1.0,
  "top_logprobs": 0,
  "tools": [],
  "tool_choice": "auto",
  "truncation": "disabled",
  "usage": {
    "input_tokens": 14,
    "output_tokens": 2,
    "total_tokens": 16,
    "input_tokens_details": {
      "cached_tokens": 0
    },
    "output_tokens_details": {
      "reasoning_tokens": 0
    }
  },
  "instructions": null,
  "max_tool_calls": null,
  "reasoning": {
    "effort": "low",
    "summary": null
  },
  "max_output_tokens": null,
  "safety_identifier": null,
  "service_tier": "default",
  "metadata": null,
  "presence_penalty": 0.0,
  "store": true
}
```