### PR TITLE
fix(docs): increase OGX wordmark size in brand lockup SVGs

### DIFF
--- a/docs/static/img/brand/ogx-lockup-color.svg
+++ b/docs/static/img/brand/ogx-lockup-color.svg
@@ -6,5 +6,5 @@
     <rect x="-46" y="-46" width="92" height="92" rx="22" transform="translate(152 390) rotate(45)" fill="#1E1E2E"/>
     <rect x="-46" y="-46" width="92" height="92" rx="22" transform="translate(360 390) rotate(45)" fill="#1E1E2E"/>
   </g>
-  <text x="182" y="106" fill="#1E1E2E" font-size="78" font-weight="800" font-family="Archivo, Inter, system-ui, sans-serif" letter-spacing="-3">OGX</text>
+  <text x="170" y="112" fill="#1E1E2E" font-size="96" font-weight="800" font-family="Archivo, Inter, system-ui, sans-serif" letter-spacing="-4">OGX</text>
 </svg>

--- a/docs/static/img/brand/ogx-lockup-mono.svg
+++ b/docs/static/img/brand/ogx-lockup-mono.svg
@@ -6,5 +6,5 @@
     <rect x="-46" y="-46" width="92" height="92" rx="22" transform="translate(152 390) rotate(45)" fill="#1E1E2E"/>
     <rect x="-46" y="-46" width="92" height="92" rx="22" transform="translate(360 390) rotate(45)" fill="#1E1E2E"/>
   </g>
-  <text x="182" y="106" fill="#1E1E2E" font-size="78" font-weight="800" font-family="Archivo, Inter, system-ui, sans-serif" letter-spacing="-3">OGX</text>
+  <text x="170" y="112" fill="#1E1E2E" font-size="96" font-weight="800" font-family="Archivo, Inter, system-ui, sans-serif" letter-spacing="-4">OGX</text>
 </svg>

--- a/docs/static/img/brand/ogx-lockup-reverse.svg
+++ b/docs/static/img/brand/ogx-lockup-reverse.svg
@@ -6,5 +6,5 @@
     <rect x="-46" y="-46" width="92" height="92" rx="22" transform="translate(152 390) rotate(45)" fill="#ffffff"/>
     <rect x="-46" y="-46" width="92" height="92" rx="22" transform="translate(360 390) rotate(45)" fill="#ffffff"/>
   </g>
-  <text x="182" y="106" fill="#ffffff" font-size="78" font-weight="800" font-family="Archivo, Inter, system-ui, sans-serif" letter-spacing="-3">OGX</text>
+  <text x="170" y="112" fill="#ffffff" font-size="96" font-weight="800" font-family="Archivo, Inter, system-ui, sans-serif" letter-spacing="-4">OGX</text>
 </svg>


### PR DESCRIPTION
# What does this PR do?

Scales the OGX wordmark text from 78pt to 96pt across all three brand lockup SVG variants (color, mono, reverse), adjusting position and letter spacing for better visual balance with the logomark.

## Test Plan

- Visual inspection of the SVGs in a browser to confirm the wordmark is properly sized and aligned relative to the diamond logomark.
- Verify the brand page renders correctly with the updated lockup files.