### PR TITLE
fix(docs): remove leseb from rename blog post authors

### DIFF
--- a/docs/blog/2026-04-28-from-llama-stack-to-ogx.md
+++ b/docs/blog/2026-04-28-from-llama-stack-to-ogx.md
@@ -139,3 +139,5 @@ The rename clears the way for the project to grow in the direction it's already 
 The name is new. The mission is sharper. The server is the same one you've been using — just with a name that finally matches what it does.
 
 Get started at [ogx-ai.github.io/docs](https://ogx-ai.github.io/docs), or join the conversation on [Discord](https://discord.gg/ZAFjsrcw).
+
+— Charlie, Francisco, Matt, Raghu, Seb

--- a/docs/blog/2026-04-28-from-llama-stack-to-ogx.md
+++ b/docs/blog/2026-04-28-from-llama-stack-to-ogx.md
@@ -1,7 +1,7 @@
 ---
 slug: from-llama-stack-to-ogx
 title: "From Llama Stack to OGX: A New Name, A Sharper Mission"
-authors: [leseb, ogx-team]
+authors: [ogx-team]
 tags: [announcement, ogx, rename, agentic, multi-sdk]
 date: 2026-04-28
 ---


### PR DESCRIPTION
# What does this PR do?

Removes `leseb` from the authors list of the "From Llama Stack to OGX" blog post, leaving `ogx-team` as the sole author. The `leseb` entry in `authors.yml` is preserved.

## Test Plan

Visual inspection of the frontmatter change:
- Before: `authors: [leseb, ogx-team]`
- After: `authors: [ogx-team]`

No functional code changes — docs-only.