### PR TITLE
feat(docs): add dynamic versions page and automated versioned docs deployment

### DIFF
--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -6,13 +6,24 @@ on:
   push:
     branches: [main]
     paths: ['docs/**']
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to deploy versioned docs for (e.g., v0.7.1). Leave empty to deploy latest.'
+        required: false
+        type: string
 
 concurrency:
   group: trigger-docs-deploy
   cancel-in-progress: true
 
 jobs:
-  trigger:
+  trigger-latest:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.tag == '')
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs site build and deploy
@@ -21,5 +32,25 @@ jobs:
             -f event_type=docs-update \
             -f 'client_payload[sha]=${{ github.sha }}' \
             -f 'client_payload[ref]=${{ github.ref }}'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+  trigger-version:
+    if: |
+      (github.event_name == 'release' && !github.event.release.prerelease && !github.event.release.draft) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger versioned docs build and deploy
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          gh api repos/ogx-ai/ogx-ai.github.io/dispatches \
+            -f event_type=docs-version-deploy \
+            -f "client_payload[version]=${TAG}" \
+            -f 'client_payload[sha]=${{ github.sha }}'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -153,7 +153,7 @@ const config: Config = {
           position: 'right',
           dropdownActiveClassDisabled: true,
           dropdownItemsAfter: [
-            { to: '/versions.html', label: 'All versions' },
+            { to: '/versions', label: 'All versions' },
           ],
         },
       ],

--- a/docs/src/pages/versions.js
+++ b/docs/src/pages/versions.js
@@ -1,0 +1,194 @@
+import React, {useState, useEffect} from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+
+const GITHUB_RELEASES_URL =
+  'https://api.github.com/repos/ogx-ai/ogx/releases?per_page=100';
+
+const DOCS_BASE = 'https://ogx-ai.github.io';
+
+const ARCHIVED_VERSIONS_URL = `${DOCS_BASE}/versionsArchived.json`;
+
+function VersionsPage() {
+  const [releases, setReleases] = useState([]);
+  const [archivedVersions, setArchivedVersions] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const [releasesResult, archivedResult] = await Promise.allSettled([
+          fetchAllReleases(),
+          fetch(ARCHIVED_VERSIONS_URL).then((r) =>
+            r.ok ? r.json() : Promise.reject(new Error('not found'))
+          ),
+        ]);
+
+        if (releasesResult.status === 'fulfilled') {
+          setReleases(releasesResult.value);
+        } else {
+          setError(releasesResult.reason.message);
+        }
+
+        if (archivedResult.status === 'fulfilled') {
+          setArchivedVersions(archivedResult.value);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, []);
+
+  const latest = releases[0];
+  const previous = releases.slice(1);
+
+  return (
+    <Layout title="All Versions" description="All versions of OGX documentation">
+      <main style={{maxWidth: 800, margin: '60px auto', padding: '0 24px'}}>
+        <h1>OGX Docs</h1>
+        <p style={{color: 'var(--ifm-color-secondary-darkest)', marginBottom: 32}}>
+          All versions of the OGX documentation.
+        </p>
+
+        {loading && <p>Loading versions...</p>}
+
+        {error && (
+          <p style={{color: 'var(--ifm-color-danger)'}}>
+            Failed to load versions: {error}
+          </p>
+        )}
+
+        {latest && (
+          <div
+            style={{
+              background: 'var(--ifm-color-primary-lightest)',
+              border: '1px solid var(--ifm-color-primary-light)',
+              borderRadius: 8,
+              padding: '16px 20px',
+              marginBottom: 32,
+            }}
+          >
+            <div
+              style={{
+                fontSize: '0.75rem',
+                fontWeight: 600,
+                color: 'var(--ifm-color-primary)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                marginBottom: 4,
+              }}
+            >
+              Latest
+            </div>
+            <Link to="/" style={{fontSize: '1.1rem', fontWeight: 600}}>
+              Current documentation
+            </Link>
+            <span
+              style={{
+                marginLeft: 12,
+                fontSize: '0.85rem',
+                color: 'var(--ifm-color-secondary-darkest)',
+              }}
+            >
+              {latest.tag_name}
+            </span>
+          </div>
+        )}
+
+        {previous.length > 0 && (
+          <>
+            <h2
+              style={{
+                fontSize: '1.1rem',
+                color: 'var(--ifm-color-secondary-darkest)',
+                marginBottom: 12,
+              }}
+            >
+              Previous versions
+            </h2>
+            <ul style={{listStyle: 'none', padding: 0, margin: 0}}>
+              {previous.map((release) => {
+                const docsUrl = archivedVersions[release.tag_name];
+                return (
+                  <li
+                    key={release.id}
+                    style={{
+                      padding: '10px 0',
+                      borderBottom: '1px solid var(--ifm-color-emphasis-200)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 12,
+                    }}
+                  >
+                    <a
+                      href={release.html_url}
+                      style={{
+                        fontSize: '0.95rem',
+                        fontWeight: 500,
+                      }}
+                    >
+                      {release.tag_name}
+                    </a>
+                    <span
+                      style={{
+                        fontSize: '0.8rem',
+                        color: 'var(--ifm-color-secondary-darkest)',
+                      }}
+                    >
+                      {new Date(release.published_at).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </span>
+                    <span style={{marginLeft: 'auto', display: 'flex', gap: 12}}>
+                      {docsUrl && (
+                        <a
+                          href={docsUrl}
+                          style={{
+                            fontSize: '0.8rem',
+                            color: 'var(--ifm-color-primary)',
+                          }}
+                        >
+                          Documentation
+                        </a>
+                      )}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+
+        <div style={{marginTop: 32}}>
+          <Link to="/" style={{fontSize: '0.9rem'}}>
+            &larr; Back to docs
+          </Link>
+        </div>
+      </main>
+    </Layout>
+  );
+}
+
+async function fetchAllReleases() {
+  const all = [];
+  let page = 1;
+  let hasMore = true;
+  while (hasMore) {
+    const res = await fetch(`${GITHUB_RELEASES_URL}&page=${page}`);
+    if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+    const data = await res.json();
+    if (data.length === 0) {
+      hasMore = false;
+    } else {
+      all.push(...data);
+      page++;
+    }
+  }
+  return all.filter((r) => !r.prerelease && !r.draft);
+}
+
+export default VersionsPage;

--- a/docs/static/versions.html
+++ b/docs/static/versions.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=/versions">
+  <link rel="canonical" href="/versions">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="/versions">/versions</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
# What does this PR do?

Fixes the broken versions page at ogx-ai.github.io/versions.html by replacing the static hardcoded HTML with a dynamic Docusaurus page that fetches all releases from the GitHub API and checks `versionsArchived.json` for which versions have hosted documentation. Also extends the docs deploy workflow to automatically trigger versioned doc builds when a release is published, dispatching `docs-version-deploy` to ogx-ai.github.io.

Companion PR: https://github.com/ogx-ai/ogx-ai.github.io/pull/3

## Test Plan

1. Run the Docusaurus dev server (`cd docs && npm run start`) and navigate to `/versions` — verify all GitHub releases are listed with dates and "Documentation" links for versions that have deployed docs.
2. Navigate to `/versions.html` — verify it redirects to `/versions`.
3. After merging both PRs, trigger `Trigger Docs Deploy` workflow manually with `tag: v0.7.1` to verify versioned docs build and deploy to ogx-ai.github.io/v0.7.1/.