### PR TITLE
fix(docs): clarify versions page labels for main-branch docs

### DIFF
--- a/docs/src/pages/versions.js
+++ b/docs/src/pages/versions.js
@@ -41,8 +41,7 @@ function VersionsPage() {
     fetchData();
   }, []);
 
-  const latest = releases[0];
-  const previous = releases.slice(1);
+  const allReleases = releases;
 
   return (
     <Layout title="All Versions" description="All versions of OGX documentation">
@@ -60,44 +59,42 @@ function VersionsPage() {
           </p>
         )}
 
-        {latest && (
+        <div
+          style={{
+            background: 'var(--ifm-color-primary-lightest)',
+            border: '1px solid var(--ifm-color-primary-light)',
+            borderRadius: 8,
+            padding: '16px 20px',
+            marginBottom: 32,
+          }}
+        >
           <div
             style={{
-              background: 'var(--ifm-color-primary-lightest)',
-              border: '1px solid var(--ifm-color-primary-light)',
-              borderRadius: 8,
-              padding: '16px 20px',
-              marginBottom: 32,
+              fontSize: '0.75rem',
+              fontWeight: 600,
+              color: 'var(--ifm-color-primary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              marginBottom: 4,
             }}
           >
-            <div
-              style={{
-                fontSize: '0.75rem',
-                fontWeight: 600,
-                color: 'var(--ifm-color-primary)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                marginBottom: 4,
-              }}
-            >
-              Latest
-            </div>
-            <Link to="/" style={{fontSize: '1.1rem', fontWeight: 600}}>
-              Current documentation
-            </Link>
-            <span
-              style={{
-                marginLeft: 12,
-                fontSize: '0.85rem',
-                color: 'var(--ifm-color-secondary-darkest)',
-              }}
-            >
-              {latest.tag_name}
-            </span>
+            Next
           </div>
-        )}
+          <Link to="/" style={{fontSize: '1.1rem', fontWeight: 600}}>
+            Current documentation
+          </Link>
+          <span
+            style={{
+              marginLeft: 12,
+              fontSize: '0.85rem',
+              color: 'var(--ifm-color-secondary-darkest)',
+            }}
+          >
+            unreleased
+          </span>
+        </div>
 
-        {previous.length > 0 && (
+        {allReleases.length > 0 && (
           <>
             <h2
               style={{
@@ -106,10 +103,10 @@ function VersionsPage() {
                 marginBottom: 12,
               }}
             >
-              Previous versions
+              Releases
             </h2>
             <ul style={{listStyle: 'none', padding: 0, margin: 0}}>
-              {previous.map((release) => {
+              {allReleases.map((release) => {
                 const docsUrl = archivedVersions[release.tag_name];
                 return (
                   <li


### PR DESCRIPTION
# What does this PR do?

The versions page at `/versions` displayed the latest GitHub release tag (e.g. `v0.7.1`) next to "Current documentation", implying the docs were pinned to that release. Since the site is built from `main`, this was misleading.

This PR changes the hero section label from "Latest / v0.7.1" to "Next / unreleased" and renames "Previous versions" to "Releases", listing all releases uniformly below.

## Test Plan

1. Run the docs dev server: `cd docs && npm install && npm run gen-api-docs all && npx docusaurus start`
2. Navigate to `http://localhost:3000/versions`
3. Verify the top section shows "Next" badge with "Current documentation — unreleased"
4. Verify all GitHub releases appear under a single "Releases" heading