### PR TITLE
fix(docs): use HTML truncate marker in rename blog post

### DIFF
--- a/docs/blog/2026-04-28-from-llama-stack-to-ogx.md
+++ b/docs/blog/2026-04-28-from-llama-stack-to-ogx.md
@@ -14,7 +14,7 @@ It's none of those. OGX is a server. Specifically, it's a **server-side agentic 
 
 This post explains why we renamed, what changed in the project's direction, and what that means for you.
 
-{/*truncate*/}
+<!--truncate-->
 
 ## Why the rename
 


### PR DESCRIPTION
# What does this PR do?

Follow-up to #5660 — fixes the same `{/*truncate*/}` → `<!--truncate-->` issue in the `from-llama-stack-to-ogx` blog post, which was missed because it didn't exist on the fork's main branch when #5660 was created.

## Test Plan

1. Build the docs site and navigate to https://ogx-ai.github.io/blog/from-llama-stack-to-ogx
2. Verify the truncate marker no longer appears as visible text in the post body