### PR TITLE
fix(docs): update README badges and links to use correct ogx-ai org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <a href="https://discord.gg/ZAFjsrcw"><img src="https://img.shields.io/discord/1257833999603335178?color=5865F2&logo=discord&logoColor=ffffff" alt="Discord"></a>
   <a href="https://github.com/ogx-ai/ogx/actions/workflows/unit-tests.yml?query=branch%3Amain"><img src="https://github.com/ogx-ai/ogx/actions/workflows/unit-tests.yml/badge.svg?branch=main" alt="Unit Tests"></a>
   <a href="https://github.com/ogx-ai/ogx/actions/workflows/integration-tests.yml?query=branch%3Amain"><img src="https://github.com/ogx-ai/ogx/actions/workflows/integration-tests.yml/badge.svg?branch=main" alt="Integration Tests"></a>
-  <a href="https://ogx-ai.github.io/docs/api-openai/conformance"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmeta-llama%2Fogx%2Fmain%2Fdocs%2Fstatic%2Fopenai-coverage.json&query=%24.summary.conformance.score&suffix=%25&label=OpenResponses%20Conformance&color=brightgreen" alt="OpenResponses Conformance"></a>
-  <a href="https://deepwiki.com/ogx/ogx"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+  <a href="https://ogx-ai.github.io/docs/api-openai/conformance"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fogx-ai%2Fogx%2Fmain%2Fdocs%2Fstatic%2Fopenai-coverage.json&query=%24.summary.conformance.score&suffix=%25&label=OpenResponses%20Conformance&color=brightgreen" alt="OpenResponses Conformance"></a>
+  <a href="https://deepwiki.com/ogx-ai/ogx"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </p>
 
 [**Quick Start**](https://ogx-ai.github.io/docs/getting_started/quickstart) | [**Documentation**](https://ogx-ai.github.io/docs) | [**OpenAI API Compatibility**](https://ogx-ai.github.io/docs/api-openai) | [**Discord**](https://discord.gg/ZAFjsrcw)
@@ -77,17 +77,17 @@ See the [Quick Start guide](https://ogx-ai.github.io/docs/getting_started/quicks
 
 |  Language |  SDK | Package |
 | :----: | :----: | :----: |
-| Python |  [ogx-client-python](https://github.com/meta-llama/llama-stack-client-python) | [![PyPI version](https://img.shields.io/pypi/v/ogx_client.svg)](https://pypi.org/project/ogx_client/) |
+| Python |  [ogx-client-python](https://github.com/ogx-ai/ogx-client-python) | [![PyPI version](https://img.shields.io/pypi/v/ogx_client.svg)](https://pypi.org/project/ogx_client/) |
 | TypeScript   | [ogx-client-typescript](https://github.com/ogx-ai/ogx-client-typescript) | [![NPM version](https://img.shields.io/npm/v/ogx-client.svg)](https://npmjs.org/package/ogx-client) |
 
 ## Community
 
 We hold regular community calls every Thursday at 09:00 AM PST — see the [Community Event on Discord](https://discord.gg/ZAFjsrcw) for details.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ogx/ogx&type=Date)](https://www.star-history.com/#ogx/ogx&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=ogx-ai/ogx&type=Date)](https://www.star-history.com/#ogx-ai/ogx&Date)
 
 Thanks to all our amazing contributors!
 
 <a href="https://github.com/ogx-ai/ogx/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=ogx/ogx" alt="OGX contributors" />
+  <img src="https://contrib.rocks/image?repo=ogx-ai/ogx" alt="OGX contributors" />
 </a>


### PR DESCRIPTION
# What does this PR do?

Fixes broken badges and links in the README that were still referencing the old org name (`ogx/ogx` or `meta-llama`) instead of the correct `ogx-ai/ogx`. This caused broken images for the star history chart and contributors section, and incorrect links for the conformance badge, DeepWiki, and the Python SDK.

## Test Plan

Visual verification — confirm that the star history chart, contributors grid, conformance badge, and DeepWiki link render correctly on the GitHub README after merge.