### PR TITLE
fix(docs): use HTML truncate marker in blog posts

### DIFF
--- a/docs/blog/2026-03-18-responses-api.md
+++ b/docs/blog/2026-03-18-responses-api.md
@@ -11,7 +11,7 @@ The [Responses API](https://developers.openai.com/blog/responses-api) is rapidly
 
 This post covers why the Responses API matters, what OGX's implementation enables, and how it connects to the broader move toward open agent standards like Open Responses.
 
-{/*truncate*/}
+<!--truncate-->
 
 ## Why the Responses API?
 

--- a/docs/blog/2026-03-20-open-responses-openai-compatibility.md
+++ b/docs/blog/2026-03-20-open-responses-openai-compatibility.md
@@ -10,7 +10,7 @@ We're excited to share that OGX has achieved **100% compliance with the Open Res
 
 With comprehensive support for Files, Vector Stores, Search, Conversations, Prompts, Chat Completions, the full Responses API, plus powerful extensions like MCP tool integration, Tool Calling, and Connectors, OGX offers something unique in the AI infrastructure landscape: a SaaS-like experience that runs entirely on your terms.
 
-{/*truncate*/}
+<!--truncate-->
 
 ## Recognition by the Open Responses Community
 

--- a/docs/blog/2026-03-30-observability.md
+++ b/docs/blog/2026-03-30-observability.md
@@ -12,7 +12,7 @@ We recently shipped built-in observability for OGX, powered by [OpenTelemetry](h
 
 This post explains the architecture behind it, walks through a hands-on tutorial, and shows what you can actually see once it's running.
 
-{/*truncate*/}
+<!--truncate-->
 
 ## Why Observability Matters for LLM Applications
 


### PR DESCRIPTION
# What does this PR do?

Blog posts use `.md` extension but had JSX-style `{/*truncate*/}` markers, which Docusaurus only recognizes in `.mdx` files. This caused the marker to render as visible `{/truncate/}` text in the blog post body. Replaced with the HTML `<!--truncate-->` marker that Docusaurus expects for Markdown files.

Affects 3 blog posts: responses-api, open-responses-openai-compatibility, and observability. A 4th post (from-llama-stack-to-ogx) has the same fix but is not yet on main.

## Test Plan

1. Run `npm start` in `docs/` and navigate to the blog listing and individual posts
2. Verify the truncate marker no longer appears as visible text
3. Verify the blog listing page correctly truncates posts with a "Read more" link