### PR TITLE
chore: update client package references from llama-stack-client to ogx-client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,7 +234,7 @@ Example:
 ```bash
 cd work/
 git clone https://github.com/ogx-ai/ogx.git
-git clone https://github.com/meta-llama/llama-stack-client-python.git
+git clone https://github.com/ogx-ai/ogx-client-python.git
 cd ogx
 
 # Show dependencies for a distribution

--- a/docs/blog/2026-01-13-introducing-llama-stack.md
+++ b/docs/blog/2026-01-13-introducing-llama-stack.md
@@ -47,7 +47,7 @@ Distributions are pre-configured bundles of provider implementations that make i
 OGX supports various developer interfaces:
 
 - **CLI**: Command-line tools for server management
-- **Python SDK**: [`ogx-client-python`](https://github.com/meta-llama/llama-stack-client-python)
+- **Python SDK**: [`ogx-client-python`](https://github.com/ogx-ai/ogx-client-python)
 - **TypeScript SDK**: [`ogx-client-typescript`](https://github.com/ogx-ai/ogx-client-typescript)
 
 ## Why OGX?

--- a/docs/blog/2026-03-01-building-agentic-flows.md
+++ b/docs/blog/2026-03-01-building-agentic-flows.md
@@ -253,9 +253,9 @@ The `OLLAMA_URL` environment variable tells the starter distribution to use Olla
 Then create the agent with some engineering documents. Some docs are indexed in the vector store up front; others live in a local directory for the agent to discover and index on demand:
 
 ```python
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
-client = LlamaStackClient(base_url="http://localhost:8321")
+client = OgxClient(base_url="http://localhost:8321")
 
 # Create the initial system prompt
 initial = client.prompts.create(

--- a/docs/blog/2026-03-20-open-responses-openai-compatibility.md
+++ b/docs/blog/2026-03-20-open-responses-openai-compatibility.md
@@ -102,9 +102,9 @@ response = client.responses.create(
 OGX extends OpenAI compatibility with full programmatic prompt management. With OpenAI, prompts are created through their admin portal and referenced by ID in the Responses API. OGX provides the same referencing pattern, plus a complete CRUD API for creating and managing prompts programmatically:
 
 ```python
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
-ls_client = LlamaStackClient()
+ls_client = OgxClient()
 
 # Create reusable prompt templates with variables
 prompt = ls_client.prompts.create(
@@ -252,10 +252,10 @@ llm = ChatOpenAI(
 ### **Native OGX Client**
 
 ```python
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 # Access the full OGX API surface
-client = LlamaStackClient(base_url="http://your-ogx")
+client = OgxClient(base_url="http://your-ogx")
 ```
 
 ## Built for Open Standards

--- a/docs/blog/self_improving_agent.py
+++ b/docs/blog/self_improving_agent.py
@@ -22,7 +22,7 @@ import sqlite3
 import time
 from typing import Annotated, get_args, get_origin
 
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +134,7 @@ class ScoreLedger:
 class ResearchAgent:
     def __init__(
         self,
-        client: LlamaStackClient,
+        client: OgxClient,
         model: str,
         vector_store_id: str,
         prompt_id: str,
@@ -165,7 +165,7 @@ class ResearchAgent:
     @classmethod
     def from_files(
         cls,
-        client: LlamaStackClient,
+        client: OgxClient,
         model: str,
         name: str,
         file_paths: list[str],
@@ -387,7 +387,7 @@ class ResearchAgent:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    client = LlamaStackClient(base_url="http://localhost:8321")
+    client = OgxClient(base_url="http://localhost:8321")
 
     MODEL = "ollama/llama3.1:8b"
     JUDGE_MODEL = "ollama/gpt-oss:20b"

--- a/docs/docs/building_applications/agent.mdx
+++ b/docs/docs/building_applications/agent.mdx
@@ -26,7 +26,7 @@ Agents are configured using the `AgentConfig` class, which includes:
 - **Safety Shields**: Guardrails to ensure responsible AI behavior
 
 ```python
-from llama_stack_client import Agent
+from ogx_client import Agent
 
 # Create the agent
 agent = Agent(
@@ -58,7 +58,7 @@ Each interaction with an agent is called a "turn" and consists of:
 <TabItem value="streaming" label="Streaming Response">
 
 ```python
-from llama_stack_client import AgentEventLogger
+from ogx_client import AgentEventLogger
 
 # Create a turn with streaming response
 turn_response = agent.create_turn(

--- a/docs/docs/building_applications/agent_execution_loop.mdx
+++ b/docs/docs/building_applications/agent_execution_loop.mdx
@@ -88,10 +88,10 @@ Here's an example that demonstrates monitoring the agent's execution:
 <TabItem value="streaming" label="Streaming Execution">
 
 ```python
-from llama_stack_client import LlamaStackClient, Agent, AgentEventLogger
+from ogx_client import OgxClient, Agent, AgentEventLogger
 
 # Replace host and port
-client = LlamaStackClient(base_url=f"http://{HOST}:{PORT}")
+client = OgxClient(base_url=f"http://{HOST}:{PORT}")
 
 agent = Agent(
     client,

--- a/docs/docs/building_applications/evals.mdx
+++ b/docs/docs/building_applications/evals.mdx
@@ -32,9 +32,9 @@ In this example, we will show you how to:
 First, let's create an agent that can search the web to answer questions:
 
 ```python
-from llama_stack_client import LlamaStackClient, Agent, AgentEventLogger
+from ogx_client import OgxClient, Agent, AgentEventLogger
 
-client = LlamaStackClient(base_url=f"http://{HOST}:{PORT}")
+client = OgxClient(base_url=f"http://{HOST}:{PORT}")
 
 agent = Agent(
     client,

--- a/docs/docs/building_applications/rag.mdx
+++ b/docs/docs/building_applications/rag.mdx
@@ -33,11 +33,11 @@ OGX supports various approaches for building RAG applications. The server provid
 The **Agent class** is a high-level client wrapper around the Responses API with automatic tool execution and session management. Best for conversational agents and multi-turn RAG.
 
 ```python
-from llama_stack_client import Agent, AgentEventLogger, LlamaStackClient
+from ogx_client import Agent, AgentEventLogger, OgxClient
 import requests
 from io import BytesIO
 
-client = LlamaStackClient(base_url="http://localhost:8321")
+client = OgxClient(base_url="http://localhost:8321")
 
 # Create vector store
 vs = client.vector_stores.create(name="my_vector_db")

--- a/docs/docs/building_applications/safety.mdx
+++ b/docs/docs/building_applications/safety.mdx
@@ -64,7 +64,7 @@ Shields can be automatically applied to agent interactions for seamless safety e
 <TabItem value="input-shields" label="Input Shields">
 
 ```python
-from llama_stack_client import Agent
+from ogx_client import Agent
 
 # Create agent with input safety shields
 agent = Agent(

--- a/docs/docs/building_applications/tools.mdx
+++ b/docs/docs/building_applications/tools.mdx
@@ -204,12 +204,12 @@ export TAVILY_SEARCH_API_KEY="your key"
 <TabItem value="implementation" label="Implementation">
 
 ```python
-from llama_stack_client.lib.agents.agent import Agent
-from llama_stack_client.types.agent_create_params import AgentConfig
-from llama_stack_client.lib.agents.event_logger import EventLogger
-from llama_stack_client import LlamaStackClient
+from ogx_client.lib.agents.agent import Agent
+from ogx_client.types.agent_create_params import AgentConfig
+from ogx_client.lib.agents.event_logger import EventLogger
+from ogx_client import OgxClient
 
-client = LlamaStackClient(
+client = OgxClient(
     base_url=f"http://localhost:8321",
     provider_data={
         "tavily_search_api_key": "your_TAVILY_SEARCH_API_KEY"
@@ -252,7 +252,7 @@ for log in EventLogger().log(response):
     ```
     or from the client side:
     ```python
-    client = LlamaStackClient(
+    client = OgxClient(
         base_url="http://localhost:8321",
         provider_data={"wolfram_alpha_api_key": wolfram_api_key},
     )

--- a/docs/docs/concepts/file_operations_vector_stores.mdx
+++ b/docs/docs/concepts/file_operations_vector_stores.mdx
@@ -175,9 +175,9 @@ The following vector store providers support file operations:
 ### 1. File Upload
 
 ```python
-from ogx import LlamaStackClient
+from ogx import OgxClient
 
-client = LlamaStackClient("http://localhost:8000")
+client = OgxClient("http://localhost:8000")
 
 # Upload a document
 with open("document.pdf", "rb") as f:

--- a/docs/docs/contributing/index.mdx
+++ b/docs/docs/contributing/index.mdx
@@ -242,7 +242,7 @@ Example:
 ```bash
 cd work/
 git clone https://github.com/ogx-ai/ogx.git
-git clone https://github.com/meta-llama/llama-stack-client-python.git
+git clone https://github.com/ogx-ai/ogx-client-python.git
 cd ogx
 
 # Show dependencies for a distribution

--- a/docs/docs/getting_started/demo_script.py
+++ b/docs/docs/getting_started/demo_script.py
@@ -4,10 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_client import Agent, AgentEventLogger, LlamaStackClient
+from ogx_client import Agent, AgentEventLogger, OgxClient
 
 vector_store_id = "my_demo_vector_db"
-client = LlamaStackClient(base_url="http://localhost:8321")
+client = OgxClient(base_url="http://localhost:8321")
 
 models = client.models.list()
 

--- a/docs/docs/getting_started/libraries.mdx
+++ b/docs/docs/getting_started/libraries.mdx
@@ -12,7 +12,7 @@ Since OGX is OpenAI-compatible, you can use any OpenAI SDK in any language. We a
 
 |  **Language** |  **Client SDK** | **Package** |
 | :----: | :----: | :----: |
-| Python |  [ogx-client-python](https://github.com/meta-llama/llama-stack-client-python) | [![PyPI version](https://img.shields.io/pypi/v/ogx_client.svg)](https://pypi.org/project/ogx_client/)
+| Python |  [ogx-client-python](https://github.com/ogx-ai/ogx-client-python) | [![PyPI version](https://img.shields.io/pypi/v/ogx-client.svg)](https://pypi.org/project/ogx-client/)
 | Node   | [ogx-client-node](https://github.com/ogx-ai/ogx-client-node) | [![NPM version](https://img.shields.io/npm/v/ogx-client.svg)](https://npmjs.org/package/ogx-client)
 
 :::tip OpenAI SDK Compatibility

--- a/docs/docs/providers/files/openai_file_operations_support.md
+++ b/docs/docs/providers/files/openai_file_operations_support.md
@@ -162,9 +162,9 @@ files:
 ### Python Client
 
 ```python
-from ogx import LlamaStackClient
+from ogx import OgxClient
 
-client = LlamaStackClient("http://localhost:8000")
+client = OgxClient("http://localhost:8000")
 
 # Create vector store
 vector_store = client.vector_stores.create(name="documents")

--- a/docs/docs/providers/openai.mdx
+++ b/docs/docs/providers/openai.mdx
@@ -24,9 +24,9 @@ You should be able to use any client that speaks OpenAI APIs with OGX. We regula
 When using the OGX client, set the `base_url` to the root of your OGX server. It will automatically route OpenAI-compatible requests to the right server endpoint for you.
 
 ```python
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
-client = LlamaStackClient(base_url="http://localhost:8321")
+client = OgxClient(base_url="http://localhost:8321")
 ```
 
 #### OpenAI Client

--- a/docs/docs/references/python_sdk_reference/index.md
+++ b/docs/docs/references/python_sdk_reference/index.md
@@ -3,7 +3,7 @@
 ## Shared Types
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     AgentConfig,
     BatchCompletion,
     CompletionMessage,
@@ -33,7 +33,7 @@ from llama_stack_client.types import (
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     ListToolGroupsResponse,
     ToolGroup,
     ToolgroupListResponse,
@@ -42,43 +42,43 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="get /v1/toolgroups">client.toolgroups.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/toolgroups.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/toolgroup_list_response.py">ToolgroupListResponse</a></code>
-- <code title="get /v1/toolgroups/{toolgroup_id}">client.toolgroups.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/toolgroups.py">get</a>(toolgroup_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_group.py">ToolGroup</a></code>
-- <code title="post /v1/toolgroups">client.toolgroups.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/toolgroups.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/toolgroup_register_params.py">params</a>) -> None</code>
-- <code title="delete /v1/toolgroups/{toolgroup_id}">client.toolgroups.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/toolgroups.py">unregister</a>(toolgroup_id) -> None</code>
+- <code title="get /v1/toolgroups">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/toolgroup_list_response.py">ToolgroupListResponse</a></code>
+- <code title="get /v1/toolgroups/{toolgroup_id}">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">get</a>(toolgroup_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_group.py">ToolGroup</a></code>
+- <code title="post /v1/toolgroups">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/toolgroup_register_params.py">params</a>) -> None</code>
+- <code title="delete /v1/toolgroups/{toolgroup_id}">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">unregister</a>(toolgroup_id) -> None</code>
 
 ## Tools
 
 Types:
 
 ```python
-from llama_stack_client.types import ListToolsResponse, Tool, ToolListResponse
+from ogx_client.types import ListToolsResponse, Tool, ToolListResponse
 ```
 
 Methods:
 
-- <code title="get /v1/tools">client.tools.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/tools.py">list</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_list_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_list_response.py">ToolListResponse</a></code>
-- <code title="get /v1/tools/{tool_name}">client.tools.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/tools.py">get</a>(tool_name) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool.py">Tool</a></code>
+- <code title="get /v1/tools">client.tools.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tools.py">list</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_list_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_list_response.py">ToolListResponse</a></code>
+- <code title="get /v1/tools/{tool_name}">client.tools.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tools.py">get</a>(tool_name) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool.py">Tool</a></code>
 
 ## ToolRuntime
 
 Types:
 
 ```python
-from llama_stack_client.types import ToolDef, ToolInvocationResult
+from ogx_client.types import ToolDef, ToolInvocationResult
 ```
 
 Methods:
 
-- <code title="post /v1/tool-runtime/invoke">client.tool_runtime.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/tool_runtime/tool_runtime.py">invoke_tool</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_runtime_invoke_tool_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_invocation_result.py">ToolInvocationResult</a></code>
-- <code title="get /v1/tool-runtime/list-tools">client.tool_runtime.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/tool_runtime/tool_runtime.py">list_tools</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_runtime_list_tools_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_def.py">JSONLDecoder[ToolDef]</a></code>
+- <code title="post /v1/tool-runtime/invoke">client.tool_runtime.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/tool_runtime.py">invoke_tool</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime_invoke_tool_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_invocation_result.py">ToolInvocationResult</a></code>
+- <code title="get /v1/tool-runtime/list-tools">client.tool_runtime.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/tool_runtime.py">list_tools</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime_list_tools_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_def.py">JSONLDecoder[ToolDef]</a></code>
 
 ### RagTool
 
 Methods:
 
-- <code title="post /v1/tool-runtime/rag-tool/insert">client.tool_runtime.rag_tool.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/tool_runtime/rag_tool.py">insert</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_runtime/rag_tool_insert_params.py">params</a>) -> None</code>
-- <code title="post /v1/tool-runtime/rag-tool/query">client.tool_runtime.rag_tool.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/tool_runtime/rag_tool.py">query</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/tool_runtime/rag_tool_query_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/shared/query_result.py">QueryResult</a></code>
+- <code title="post /v1/tool-runtime/rag-tool/insert">client.tool_runtime.rag_tool.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/rag_tool.py">insert</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime/rag_tool_insert_params.py">params</a>) -> None</code>
+- <code title="post /v1/tool-runtime/rag-tool/query">client.tool_runtime.rag_tool.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/rag_tool.py">query</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime/rag_tool_query_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/shared/query_result.py">QueryResult</a></code>
 
 ## Agents
 
@@ -93,7 +93,7 @@ The Responses API provides equivalent functionality with an OpenAI-compatible in
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     InferenceStep,
     MemoryRetrievalStep,
     ShieldCallStep,
@@ -105,54 +105,54 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="post /v1/agents">client.agents.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/agents.py">create</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agent_create_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agent_create_response.py">AgentCreateResponse</a></code>
-- <code title="delete /v1/agents/{agent_id}">client.agents.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/agents.py">delete</a>(agent_id) -> None</code>
+- <code title="post /v1/agents">client.agents.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/agents.py">create</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agent_create_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agent_create_response.py">AgentCreateResponse</a></code>
+- <code title="delete /v1/agents/{agent_id}">client.agents.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/agents.py">delete</a>(agent_id) -> None</code>
 
 ### Session
 
 Types:
 
 ```python
-from llama_stack_client.types.agents import Session, SessionCreateResponse
+from ogx_client.types.agents import Session, SessionCreateResponse
 ```
 
 Methods:
 
-- <code title="post /v1/agents/{agent_id}/session">client.agents.session.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/session.py">create</a>(agent_id, \*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/session_create_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/session_create_response.py">SessionCreateResponse</a></code>
-- <code title="get /v1/agents/{agent_id}/session/{session_id}">client.agents.session.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/session.py">retrieve</a>(session_id, \*, agent_id, \*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/session_retrieve_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/session.py">Session</a></code>
-- <code title="delete /v1/agents/{agent_id}/session/{session_id}">client.agents.session.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/session.py">delete</a>(session_id, \*, agent_id) -> None</code>
+- <code title="post /v1/agents/{agent_id}/session">client.agents.session.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/session.py">create</a>(agent_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session_create_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session_create_response.py">SessionCreateResponse</a></code>
+- <code title="get /v1/agents/{agent_id}/session/{session_id}">client.agents.session.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/session.py">retrieve</a>(session_id, \*, agent_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session_retrieve_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session.py">Session</a></code>
+- <code title="delete /v1/agents/{agent_id}/session/{session_id}">client.agents.session.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/session.py">delete</a>(session_id, \*, agent_id) -> None</code>
 
 ### Steps
 
 Types:
 
 ```python
-from llama_stack_client.types.agents import StepRetrieveResponse
+from ogx_client.types.agents import StepRetrieveResponse
 ```
 
 Methods:
 
-- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}">client.agents.steps.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/steps.py">retrieve</a>(step_id, \*, agent_id, session_id, turn_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/step_retrieve_response.py">StepRetrieveResponse</a></code>
+- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}">client.agents.steps.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/steps.py">retrieve</a>(step_id, \*, agent_id, session_id, turn_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/step_retrieve_response.py">StepRetrieveResponse</a></code>
 
 ### Turn
 
 Types:
 
 ```python
-from llama_stack_client.types.agents import Turn, TurnCreateResponse
+from ogx_client.types.agents import Turn, TurnCreateResponse
 ```
 
 Methods:
 
-- <code title="post /v1/agents/{agent_id}/session/{session_id}/turn">client.agents.turn.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/turn.py">create</a>(session_id, \*, agent_id, \*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/turn_create_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/turn_create_response.py">TurnCreateResponse</a></code>
-- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}">client.agents.turn.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/agents/turn.py">retrieve</a>(turn_id, \*, agent_id, session_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/agents/turn.py">Turn</a></code>
+- <code title="post /v1/agents/{agent_id}/session/{session_id}/turn">client.agents.turn.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/turn.py">create</a>(session_id, \*, agent_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/turn_create_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/turn_create_response.py">TurnCreateResponse</a></code>
+- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}">client.agents.turn.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/turn.py">retrieve</a>(turn_id, \*, agent_id, session_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/turn.py">Turn</a></code>
 
 ## Datasets
 
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     ListDatasetsResponse,
     DatasetRetrieveResponse,
     DatasetListResponse,
@@ -161,57 +161,57 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="get /v1/datasets/{dataset_id}">client.datasets.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/datasets.py">retrieve</a>(dataset_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/dataset_retrieve_response.py">Optional[DatasetRetrieveResponse]</a></code>
-- <code title="get /v1/datasets">client.datasets.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/datasets.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/dataset_list_response.py">DatasetListResponse</a></code>
-- <code title="post /v1/datasets">client.datasets.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/datasets.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/dataset_register_params.py">params</a>) -> None</code>
-- <code title="delete /v1/datasets/{dataset_id}">client.datasets.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/datasets.py">unregister</a>(dataset_id) -> None</code>
+- <code title="get /v1/datasets/{dataset_id}">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">retrieve</a>(dataset_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/dataset_retrieve_response.py">Optional[DatasetRetrieveResponse]</a></code>
+- <code title="get /v1/datasets">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/dataset_list_response.py">DatasetListResponse</a></code>
+- <code title="post /v1/datasets">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/dataset_register_params.py">params</a>) -> None</code>
+- <code title="delete /v1/datasets/{dataset_id}">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">unregister</a>(dataset_id) -> None</code>
 
 ## Eval
 
 Types:
 
 ```python
-from llama_stack_client.types import EvaluateResponse, Job
+from ogx_client.types import EvaluateResponse, Job
 ```
 
 Methods:
 
-- <code title="post /v1/eval/tasks/{benchmark_id}/evaluations">client.eval.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/eval/eval.py">evaluate_rows</a>(benchmark_id, \*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/eval_evaluate_rows_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/evaluate_response.py">EvaluateResponse</a></code>
-- <code title="post /v1/eval/tasks/{benchmark_id}/jobs">client.eval.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/eval/eval.py">run_eval</a>(benchmark_id, \*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/eval_run_eval_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/job.py">Job</a></code>
+- <code title="post /v1/eval/tasks/{benchmark_id}/evaluations">client.eval.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/eval.py">evaluate_rows</a>(benchmark_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/eval_evaluate_rows_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/evaluate_response.py">EvaluateResponse</a></code>
+- <code title="post /v1/eval/tasks/{benchmark_id}/jobs">client.eval.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/eval.py">run_eval</a>(benchmark_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/eval_run_eval_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/job.py">Job</a></code>
 
 ### Jobs
 
 Types:
 
 ```python
-from llama_stack_client.types.eval import JobStatusResponse
+from ogx_client.types.eval import JobStatusResponse
 ```
 
 Methods:
 
-- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}/result">client.eval.jobs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">retrieve</a>(job_id, \*, benchmark_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/evaluate_response.py">EvaluateResponse</a></code>
-- <code title="delete /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">cancel</a>(job_id, \*, benchmark_id) -> None</code>
-- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">status</a>(job_id, \*, benchmark_id) -> Optional[JobStatusResponse]</code>
+- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}/result">client.eval.jobs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">retrieve</a>(job_id, \*, benchmark_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/evaluate_response.py">EvaluateResponse</a></code>
+- <code title="delete /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">cancel</a>(job_id, \*, benchmark_id) -> None</code>
+- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">status</a>(job_id, \*, benchmark_id) -> Optional[JobStatusResponse]</code>
 
 ## Inspect
 
 Types:
 
 ```python
-from llama_stack_client.types import HealthInfo, ProviderInfo, RouteInfo, VersionInfo
+from ogx_client.types import HealthInfo, ProviderInfo, RouteInfo, VersionInfo
 ```
 
 Methods:
 
-- <code title="get /v1/health">client.inspect.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/inspect.py">health</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/health_info.py">HealthInfo</a></code>
-- <code title="get /v1/version">client.inspect.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/inspect.py">version</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/version_info.py">VersionInfo</a></code>
+- <code title="get /v1/health">client.inspect.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/inspect.py">health</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/health_info.py">HealthInfo</a></code>
+- <code title="get /v1/version">client.inspect.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/inspect.py">version</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/version_info.py">VersionInfo</a></code>
 
 ## Inference
 
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     CompletionResponse,
     EmbeddingsResponse,
     TokenLogProbs,
@@ -222,7 +222,7 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="post /v1/inference/embeddings">client.inference.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/inference.py">embeddings</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/inference_embeddings_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/embeddings_response.py">EmbeddingsResponse</a></code>
+- <code title="post /v1/inference/embeddings">client.inference.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/inference.py">embeddings</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/inference_embeddings_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/embeddings_response.py">EmbeddingsResponse</a></code>
 
 ## VectorIo
 
@@ -244,13 +244,13 @@ Related: [Issue #2981](https://github.com/ogx-ai/ogx/issues/2981)
 Types:
 
 ```python
-from llama_stack_client.types import QueryChunksResponse
+from ogx_client.types import QueryChunksResponse
 ```
 
 Methods:
 
-- <code title="post /v1/vector-io/insert">client.vector_io.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/vector_io.py">insert</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/vector_io_insert_params.py">params</a>) -> None</code>
-- <code title="post /v1/vector-io/query">client.vector_io.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/vector_io.py">query</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/vector_io_query_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/query_chunks_response.py">QueryChunksResponse</a></code>
+- <code title="post /v1/vector-io/insert">client.vector_io.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_io.py">insert</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_io_insert_params.py">params</a>) -> None</code>
+- <code title="post /v1/vector-io/query">client.vector_io.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_io.py">query</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_io_query_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/query_chunks_response.py">QueryChunksResponse</a></code>
 
 ## VectorDBs
 
@@ -274,7 +274,7 @@ Related: [Issue #2981](https://github.com/ogx-ai/ogx/issues/2981)
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     ListVectorDBsResponse,
     VectorDBRetrieveResponse,
     VectorDBListResponse,
@@ -284,25 +284,25 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="get /v1/vector-dbs/{vector_db_id}">client.vector_dbs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">retrieve</a>(vector_db_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/vector_db_retrieve_response.py">Optional[VectorDBRetrieveResponse]</a></code>
-- <code title="get /v1/vector-dbs">client.vector_dbs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/vector_db_list_response.py">VectorDBListResponse</a></code>
-- <code title="post /v1/vector-dbs">client.vector_dbs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/vector_db_register_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/vector_db_register_response.py">VectorDBRegisterResponse</a></code>
-- <code title="delete /v1/vector-dbs/{vector_db_id}">client.vector_dbs.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">unregister</a>(vector_db_id) -> None</code>
+- <code title="get /v1/vector-dbs/{vector_db_id}">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">retrieve</a>(vector_db_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_retrieve_response.py">Optional[VectorDBRetrieveResponse]</a></code>
+- <code title="get /v1/vector-dbs">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_list_response.py">VectorDBListResponse</a></code>
+- <code title="post /v1/vector-dbs">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_register_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_register_response.py">VectorDBRegisterResponse</a></code>
+- <code title="delete /v1/vector-dbs/{vector_db_id}">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">unregister</a>(vector_db_id) -> None</code>
 
 ## Models
 
 Types:
 
 ```python
-from llama_stack_client.types import ListModelsResponse, Model, ModelListResponse
+from ogx_client.types import ListModelsResponse, Model, ModelListResponse
 ```
 
 Methods:
 
-- <code title="get /v1/models/{model_id}">client.models.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/models.py">retrieve</a>(model_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/model.py">Optional[Model]</a></code>
-- <code title="get /v1/models">client.models.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/models.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/model_list_response.py">ModelListResponse</a></code>
-- <code title="post /v1/models">client.models.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/models.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/model_register_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/model.py">Model</a></code>
-- <code title="delete /v1/models/{model_id}">client.models.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/models.py">unregister</a>(model_id) -> None</code>
+- <code title="get /v1/models/{model_id}">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">retrieve</a>(model_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model.py">Optional[Model]</a></code>
+- <code title="get /v1/models">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model_list_response.py">ModelListResponse</a></code>
+- <code title="post /v1/models">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model_register_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model.py">Model</a></code>
+- <code title="delete /v1/models/{model_id}">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">unregister</a>(model_id) -> None</code>
 
 ## PostTraining
 
@@ -315,20 +315,20 @@ Methods:
 Types:
 
 ```python
-from llama_stack_client.types import ListPostTrainingJobsResponse, PostTrainingJob
+from ogx_client.types import ListPostTrainingJobsResponse, PostTrainingJob
 ```
 
 Methods:
 
-- <code title="post /v1/post-training/preference-optimize">client.post_training.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/post_training/post_training.py">preference_optimize</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training_preference_optimize_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training_job.py">PostTrainingJob</a></code>
-- <code title="post /v1/post-training/supervised-fine-tune">client.post_training.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/post_training/post_training.py">supervised_fine_tune</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training_supervised_fine_tune_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training_job.py">PostTrainingJob</a></code>
+- <code title="post /v1/post-training/preference-optimize">client.post_training.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/post_training.py">preference_optimize</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_preference_optimize_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_job.py">PostTrainingJob</a></code>
+- <code title="post /v1/post-training/supervised-fine-tune">client.post_training.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/post_training.py">supervised_fine_tune</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_supervised_fine_tune_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_job.py">PostTrainingJob</a></code>
 
 ### Job
 
 Types:
 
 ```python
-from llama_stack_client.types.post_training import (
+from ogx_client.types.post_training import (
     JobListResponse,
     JobArtifactsResponse,
     JobStatusResponse,
@@ -337,60 +337,60 @@ from llama_stack_client.types.post_training import (
 
 Methods:
 
-- <code title="get /v1/post-training/jobs">client.post_training.job.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/post_training/job.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training/job_list_response.py">JobListResponse</a></code>
-- <code title="get /v1/post-training/job/artifacts">client.post_training.job.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/post_training/job.py">artifacts</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training/job_artifacts_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training/job_artifacts_response.py">Optional[JobArtifactsResponse]</a></code>
-- <code title="post /v1/post-training/job/cancel">client.post_training.job.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/post_training/job.py">cancel</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training/job_cancel_params.py">params</a>) -> None</code>
-- <code title="get /v1/post-training/job/status">client.post_training.job.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/post_training/job.py">status</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training/job_status_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/post_training/job_status_response.py">Optional[JobStatusResponse]</a></code>
+- <code title="get /v1/post-training/jobs">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_list_response.py">JobListResponse</a></code>
+- <code title="get /v1/post-training/job/artifacts">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">artifacts</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_artifacts_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_artifacts_response.py">Optional[JobArtifactsResponse]</a></code>
+- <code title="post /v1/post-training/job/cancel">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">cancel</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_cancel_params.py">params</a>) -> None</code>
+- <code title="get /v1/post-training/job/status">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">status</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_status_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_status_response.py">Optional[JobStatusResponse]</a></code>
 
 ## Providers
 
 Types:
 
 ```python
-from llama_stack_client.types import ListProvidersResponse, ProviderListResponse
+from ogx_client.types import ListProvidersResponse, ProviderListResponse
 ```
 
 Methods:
 
-- <code title="get /v1/inspect/providers">client.providers.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/providers.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/provider_list_response.py">ProviderListResponse</a></code>
+- <code title="get /v1/inspect/providers">client.providers.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/providers.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/provider_list_response.py">ProviderListResponse</a></code>
 
 ## Routes
 
 Types:
 
 ```python
-from llama_stack_client.types import ListRoutesResponse, RouteListResponse
+from ogx_client.types import ListRoutesResponse, RouteListResponse
 ```
 
 Methods:
 
-- <code title="get /v1/inspect/routes">client.routes.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/routes.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/route_list_response.py">RouteListResponse</a></code>
+- <code title="get /v1/inspect/routes">client.routes.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/routes.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/route_list_response.py">RouteListResponse</a></code>
 
 ## Safety
 
 Types:
 
 ```python
-from llama_stack_client.types import RunShieldResponse
+from ogx_client.types import RunShieldResponse
 ```
 
 Methods:
 
-- <code title="post /v1/safety/run-shield">client.safety.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/safety.py">run_shield</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/safety_run_shield_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/run_shield_response.py">RunShieldResponse</a></code>
+- <code title="post /v1/safety/run-shield">client.safety.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/safety.py">run_shield</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/safety_run_shield_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/run_shield_response.py">RunShieldResponse</a></code>
 
 ## Shields
 
 Types:
 
 ```python
-from llama_stack_client.types import ListShieldsResponse, Shield, ShieldListResponse
+from ogx_client.types import ListShieldsResponse, Shield, ShieldListResponse
 ```
 
 Methods:
 
-- <code title="get /v1/shields/{identifier}">client.shields.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/shields.py">retrieve</a>(identifier) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/shield.py">Optional[Shield]</a></code>
-- <code title="get /v1/shields">client.shields.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/shields.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/shield_list_response.py">ShieldListResponse</a></code>
-- <code title="post /v1/shields">client.shields.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/shields.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/shield_register_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/shield.py">Shield</a></code>
+- <code title="get /v1/shields/{identifier}">client.shields.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/shields.py">retrieve</a>(identifier) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/shield.py">Optional[Shield]</a></code>
+- <code title="get /v1/shields">client.shields.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/shields.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/shield_list_response.py">ShieldListResponse</a></code>
+- <code title="post /v1/shields">client.shields.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/shields.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/shield_register_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/shield.py">Shield</a></code>
 
 ## SyntheticDataGeneration
 
@@ -403,45 +403,45 @@ Methods:
 Types:
 
 ```python
-from llama_stack_client.types import SyntheticDataGenerationResponse
+from ogx_client.types import SyntheticDataGenerationResponse
 ```
 
 Methods:
 
-- <code title="post /v1/synthetic-data-generation/generate">client.synthetic_data_generation.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/synthetic_data_generation.py">generate</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/synthetic_data_generation_generate_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/synthetic_data_generation_response.py">SyntheticDataGenerationResponse</a></code>
+- <code title="post /v1/synthetic-data-generation/generate">client.synthetic_data_generation.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/synthetic_data_generation.py">generate</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/synthetic_data_generation_generate_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/synthetic_data_generation_response.py">SyntheticDataGenerationResponse</a></code>
 
 ## Datasetio
 
 Types:
 
 ```python
-from llama_stack_client.types import PaginatedRowsResult
+from ogx_client.types import PaginatedRowsResult
 ```
 
 Methods:
 
-- <code title="post /v1/datasetio/rows">client.datasetio.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/datasetio.py">append_rows</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/datasetio_append_rows_params.py">params</a>) -> None</code>
-- <code title="get /v1/datasetio/rows">client.datasetio.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/datasetio.py">get_rows_paginated</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/datasetio_get_rows_paginated_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/paginated_rows_result.py">PaginatedRowsResult</a></code>
+- <code title="post /v1/datasetio/rows">client.datasetio.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasetio.py">append_rows</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/datasetio_append_rows_params.py">params</a>) -> None</code>
+- <code title="get /v1/datasetio/rows">client.datasetio.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasetio.py">get_rows_paginated</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/datasetio_get_rows_paginated_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/paginated_rows_result.py">PaginatedRowsResult</a></code>
 
 ## Scoring
 
 Types:
 
 ```python
-from llama_stack_client.types import ScoringScoreResponse, ScoringScoreBatchResponse
+from ogx_client.types import ScoringScoreResponse, ScoringScoreBatchResponse
 ```
 
 Methods:
 
-- <code title="post /v1/scoring/score">client.scoring.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/scoring.py">score</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_score_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_score_response.py">ScoringScoreResponse</a></code>
-- <code title="post /v1/scoring/score-batch">client.scoring.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/scoring.py">score_batch</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_score_batch_params.py">params</a>) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_score_batch_response.py">ScoringScoreBatchResponse</a></code>
+- <code title="post /v1/scoring/score">client.scoring.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring.py">score</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_response.py">ScoringScoreResponse</a></code>
+- <code title="post /v1/scoring/score-batch">client.scoring.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring.py">score_batch</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_batch_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_batch_response.py">ScoringScoreBatchResponse</a></code>
 
 ## ScoringFunctions
 
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     ListScoringFunctionsResponse,
     ScoringFn,
     ScoringFunctionListResponse,
@@ -450,16 +450,16 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="get /v1/scoring-functions/{scoring_fn_id}">client.scoring_functions.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">retrieve</a>(scoring_fn_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_fn.py">Optional[ScoringFn]</a></code>
-- <code title="get /v1/scoring-functions">client.scoring_functions.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_function_list_response.py">ScoringFunctionListResponse</a></code>
-- <code title="post /v1/scoring-functions">client.scoring_functions.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/scoring_function_register_params.py">params</a>) -> None</code>
+- <code title="get /v1/scoring-functions/{scoring_fn_id}">client.scoring_functions.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">retrieve</a>(scoring_fn_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_fn.py">Optional[ScoringFn]</a></code>
+- <code title="get /v1/scoring-functions">client.scoring_functions.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_function_list_response.py">ScoringFunctionListResponse</a></code>
+- <code title="post /v1/scoring-functions">client.scoring_functions.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_function_register_params.py">params</a>) -> None</code>
 
 ## Benchmarks
 
 Types:
 
 ```python
-from llama_stack_client.types import (
+from ogx_client.types import (
     Benchmark,
     ListBenchmarksResponse,
     BenchmarkListResponse,
@@ -468,6 +468,6 @@ from llama_stack_client.types import (
 
 Methods:
 
-- <code title="get /v1/eval-tasks/{benchmark_id}">client.benchmarks.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/benchmarks.py">retrieve</a>(benchmark_id) -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/benchmark.py">Optional[Benchmark]</a></code>
-- <code title="get /v1/eval-tasks">client.benchmarks.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/benchmarks.py">list</a>() -> <a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/benchmark_list_response.py">BenchmarkListResponse</a></code>
-- <code title="post /v1/eval-tasks">client.benchmarks.<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/resources/benchmarks.py">register</a>(\*\*<a href="https://github.com/meta-llama/llama-stack-client-python/tree/main/src/ogx_client/types/benchmark_register_params.py">params</a>) -> None</code>
+- <code title="get /v1/eval-tasks/{benchmark_id}">client.benchmarks.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/benchmarks.py">retrieve</a>(benchmark_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/benchmark.py">Optional[Benchmark]</a></code>
+- <code title="get /v1/eval-tasks">client.benchmarks.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/benchmarks.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/benchmark_list_response.py">BenchmarkListResponse</a></code>
+- <code title="post /v1/eval-tasks">client.benchmarks.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/benchmarks.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/benchmark_register_params.py">params</a>) -> None</code>

--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -235,7 +235,7 @@ In `test_ogx.py`, write the following code:
 
 ```python
 import os
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 # Get the model ID from the environment variable
 INFERENCE_MODEL = os.environ.get("INFERENCE_MODEL")
@@ -245,7 +245,7 @@ if INFERENCE_MODEL is None:
     raise ValueError("The environment variable 'INFERENCE_MODEL' is not set.")
 
 # Initialize the client
-client = LlamaStackClient(base_url="http://localhost:8321")
+client = OgxClient(base_url="http://localhost:8321")
 
 # Create a chat completion request
 response = client.chat.completions.create(
@@ -295,7 +295,7 @@ This command initializes the model to interact with your local OGX instance.
 
 **Explore Client SDKs**: Utilize our client SDKs for various languages to integrate OGX into your applications:
 
-- [Python SDK](https://github.com/meta-llama/llama-stack-client-python)
+- [Python SDK](https://github.com/ogx-ai/ogx-client-python)
 - [Node SDK](https://github.com/ogx-ai/ogx-client-node)
 - [Swift SDK](https://github.com/ogx-ai/ogx-client-swift)
 - [Kotlin SDK](https://github.com/ogx-ai/ogx-client-kotlin)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client>=0.7.1", # Optional for library-only usage
+    "ogx-client>=0.7.3", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -176,7 +176,7 @@ type_checking = [
     "langchain-openai",
     "langchain-core",
     "langgraph",
-    "ogx-client>=0.7.1",
+    "ogx-client>=0.7.3",
 ]
 # These are the dependencies required for running unit tests.
 unit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "llama-stack-client>=0.7.1", # Optional for library-only usage
+    "ogx-client>=0.7.1", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -176,7 +176,7 @@ type_checking = [
     "langchain-openai",
     "langchain-core",
     "langgraph",
-    "llama-stack-client>=0.7.1",
+    "ogx-client>=0.7.1",
 ]
 # These are the dependencies required for running unit tests.
 unit = [

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -280,11 +280,11 @@ run_client_ts_tests() {
     if [[ -d "$TS_CLIENT_PATH" ]]; then
         # It's a directory path - use local checkout
         if [[ ! -f "$TS_CLIENT_PATH/package.json" ]]; then
-            echo "Error: $TS_CLIENT_PATH exists but doesn't look like llama-stack-client-typescript (no package.json)"
+            echo "Error: $TS_CLIENT_PATH exists but doesn't look like ogx-client-typescript (no package.json)"
             popd >/dev/null
             return 1
         fi
-        echo "Using local llama-stack-client-typescript from: $TS_CLIENT_PATH"
+        echo "Using local ogx-client-typescript from: $TS_CLIENT_PATH"
 
         # Build the TypeScript client first
         echo "Building TypeScript client..."
@@ -301,26 +301,26 @@ run_client_ts_tests() {
         fi
 
         # Then install the client from local directory
-        echo "Installing llama-stack-client from: $TS_CLIENT_PATH"
+        echo "Installing ogx-client from: $TS_CLIENT_PATH"
         npm install "$TS_CLIENT_PATH" --silent
     else
         # It's an npm version specifier - install from npm
-        echo "Installing llama-stack-client@${TS_CLIENT_PATH} from npm"
+        echo "Installing ogx-client@${TS_CLIENT_PATH} from npm"
         if [[ "${CI:-}" == "true" || "${CI:-}" == "1" ]]; then
             npm ci --silent
-            npm install "llama-stack-client@${TS_CLIENT_PATH}" --silent
+            npm install "ogx-client@${TS_CLIENT_PATH}" --silent
         else
-            npm install "llama-stack-client@${TS_CLIENT_PATH}" --silent
+            npm install "ogx-client@${TS_CLIENT_PATH}" --silent
         fi
     fi
 
     # Verify installation
-    echo "Verifying llama-stack-client installation..."
-    if npm list llama-stack-client 2>/dev/null | grep -q llama-stack-client; then
-        echo "✅ llama-stack-client successfully installed"
-        npm list llama-stack-client
+    echo "Verifying ogx-client installation..."
+    if npm list ogx-client 2>/dev/null | grep -q ogx-client; then
+        echo "✅ ogx-client successfully installed"
+        npm list ogx-client
     else
-        echo "❌ llama-stack-client not found in node_modules"
+        echo "❌ ogx-client not found in node_modules"
         echo "Installed packages:"
         npm list --depth=0
         popd >/dev/null

--- a/src/ogx/core/library_client.py
+++ b/src/ogx/core/library_client.py
@@ -24,18 +24,16 @@ from fastapi import Response as FastAPIResponse
 from ogx.core.utils.type_inspection import is_body_param, is_unwrapped_body_param
 
 try:
-    from llama_stack_client import (
+    from ogx_client import (
         NOT_GIVEN,
         APIResponse,
         AsyncAPIResponse,
-        AsyncLlamaStackClient,
+        AsyncOgxClient,
         AsyncStream,
-        LlamaStackClient,
+        OgxClient,
     )
 except ImportError as e:
-    raise ImportError(
-        "llama-stack-client is not installed. Please install it with `uv pip install ogx[client]`."
-    ) from e
+    raise ImportError("ogx-client is not installed. Please install it with `uv pip install ogx[client]`.") from e
 
 from pydantic import BaseModel, TypeAdapter
 from rich.console import Console
@@ -157,7 +155,7 @@ class LibraryClientHttpxResponse:
         self.headers = response.headers
 
 
-class OGXAsLibraryClient(LlamaStackClient):
+class OGXAsLibraryClient(OgxClient):
     """Synchronous client that runs a OGX distribution in-process as a library."""
 
     def __init__(
@@ -258,7 +256,7 @@ class OGXAsLibraryClient(LlamaStackClient):
             return result
 
 
-class AsyncOGXAsLibraryClient(AsyncLlamaStackClient):
+class AsyncOGXAsLibraryClient(AsyncOgxClient):
     """Async client that runs a OGX distribution in-process as a library."""
 
     def __init__(
@@ -580,7 +578,7 @@ class AsyncOGXAsLibraryClient(AsyncLlamaStackClient):
             ),
         )
 
-        # we use asynchronous impl always internally and channel all requests to AsyncLlamaStackClient
+        # we use asynchronous impl always internally and channel all requests to AsyncOgxClient
         # however, the top-level caller may be a SyncAPIClient -- so its stream_cls might be a Stream (SyncStream)
         # so we need to convert it to AsyncStream
         # mypy can't track runtime variables inside the [...] of a generic, so ignore that check

--- a/src/ogx/testing/api_recorder.py
+++ b/src/ogx/testing/api_recorder.py
@@ -277,18 +277,18 @@ def patch_httpx_for_test_id():
     We use the _prepare_request hook that Stainless clients provide for mutating
     requests after construction but before sending.
     """
-    from llama_stack_client import LlamaStackClient
+    from ogx_client import OgxClient
 
-    if "llama_stack_client_prepare_request" in _original_methods:
+    if "ogx_client_prepare_request" in _original_methods:
         return
 
-    _original_methods["llama_stack_client_prepare_request"] = LlamaStackClient._prepare_request
+    _original_methods["ogx_client_prepare_request"] = OgxClient._prepare_request
     _original_methods["openai_prepare_request"] = OpenAI._prepare_request
 
     def patched_prepare_request(self, request):
         # Call original first (it's a sync method that returns None)
         # Determine which original to call based on client type
-        _original_methods["llama_stack_client_prepare_request"](self, request)
+        _original_methods["ogx_client_prepare_request"](self, request)
         _original_methods["openai_prepare_request"](self, request)
 
         # Only inject test ID in server mode
@@ -313,20 +313,20 @@ def patch_httpx_for_test_id():
 
         return None
 
-    LlamaStackClient._prepare_request = patched_prepare_request
+    OgxClient._prepare_request = patched_prepare_request
     OpenAI._prepare_request = patched_prepare_request
 
 
 # currently, unpatch is never called
 def unpatch_httpx_for_test_id():
     """Remove client _prepare_request patches for test ID injection."""
-    if "llama_stack_client_prepare_request" not in _original_methods:
+    if "ogx_client_prepare_request" not in _original_methods:
         return
 
-    from llama_stack_client import LlamaStackClient
+    from ogx_client import OgxClient
 
-    LlamaStackClient._prepare_request = _original_methods["llama_stack_client_prepare_request"]
-    del _original_methods["llama_stack_client_prepare_request"]
+    OgxClient._prepare_request = _original_methods["ogx_client_prepare_request"]
+    del _original_methods["ogx_client_prepare_request"]
     OpenAI._prepare_request = _original_methods["openai_prepare_request"]
     del _original_methods["openai_prepare_request"]
 

--- a/tests/integration/admin/test_admin.py
+++ b/tests/integration/admin/test_admin.py
@@ -4,13 +4,13 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 from ogx.core.library_client import OGXAsLibraryClient
 
 
 class TestAdmin:
-    def test_admin_providers_list(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_admin_providers_list(self, ogx_client: OGXAsLibraryClient | OgxClient):
         provider_list = ogx_client.alpha.admin.list_providers()
         assert provider_list is not None
         assert len(provider_list) > 0
@@ -20,17 +20,17 @@ class TestAdmin:
             provider = ogx_client.alpha.admin.inspect_provider(pid)
             assert provider is not None
 
-    def test_health(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_health(self, ogx_client: OGXAsLibraryClient | OgxClient):
         health = ogx_client.alpha.admin.health()
         assert health is not None
         assert health.status == "OK"
 
-    def test_version(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_version(self, ogx_client: OGXAsLibraryClient | OgxClient):
         version = ogx_client.alpha.admin.version()
         assert version is not None
         assert version.version is not None
 
-    def test_list_routes_default(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_list_routes_default(self, ogx_client: OGXAsLibraryClient | OgxClient):
         """Test list_routes with default filter (non-deprecated v1 routes)."""
         routes = ogx_client.alpha.admin.list_routes()
         assert routes is not None
@@ -46,7 +46,7 @@ class TestAdmin:
         assert "/inspect/routes" in paths or "/v1/inspect/routes" in paths
         assert "/health" in paths or "/v1/health" in paths
 
-    def test_list_routes_filter_by_deprecated(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_list_routes_filter_by_deprecated(self, ogx_client: OGXAsLibraryClient | OgxClient):
         """Test list_routes with deprecated filter."""
         routes = ogx_client.alpha.admin.list_routes(api_filter="deprecated")
         assert routes is not None
@@ -55,7 +55,7 @@ class TestAdmin:
         # Verify we get some deprecated routes (e.g., /toolgroups, /shields, /models, etc.)
         assert len(routes) > 0, "Deprecated filter should return some deprecated routes"
 
-    def test_list_routes_filter_by_v1(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_list_routes_filter_by_v1(self, ogx_client: OGXAsLibraryClient | OgxClient):
         """Test list_routes with v1 filter."""
         routes = ogx_client.alpha.admin.list_routes(api_filter="v1")
         assert routes is not None

--- a/tests/integration/client-typescript/setup.ts
+++ b/tests/integration/client-typescript/setup.ts
@@ -9,7 +9,7 @@
  * This file mimics pytest's fixture system by providing shared test configuration.
  */
 
-import LlamaStackClient from 'llama-stack-client';
+import OgxClient from 'ogx-client';
 
 /**
  * Load test configuration from the Python setup system.
@@ -62,7 +62,7 @@ beforeAll(() => {
  * @param testId - Test ID to send in X-OGX-Provider-Data header for replay mode.
  *                 Format: "tests/integration/responses/test_basic_responses.py::test_name[params]"
  */
-export function createTestClient(testId?: string): LlamaStackClient {
+export function createTestClient(testId?: string): OgxClient {
   const headers: Record<string, string> = {};
 
   // In server mode with replay, send test ID for recording isolation
@@ -72,7 +72,7 @@ export function createTestClient(testId?: string): LlamaStackClient {
     });
   }
 
-  return new LlamaStackClient({
+  return new OgxClient({
     baseURL: TEST_CONFIG.baseURL,
     timeout: 60000, // 60 seconds
     defaultHeaders: headers,

--- a/tests/integration/files/test_files.py
+++ b/tests/integration/files/test_files.py
@@ -178,7 +178,7 @@ def test_expires_after_requests(openai_client):
 @patch("ogx.core.storage.sqlstore.authorized_sqlstore.get_authenticated_user")
 def test_files_authentication_isolation(mock_get_authenticated_user, ogx_client):
     """Test that users can only access their own files."""
-    from llama_stack_client import NotFoundError
+    from ogx_client import NotFoundError
 
     client = ogx_client
 

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -171,7 +171,7 @@ def client_with_models(
     providers = [p for p in client.providers.list() if p.api == "inference"]
     assert len(providers) > 0, "No inference providers found"
 
-    model_ids = {m.id for m in client.models.list()}
+    model_ids = {m.id for m in client.models.list().data}
 
     if text_model_id and text_model_id not in model_ids:
         raise ValueError(f"text_model_id {text_model_id} not found")

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -22,7 +22,7 @@ setup_logging()
 import pytest
 import requests
 import yaml
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 from openai import OpenAI
 
 from ogx.core.datatypes import QualifiedModel, RerankerModel, VectorStoresConfig
@@ -307,7 +307,7 @@ def instantiate_ogx_client(session):
         else:
             print(f"Port {port} is already in use, assuming server is already running...")
 
-        return LlamaStackClient(
+        return OgxClient(
             base_url=base_url,
             provider_data=get_provider_data(),
             timeout=int(os.environ.get("OGX_CLIENT_TIMEOUT", "30")),
@@ -317,7 +317,7 @@ def instantiate_ogx_client(session):
     try:
         parsed_url = urlparse(config)
         if parsed_url.scheme and parsed_url.netloc:
-            return LlamaStackClient(
+            return OgxClient(
                 base_url=config,
                 provider_data=get_provider_data(),
             )

--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -17,7 +17,11 @@ from ..test_cases.test_case import TestCase
 def provider_from_model(client_with_models, model_id):
     models = {m.id: m for m in client_with_models.models.list().data}
     models.update(
-        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list().data if m.custom_metadata}
+        {
+            m.custom_metadata["provider_resource_id"]: m
+            for m in client_with_models.models.list().data
+            if m.custom_metadata
+        }
     )
     provider_id = models[model_id].custom_metadata["provider_id"]
     providers = {p.provider_id: p for p in client_with_models.providers.list()}

--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -15,9 +15,9 @@ from ..test_cases.test_case import TestCase
 
 
 def provider_from_model(client_with_models, model_id):
-    models = {m.id: m for m in client_with_models.models.list()}
+    models = {m.id: m for m in client_with_models.models.list().data}
     models.update(
-        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list() if m.custom_metadata}
+        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list().data if m.custom_metadata}
     )
     provider_id = models[model_id].custom_metadata["provider_id"]
     providers = {p.provider_id: p for p in client_with_models.providers.list()}

--- a/tests/integration/inference/test_openai_embeddings.py
+++ b/tests/integration/inference/test_openai_embeddings.py
@@ -31,9 +31,9 @@ def decode_base64_to_floats(base64_string: str) -> list[float]:
 
 
 def provider_from_model(client_with_models, model_id):
-    models = {m.id: m for m in client_with_models.models.list()}
+    models = {m.id: m for m in client_with_models.models.list().data}
     models.update(
-        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list() if m.custom_metadata}
+        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list().data if m.custom_metadata}
     )
     provider_id = models[model_id].custom_metadata["provider_id"]
     providers = {p.provider_id: p for p in client_with_models.providers.list()}

--- a/tests/integration/inference/test_openai_embeddings.py
+++ b/tests/integration/inference/test_openai_embeddings.py
@@ -33,7 +33,11 @@ def decode_base64_to_floats(base64_string: str) -> list[float]:
 def provider_from_model(client_with_models, model_id):
     models = {m.id: m for m in client_with_models.models.list().data}
     models.update(
-        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list().data if m.custom_metadata}
+        {
+            m.custom_metadata["provider_resource_id"]: m
+            for m in client_with_models.models.list().data
+            if m.custom_metadata
+        }
     )
     provider_id = models[model_id].custom_metadata["provider_id"]
     providers = {p.provider_id: p for p in client_with_models.providers.list()}

--- a/tests/integration/inference/test_provider_data_routing.py
+++ b/tests/integration/inference/test_provider_data_routing.py
@@ -51,7 +51,7 @@ def test_unregistered_model_routing_with_provider_data(client_with_models):
     test_model_id = "anthropic/claude-3-5-sonnet-20241022"
 
     # First, verify the model is NOT registered
-    registered_models = {m.id for m in client.models.list()}
+    registered_models = {m.id for m in client.models.list().data}
     assert test_model_id not in registered_models, f"Model {test_model_id} should not be pre-registered for this test"
 
     # Check if anthropic provider is available in ci-tests

--- a/tests/integration/inference/test_rerank.py
+++ b/tests/integration/inference/test_rerank.py
@@ -5,9 +5,9 @@
 # the root directory of this source tree.
 
 import pytest
-from llama_stack_client import BadRequestError as OGXBadRequestError
-from llama_stack_client.types.alpha import InferenceRerankResponse
-from llama_stack_client.types.shared.interleaved_content import (
+from ogx_client import BadRequestError as OGXBadRequestError
+from ogx_client.types.alpha import InferenceRerankResponse
+from ogx_client.types.shared.interleaved_content import (
     ImageContentItem,
     ImageContentItemImage,
     ImageContentItemImageURL,

--- a/tests/integration/inspect/test_inspect.py
+++ b/tests/integration/inspect/test_inspect.py
@@ -5,26 +5,26 @@
 # the root directory of this source tree.
 
 import pytest
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 from ogx.core.library_client import OGXAsLibraryClient
 
 
 class TestInspect:
     @pytest.mark.skip(reason="inspect tests disabled")
-    def test_health(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_health(self, ogx_client: OGXAsLibraryClient | OgxClient):
         health = ogx_client.inspect.health()
         assert health is not None
         assert health.status == "OK"
 
     @pytest.mark.skip(reason="inspect tests disabled")
-    def test_version(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_version(self, ogx_client: OGXAsLibraryClient | OgxClient):
         version = ogx_client.inspect.version()
         assert version is not None
         assert version.version is not None
 
     @pytest.mark.skip(reason="inspect tests disabled")
-    def test_list_routes_default(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_list_routes_default(self, ogx_client: OGXAsLibraryClient | OgxClient):
         """Test list_routes with default filter (non-deprecated v1 routes)."""
         response = ogx_client.routes.list()
         assert response is not None
@@ -43,7 +43,7 @@ class TestInspect:
         assert "/health" in paths or "/v1/health" in paths
 
     @pytest.mark.skip(reason="inspect tests disabled")
-    def test_list_routes_filter_by_deprecated(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_list_routes_filter_by_deprecated(self, ogx_client: OGXAsLibraryClient | OgxClient):
         """Test list_routes with deprecated filter."""
         response = ogx_client.routes.list(api_filter="deprecated")
         assert response is not None
@@ -58,7 +58,7 @@ class TestInspect:
             assert len(openai_routes) > 0, "Deprecated filter should include /openai/ routes"
 
     @pytest.mark.skip(reason="inspect tests disabled")
-    def test_list_routes_filter_by_v1(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_list_routes_filter_by_v1(self, ogx_client: OGXAsLibraryClient | OgxClient):
         """Test list_routes with v1 filter."""
         response = ogx_client.routes.list(api_filter="v1")
         assert response is not None

--- a/tests/integration/providers/test_providers.py
+++ b/tests/integration/providers/test_providers.py
@@ -4,13 +4,13 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 from ogx.core.library_client import OGXAsLibraryClient
 
 
 class TestProviders:
-    def test_providers(self, ogx_client: OGXAsLibraryClient | LlamaStackClient):
+    def test_providers(self, ogx_client: OGXAsLibraryClient | OgxClient):
         provider_list = ogx_client.providers.list()
         assert provider_list is not None
         assert len(provider_list) > 0

--- a/tests/integration/responses/helpers.py
+++ b/tests/integration/responses/helpers.py
@@ -26,9 +26,13 @@ __all__ = [
 
 
 def provider_from_model(client_with_models, model_id):
-    models = {m.id: m for m in client_with_models.models.list()}
+    models = {m.id: m for m in client_with_models.models.list().data}
     models.update(
-        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list() if m.custom_metadata}
+        {
+            m.custom_metadata["provider_resource_id"]: m
+            for m in client_with_models.models.list().data
+            if m.custom_metadata
+        }
     )
     provider_id = models[model_id].custom_metadata["provider_id"]
     providers = {p.provider_id: p for p in client_with_models.providers.list()}

--- a/tests/integration/responses/test_compact_responses.py
+++ b/tests/integration/responses/test_compact_responses.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import pytest
-from llama_stack_client import LlamaStackClient
+from ogx_client import OgxClient
 
 from .helpers import skip_if_provider_is_vertexai
 
@@ -36,7 +36,7 @@ class TestCompactResponses:
 
     @pytest.fixture(autouse=True)
     def _skip_non_openai_client(self, responses_client):
-        if isinstance(responses_client, LlamaStackClient):
+        if isinstance(responses_client, OgxClient):
             pytest.skip("Compact tests require OpenAI client")
 
     def test_compact_basic_conversation(self, responses_client, text_model_id):
@@ -248,7 +248,7 @@ class TestContextManagement:
 
     @pytest.fixture(autouse=True)
     def _skip_non_openai_client(self, responses_client):
-        if isinstance(responses_client, LlamaStackClient):
+        if isinstance(responses_client, OgxClient):
             pytest.skip("Context management tests require OpenAI client")
 
     @pytest.fixture(autouse=True)

--- a/tests/integration/responses/test_mcp_authentication.py
+++ b/tests/integration/responses/test_mcp_authentication.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 
-import llama_stack_client
+import ogx_client
 import openai
 import pytest
 
@@ -76,9 +76,7 @@ def test_mcp_authorization_error_when_header_provided(responses_client, client_w
         )
 
         # Create response - should raise BadRequestError for security reasons
-        with pytest.raises(
-            (llama_stack_client.BadRequestError, openai.BadRequestError), match="'authorization' parameter"
-        ):
+        with pytest.raises((ogx_client.BadRequestError, openai.BadRequestError), match="'authorization' parameter"):
             responses_client.responses.create(
                 model=text_model_id,
                 input="What is the boiling point of myawesomeliquid?",

--- a/tests/integration/responses/test_reasoning.py
+++ b/tests/integration/responses/test_reasoning.py
@@ -19,9 +19,13 @@ def _get_attr(item, key, default=None):
 
 
 def provider_from_model(client_with_models, text_model_id):
-    models = {m.id: m for m in client_with_models.models.list()}
+    models = {m.id: m for m in client_with_models.models.list().data}
     models.update(
-        {m.custom_metadata["provider_resource_id"]: m for m in client_with_models.models.list() if m.custom_metadata}
+        {
+            m.custom_metadata["provider_resource_id"]: m
+            for m in client_with_models.models.list().data
+            if m.custom_metadata
+        }
     )
     provider_id = models[text_model_id].custom_metadata["provider_id"]
     providers = {p.provider_id: p for p in client_with_models.providers.list()}

--- a/tests/integration/responses/test_tool_responses.py
+++ b/tests/integration/responses/test_tool_responses.py
@@ -9,7 +9,7 @@ import logging  # allow-direct-logging
 import os
 
 import httpx
-import llama_stack_client
+import ogx_client
 import openai
 import pytest
 
@@ -267,7 +267,7 @@ def test_response_non_streaming_mcp_tool(responses_client, client_with_models, t
         exc_type = (
             AuthenticationRequiredError
             if isinstance(responses_client, OGXAsLibraryClient)
-            else (httpx.HTTPStatusError, openai.AuthenticationError, llama_stack_client.AuthenticationError)
+            else (httpx.HTTPStatusError, openai.AuthenticationError, ogx_client.AuthenticationError)
         )
         # Suppress expected auth error logs only for the failing auth attempt
         with caplog.at_level(logging.CRITICAL, logger="ogx.providers.inline.responses.builtin.responses.streaming"):
@@ -994,7 +994,7 @@ def test_max_tool_calls_invalid(responses_client, text_model_id):
 
     # Create a response with an invalid max_tool_calls value i.e. 0
     # Handle ValueError from LLS and BadRequestError from OpenAI client
-    with pytest.raises((ValueError, llama_stack_client.BadRequestError, openai.BadRequestError)) as excinfo:
+    with pytest.raises((ValueError, ogx_client.BadRequestError, openai.BadRequestError)) as excinfo:
         responses_client.responses.create(
             model=text_model_id,
             input=input,

--- a/tests/integration/safety/test_llama_guard.py
+++ b/tests/integration/safety/test_llama_guard.py
@@ -39,7 +39,7 @@ def text_model(request, client_with_models):
     model_id = request.param
 
     # Check if the model is available
-    available_models = [m.id for m in client_with_models.models.list()]
+    available_models = [m.id for m in client_with_models.models.list().data]
 
     if model_id not in available_models:
         pytest.skip(
@@ -73,7 +73,7 @@ def vision_model(request, client_with_models):
     model_id = request.param
 
     # Check if the model is available
-    available_models = [m.id for m in client_with_models.models.list()]
+    available_models = [m.id for m in client_with_models.models.list().data]
 
     if model_id not in available_models:
         pytest.skip(

--- a/tests/integration/tool_runtime/test_mcp.py
+++ b/tests/integration/tool_runtime/test_mcp.py
@@ -5,8 +5,8 @@
 # the root directory of this source tree.
 
 import pytest
-from llama_stack_client.lib.agents.agent import Agent
-from llama_stack_client.lib.agents.turn_events import StepCompleted, StepProgress, ToolCallIssuedDelta
+from ogx_client.lib.agents.agent import Agent
+from ogx_client.lib.agents.turn_events import StepCompleted, StepProgress, ToolCallIssuedDelta
 
 AUTH_TOKEN = "test-token"
 

--- a/tests/integration/tool_runtime/test_mcp_json_schema.py
+++ b/tests/integration/tool_runtime/test_mcp_json_schema.py
@@ -10,8 +10,8 @@ via the Responses/Agent API.
 """
 
 import pytest
-from llama_stack_client.lib.agents.agent import Agent
-from llama_stack_client.lib.agents.turn_events import StepCompleted, StepProgress, ToolCallIssuedDelta
+from ogx_client.lib.agents.agent import Agent
+from ogx_client.lib.agents.turn_events import StepCompleted, StepProgress, ToolCallIssuedDelta
 
 from tests.common.mcp import make_mcp_server
 

--- a/tests/integration/vector_io/test_openai_vector_stores.py
+++ b/tests/integration/vector_io/test_openai_vector_stores.py
@@ -8,7 +8,7 @@ import time
 from io import BytesIO
 
 import pytest
-from llama_stack_client import BadRequestError
+from ogx_client import BadRequestError
 from openai import BadRequestError as OpenAIBadRequestError
 from openai import OpenAI
 

--- a/uv.lock
+++ b/uv.lock
@@ -3663,7 +3663,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "oci", specifier = ">=2.165.0" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.7.1" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.7.3" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -3797,7 +3797,7 @@ type-checking = [
     { name = "lm-format-enforcer" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=0.7.1" },
+    { name = "ogx-client", specifier = ">=0.7.3" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -3862,7 +3862,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "0.7.2"
+version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3881,9 +3881,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/ab/cb016ce17482054824fa986a296c4be9cf00178110eb27f26094cdc6b449/ogx_client-0.7.2.tar.gz", hash = "sha256:85e3f178ef826480e1f5851a00cf5695d64a6a71c2c22867b127f651fa0c0253", size = 436426, upload-time = "2026-05-01T17:38:26.139Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/14/de328d875a8fe536fbb784cd2bb71d3e2811b69319cf2aab9aa151f5b5ab/ogx_client-0.7.3.tar.gz", hash = "sha256:f9e9fe66608166a658df63642955706e7c12892b3ee0dd21cbb889d7396c6621", size = 436495, upload-time = "2026-05-01T19:01:31.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/8d/7dfe156c07429660e42344ef4180367379f09edf1afcefec2f313fa52de7/ogx_client-0.7.2-py3-none-any.whl", hash = "sha256:3e12e4eae159021c2fa56f3427dcef8fd647e7552b60774858f2f5f333a8ec91", size = 311412, upload-time = "2026-05-01T17:38:24.283Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1d/767a470740cc71f7f405ad93b2f259c26a75ebf62f93236c2d8198a07366/ogx_client-0.7.3-py3-none-any.whl", hash = "sha256:29c4bcb70ffeedbc27d2f833c6a2ca5c0ae91b30f8d7024dddba8b94f5deec13", size = 311473, upload-time = "2026-05-01T19:01:29.339Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2654,32 +2654,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llama-stack-client"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "distro" },
-    { name = "fire" },
-    { name = "httpx" },
-    { name = "pandas" },
-    { name = "prompt-toolkit" },
-    { name = "pyaml" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "sniffio" },
-    { name = "termcolor" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/3d/c4a268a4b60feb6f7e6da3fad2504aa157a52384529766560f8f3cfca43f/llama_stack_client-0.7.2.tar.gz", hash = "sha256:0e3458800af6a18fd8fc5e0760ed626931a416f6c1fdf24aeba4001e6fca9aec", size = 372953, upload-time = "2026-04-08T14:19:32.02Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/a8/cc7fa209471abcaac51139b3e6655c3b18ea718f0afa7cfa6ad974dd9eab/llama_stack_client-0.7.2-py3-none-any.whl", hash = "sha256:8b86156f2522c241ae46280e59287b7716c3cdaf016b6477630eb64bd8cbf150", size = 375337, upload-time = "2026-04-08T14:19:30.444Z" },
-]
-
-[[package]]
 name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3466,7 +3440,7 @@ dependencies = [
 
 [package.optional-dependencies]
 client = [
-    { name = "llama-stack-client" },
+    { name = "ogx-client" },
 ]
 starter = [
     { name = "aiohttp" },
@@ -3605,10 +3579,10 @@ type-checking = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
-    { name = "llama-stack-client" },
     { name = "lm-format-enforcer" },
     { name = "mcp" },
     { name = "nest-asyncio" },
+    { name = "ogx-client" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -3681,7 +3655,6 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema" },
     { name = "langdetect", marker = "extra == 'starter'" },
-    { name = "llama-stack-client", marker = "extra == 'client'", specifier = ">=0.7.1" },
     { name = "matplotlib", marker = "extra == 'starter'" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "mcp", marker = "extra == 'starter'", specifier = ">=1.23.0" },
@@ -3690,6 +3663,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "oci", specifier = ">=2.165.0" },
     { name = "ogx-api", editable = "src/ogx_api" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.7.1" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -3820,10 +3794,10 @@ type-checking = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
-    { name = "llama-stack-client", specifier = ">=0.7.1" },
     { name = "lm-format-enforcer" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
+    { name = "ogx-client", specifier = ">=0.7.1" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -3884,6 +3858,32 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
+]
+
+[[package]]
+name = "ogx-client"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "distro" },
+    { name = "fire" },
+    { name = "httpx" },
+    { name = "pandas" },
+    { name = "prompt-toolkit" },
+    { name = "pyaml" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "sniffio" },
+    { name = "termcolor" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/ab/cb016ce17482054824fa986a296c4be9cf00178110eb27f26094cdc6b449/ogx_client-0.7.2.tar.gz", hash = "sha256:85e3f178ef826480e1f5851a00cf5695d64a6a71c2c22867b127f651fa0c0253", size = 436426, upload-time = "2026-05-01T17:38:26.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/8d/7dfe156c07429660e42344ef4180367379f09edf1afcefec2f313fa52de7/ogx_client-0.7.2-py3-none-any.whl", hash = "sha256:3e12e4eae159021c2fa56f3427dcef8fd647e7552b60774858f2f5f333a8ec91", size = 311412, upload-time = "2026-05-01T17:38:24.283Z" },
 ]
 
 [[package]]
@@ -6612,9 +6612,9 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:a47b7986bee3f61ad217d8a8ce24605809ab425baf349f97de758815edd2ef54" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:a47b7986bee3f61ad217d8a8ce24605809ab425baf349f97de758815edd2ef54", upload-time = "2025-10-01T23:35:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58", upload-time = "2025-10-01T23:35:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390", upload-time = "2025-10-01T23:35:55Z" },
 ]
 
 [[package]]
@@ -6637,19 +6637,19 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:0e34e276722ab7dd0dffa9e12fe2135a9b34a0e300c456ed7ad6430229404eb5" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:610f600c102386e581327d5efc18c0d6edecb9820b4140d26163354a99cd800d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:cb9a8ba8137ab24e36bf1742cb79a1294bd374db570f09fc15a5e1318160db4e" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:2be20b2c05a0cce10430cc25f32b689259640d273232b2de357c35729132256d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:99fc421a5d234580e45957a7b02effbf3e1c884a5dd077afc85352c77bf41434" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:8b5882276633cf91fe3d2d7246c743b94d44a7e660b27f1308007fdb1bb89f7d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5064b5e23772c8d164068cc7c12e01a75faf7b948ecd95a0d4007d7487e5f25" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f81dedb4c6076ec325acc3b47525f9c550e5284a18eae1d9061c543f7b6e7de" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:e1ee1b2346ade3ea90306dfbec7e8ff17bc220d344109d189ae09078333b0856" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:64c187345509f2b1bb334feed4666e2c781ca381874bde589182f81247e61f88" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af81283ac671f434b1b25c95ba295f270e72db1fad48831eb5e4748ff9840041" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a9dbb6f64f63258bc811e2c0c99640a81e5af93c531ad96e95c5ec777ea46dab" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:6d93a7165419bc4b2b907e859ccab0dea5deeab261448ae9a5ec5431f14c0e64" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:0e34e276722ab7dd0dffa9e12fe2135a9b34a0e300c456ed7ad6430229404eb5", upload-time = "2025-10-01T23:33:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:610f600c102386e581327d5efc18c0d6edecb9820b4140d26163354a99cd800d", upload-time = "2025-10-01T23:33:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:cb9a8ba8137ab24e36bf1742cb79a1294bd374db570f09fc15a5e1318160db4e", upload-time = "2025-10-01T23:33:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:2be20b2c05a0cce10430cc25f32b689259640d273232b2de357c35729132256d", upload-time = "2025-10-01T23:33:52Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:99fc421a5d234580e45957a7b02effbf3e1c884a5dd077afc85352c77bf41434", upload-time = "2025-10-01T23:34:10Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:8b5882276633cf91fe3d2d7246c743b94d44a7e660b27f1308007fdb1bb89f7d", upload-time = "2025-10-01T23:34:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5064b5e23772c8d164068cc7c12e01a75faf7b948ecd95a0d4007d7487e5f25", upload-time = "2025-10-01T23:34:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f81dedb4c6076ec325acc3b47525f9c550e5284a18eae1d9061c543f7b6e7de", upload-time = "2025-10-01T23:34:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:e1ee1b2346ade3ea90306dfbec7e8ff17bc220d344109d189ae09078333b0856", upload-time = "2025-10-01T23:34:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:64c187345509f2b1bb334feed4666e2c781ca381874bde589182f81247e61f88", upload-time = "2025-10-01T23:34:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af81283ac671f434b1b25c95ba295f270e72db1fad48831eb5e4748ff9840041", upload-time = "2025-10-01T23:34:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a9dbb6f64f63258bc811e2c0c99640a81e5af93c531ad96e95c5ec777ea46dab", upload-time = "2025-10-01T23:34:53Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:6d93a7165419bc4b2b907e859ccab0dea5deeab261448ae9a5ec5431f14c0e64", upload-time = "2025-10-01T23:34:58Z" },
 ]
 
 [[package]]
@@ -6707,12 +6707,12 @@ dependencies = [
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b", upload-time = "2025-08-05T20:11:47Z" },
 ]
 
 [[package]]
@@ -6729,12 +6729,12 @@ dependencies = [
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ae459d4509d3b837b978dc6c66106601f916b6d2cda75c137e3f5f48324ce1da" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a651ccc540cf4c87eb988730c59c2220c52b57adc276f044e7efb9830fa65a1d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:dea90a67d60a5366b0358a0b8d6bf267805278697d6fd950cf0e31139e56d1be" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:82928788025170c62e7df1120dcdc0cd175bfc31c08374613ce6d1a040bc0cda" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:474d77adbbbed5166db3e5636b4b4ae3399c66ef5bfa12536e254b32259c90c0" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:8d6a47e23d7896f0ef9aa7ea7179eb6324e82438aa66d19884c2020d0646b104" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ae459d4509d3b837b978dc6c66106601f916b6d2cda75c137e3f5f48324ce1da", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a651ccc540cf4c87eb988730c59c2220c52b57adc276f044e7efb9830fa65a1d", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:dea90a67d60a5366b0358a0b8d6bf267805278697d6fd950cf0e31139e56d1be", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:82928788025170c62e7df1120dcdc0cd175bfc31c08374613ce6d1a040bc0cda", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:474d77adbbbed5166db3e5636b4b4ae3399c66ef5bfa12536e254b32259c90c0", upload-time = "2025-08-05T20:11:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:8d6a47e23d7896f0ef9aa7ea7179eb6324e82438aa66d19884c2020d0646b104", upload-time = "2025-08-05T20:11:47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates package dependencies and workflow tests to use the renamed `ogx-client` package instead of `llama-stack-client`.

## Changes

- **pyproject.toml**: Update `client` and `type_checking` dependencies to `ogx-client>=0.7.1`
- **.github/workflows/pypi.yml**: Update Python import test to use `ogx_client` module
- **.github/workflows/pypi.yml**: Update npm package test to use `ogx-client` package name

## Context

Part of the rename from `llama-stack` to `ogx`. The Stainless config in `client-sdks/stainless/config.yml` is already updated to generate clients with the new names:
- Python package: `ogx-client` (module: `ogx_client`)
- npm package: `ogx-client`

## Blockers

⚠️ **This PR is blocked on Stainless regenerating the client SDKs** with the new package names in:
- `ogx-ai/ogx-client-python`
- `ogx-ai/ogx-client-typescript`

CI may fail until `ogx-client` is published to PyPI and npm.

## Related

- Stainless config: `client-sdks/stainless/config.yml` (lines 16-27)
- Stainless org/project in workflow: `.github/workflows/stainless-builds.yml` (lines 47, 50)