### PR TITLE
fix: update mlflow port to 5001

### DIFF
--- a/scripts/telemetry/README.md
+++ b/scripts/telemetry/README.md
@@ -27,7 +27,7 @@ This directory contains configuration files and a setup script to deploy a full 
 | **Jaeger** | Distributed tracing UI | 16686 |
 | **Prometheus** | Metrics storage and querying | 9090 |
 | **Grafana** | Dashboards and visualization | 3000 |
-| **MLflow** | Trace ingest via OTLP `/v1/traces` (container in this stack) | 5000 |
+| **MLflow** | Trace ingest via OTLP `/v1/traces` (container in this stack) | 5001 |
 
 ## Pre-requisites
 
@@ -69,9 +69,9 @@ This will:
 
 > **MLflow traces**
 >
-> - MLflow is now started as a container in this stack (`mlflow:5000`), OTLP endpoint `/v1/traces`.
-> - Collector exporter `otlphttp/mlflow` points to `http://mlflow:5000/v1/traces`, header `x-mlflow-experiment-id: "1"`. If you need auth, set `MLFLOW_OTEL_HEADERS` (e.g., `Authorization=Bearer <token>`) before running the setup script.
-> - If you prefer an external MLflow, override `MLFLOW_OTEL_ENDPOINT` before running the script (e.g., `http://host.docker.internal:5000`).
+> - MLflow is now started as a container in this stack (`mlflow:5001`), OTLP endpoint `/v1/traces`.
+> - Collector exporter `otlphttp/mlflow` points to `http://mlflow:5001/v1/traces`, header `x-mlflow-experiment-id: "1"`. If you need auth, set `MLFLOW_OTEL_HEADERS` (e.g., `Authorization=Bearer <token>`) before running the setup script.
+> - If you prefer an external MLflow, override `MLFLOW_OTEL_ENDPOINT` before running the script (e.g., `http://host.docker.internal:5001`).
 
 ### Install OpenTelemetry instrumentation For OGX Server and Client
 
@@ -131,7 +131,7 @@ Open the following UIs in your browser:
 
 | Service | URL | Credentials |
 |---|---|---|
-| **Mlflow** (traces) | [http://localhost:5000](http://localhost:5000) | N/A |
+| **Mlflow** (traces) | [http://localhost:5001](http://localhost:5001) | N/A |
 | **Jaeger** (traces) | [http://localhost:16686](http://localhost:16686) | N/A |
 | **Prometheus** (metrics) | [http://localhost:9090](http://localhost:9090) | N/A |
 | **Grafana** (dashboards) | [http://localhost:3000](http://localhost:3000) | admin / admin |

--- a/scripts/telemetry/setup_telemetry.sh
+++ b/scripts/telemetry/setup_telemetry.sh
@@ -118,15 +118,15 @@ $CONTAINER_RUNTIME run -d --name jaeger \
 echo "📒 Starting MLflow..."
 $CONTAINER_RUNTIME run -d --name mlflow \
   --network llama-telemetry \
-  -p 5000:5000 \
+  -p 5001:5001 \
   -v "$MLFLOW_BACKEND_STORE:/mlflow/mlflow.db" \
   -v "$MLFLOW_ARTIFACT_ROOT:/mlflow/artifacts" \
   ghcr.io/mlflow/mlflow:latest \
   mlflow server \
     --backend-store-uri sqlite:////mlflow/mlflow.db \
     --default-artifact-root /mlflow/artifacts \
-    --host 0.0.0.0 --port 5000 \
-    --allowed-hosts localhost,localhost:5000,127.0.0.1,127.0.0.1:5000,host.docker.internal,host.docker.internal:5000
+    --host 0.0.0.0 --port 5001 \
+    --allowed-hosts localhost,localhost:5001,127.0.0.1,127.0.0.1:5001,host.docker.internal,host.docker.internal:5001
 
 # Add host aliases so the Collector can reach host services (e.g., MLflow)
 ADD_HOST_OPT=""
@@ -195,7 +195,7 @@ echo ""
 echo "✅ Telemetry stack is ready!"
 echo ""
 echo "🌐 Service URLs:"
-echo "   MLflow:           http://localhost:5000"
+echo "   MLflow:           http://localhost:5001"
 echo "   Jaeger UI:        http://localhost:16686"
 echo "   Prometheus:       http://localhost:9090"
 echo "   Grafana:          http://localhost:3000 (admin/admin)"
@@ -215,7 +215,7 @@ echo "   5. Check Prometheus for metrics: http://localhost:9090"
 echo "   6. Set up Grafana dashboards: http://localhost:3000"
 echo ""
 echo "🔍 To test the setup, run:"
-echo "   curl -X POST http://localhost:5000/v1/inference/chat/completions \\"
+echo "   curl -X POST http://localhost:5001/v1/inference/chat/completions \\"
 echo "     -H 'Content-Type: application/json' \\"
 echo "     -d '{\"model_id\": \"your-model\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}'"
 echo ""


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

```console
% lsof -i :5000
COMMAND     PID       USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ControlCe 17228 gyliu-cary   14u  IPv4 0x9e69880557ab4c98      0t0  TCP *:commplex-main (LISTEN)
ControlCe 17228 gyliu-cary   15u  IPv6 0x4061eb5123ba5a44      0t0  TCP *:commplex-main (LISTEN)
```
Seems 5000 is used by ControlCenter, which is a macOS system process. When end user run telemetry test, there will always be some errors of port in use and mlflow cannot start.

Update default port of mlflow to 5001. 

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
