### PR TITLE
fix(ci): revert Stainless org/project names to pre-rename values

### DIFF
--- a/.github/workflows/stainless-builds.yml
+++ b/.github/workflows/stainless-builds.yml
@@ -44,10 +44,10 @@ concurrency:
 
 env:
   # Stainless organization name.
-  STAINLESS_ORG: ogx
+  STAINLESS_ORG: llamastack
 
   # Stainless project name.
-  STAINLESS_PROJECT: ogx-client
+  STAINLESS_PROJECT: llama-stack-client
 
   # Path to your OpenAPI spec.
   OAS_PATH: ./client-sdks/stainless/openapi.yml


### PR DESCRIPTION
# What does this PR do?

The rename commit (#5613) changed `STAINLESS_ORG` from `llamastack` to `ogx` and `STAINLESS_PROJECT` from `llama-stack-client` to `ogx-client` in the Stainless SDK workflow. However, the Stainless API (api.stainless.com) is a third-party service with its own project registry — GitHub's repo redirect does not apply here. The project is still registered under the old names on Stainless, causing 401/404 errors on every PR that touches `client-sdks/stainless/**`.

This reverts just the two env vars to the old values. Once the project is renamed on the Stainless dashboard, these can be updated.

## Test Plan

Verify the `Stainless SDK Builds` workflow passes on a PR that touches `client-sdks/stainless/**` files (e.g. re-run the [failing job](https://github.com/ogx-ai/ogx/actions/runs/25000181446/job/73207867932?pr=5572)).