### PR TITLE
fix(docs): replace `ogx run` with `ogx stack run` across codebase

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -285,7 +285,7 @@ src/
       registry/             # Provider spec declarations
       utils/                # Shared provider utilities
     distributions/          # Pre-built distribution configs
-    cli/                    # CLI commands (ogx run, build, etc.)
+    cli/                    # CLI commands (ogx stack run, build, etc.)
     testing/                # Test infrastructure (api_recorder)
 tests/
   unit/                     # Fast, isolated tests

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -LsSf https://github.com/ogx-ai/ogx/raw/main/scripts/install.sh | bash
 uv pip install ogx[starter]
 
 # Start the server (uses the starter distribution with Ollama)
-uv run ogx run starter
+uv run ogx stack run starter
 ```
 
 Then connect with any OpenAI, Anthropic, or Google GenAI client — [Python](https://github.com/openai/openai-python), [TypeScript](https://github.com/openai/openai-node), [curl](https://platform.openai.com/docs/api-reference), or any framework that speaks these APIs.

--- a/benchmarking/rag/start_stack.sh
+++ b/benchmarking/rag/start_stack.sh
@@ -14,4 +14,4 @@ echo "Starting OGX with config: $CONFIG"
 echo "Milvus URI: ${MILVUS_URI:-http://localhost:19530}"
 echo "Port: 8321"
 
-ogx run "$CONFIG" --port 8321
+ogx stack run "$CONFIG" --port 8321

--- a/benchmarking/vertical-scaling/run-benchmark.sh
+++ b/benchmarking/vertical-scaling/run-benchmark.sh
@@ -174,7 +174,7 @@ echo "Workers: $WORKERS"
 echo "Backend: $MOCK_URL"
 echo ""
 
-OPENAI_BASE_URL="$MOCK_URL/v1" OPENAI_API_KEY="fake-token" uv run ogx run --providers inference=remote::openai --port $STACK_PORT > "$SCRIPT_DIR/stack.log" 2>&1 &
+OPENAI_BASE_URL="$MOCK_URL/v1" OPENAI_API_KEY="fake-token" uv run ogx stack run --providers inference=remote::openai --port $STACK_PORT > "$SCRIPT_DIR/stack.log" 2>&1 &
 STACK_PID=$!
 echo "$STACK_PID" >> "$PIDS_FILE"
 echo "Stack Server PID: $STACK_PID"

--- a/docs/blog/2026-01-30-how-to-get-started.md
+++ b/docs/blog/2026-01-30-how-to-get-started.md
@@ -54,7 +54,7 @@ If you already have Ollama installed as a service, you can simply pull the model
 ```bash
 ollama pull gpt-oss:20b
 uv run --with ogx ogx list-deps --providers inference=remote::ollama --format uv | sh
-uv run --with ogx ogx run --providers inference=remote::ollama
+uv run --with ogx ogx stack run --providers inference=remote::ollama
 
 ```
 
@@ -64,7 +64,7 @@ If you don't have Ollama running as a service, you can start it manually:
 ollama serve > /dev/null 2>&1 &
 ollama run gpt-oss:20b --keepalive 60m # you can exit this once the model is running due to --keepalive
 uv run --with ogx ogx --providers inference=remote::ollama --format uv | sh
-uv run --with ogx ogx run --providers inference=remote::ollama
+uv run --with ogx ogx stack run --providers inference=remote::ollama
 
 ```
 
@@ -77,7 +77,7 @@ ollama serve > /dev/null 2>&1 &
 ollama run gpt-oss:20b --keepalive 60m # you can exit this once the model is running due to --keepalive
 uv run --with ogx ogx list-deps starter --format uv | sh
 export OLLAMA_URL=http://localhost:11434/v1
-uv run --with ogx ogx run starter
+uv run --with ogx ogx stack run starter
 
 ```
 

--- a/docs/blog/2026-03-01-building-agentic-flows.md
+++ b/docs/blog/2026-03-01-building-agentic-flows.md
@@ -245,7 +245,7 @@ First, pull the models and start Ollama, then run the OGX starter distribution p
 ```bash
 ollama pull llama3.1:8b
 ollama pull gpt-oss:20b
-OLLAMA_URL=http://localhost:11434/v1 uv run --with ogx ogx run starter
+OLLAMA_URL=http://localhost:11434/v1 uv run --with ogx ogx stack run starter
 ```
 
 The `OLLAMA_URL` environment variable tells the starter distribution to use Ollama as its inference provider. The server starts on `http://localhost:8321` by default.

--- a/docs/blog/2026-03-20-open-responses-openai-compatibility.md
+++ b/docs/blog/2026-03-20-open-responses-openai-compatibility.md
@@ -200,7 +200,7 @@ ollama run gpt-oss:20b
 
 # Launch OGX with the starter distribution
 
-OLLAMA_URL=http://localhost:11434/v1 uv run ogx run starter
+OLLAMA_URL=http://localhost:11434/v1 uv run ogx stack run starter
 ```
 
 ```python

--- a/docs/blog/2026-03-30-observability.md
+++ b/docs/blog/2026-03-30-observability.md
@@ -188,7 +188,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 export OTEL_SERVICE_NAME=ogx-server
 
-uv run opentelemetry-instrument ogx run starter
+uv run opentelemetry-instrument ogx stack run starter
 ```
 
 That's it. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, both auto and manual instrumentation activate. When it's not set, metrics are recorded in memory but never exported — no overhead, no errors.

--- a/docs/blog/2026-04-06-mlflow-observability.md
+++ b/docs/blog/2026-04-06-mlflow-observability.md
@@ -316,7 +316,7 @@ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:5000/v1/traces \
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf \
 OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-mlflow-experiment-id=1" \
 OTEL_SERVICE_NAME=ogx-server \
-opentelemetry-instrument ogx run starter
+opentelemetry-instrument ogx stack run starter
 ```
 
 This gives you end-to-end visibility: client-side spans showing the request lifecycle, and server-side spans showing internal OGX processing.

--- a/docs/docs/building_applications/codex_cli_integration.mdx
+++ b/docs/docs/building_applications/codex_cli_integration.mdx
@@ -11,7 +11,7 @@ This integration is in early development (alpha status). While core functionalit
 # 1. Start OGX with Codex support
 ```bash
 export OPENAI_API_KEY="your-key-here"
-ogx run starter
+ogx stack run starter
 ```
 
 # 2. Configure Codex CLI

--- a/docs/docs/building_applications/rag.mdx
+++ b/docs/docs/building_applications/rag.mdx
@@ -21,7 +21,7 @@ In one terminal, start the OGX server:
 
 ```bash
 ogx list-deps starter | xargs -L1 uv pip install
-ogx run starter
+ogx stack run starter
 ```
 
 ### 2. Choose Your Approach

--- a/docs/docs/building_applications/telemetry.mdx
+++ b/docs/docs/building_applications/telemetry.mdx
@@ -34,7 +34,7 @@ uv run opentelemetry-instrument \
     --metrics_exporter otlp \
     --service_name ogx-server \
     -- \
-    ogx run starter
+    ogx stack run starter
 ```
 
 This sends traces and metrics to an OTLP collector on port 4318. The next section shows how to set up the full observability stack.

--- a/docs/docs/concepts/apis/external.mdx
+++ b/docs/docs/concepts/apis/external.mdx
@@ -313,7 +313,7 @@ server:
 8. Run the server:
 
 ```bash
-ogx run ~/.llama/config.yaml
+ogx stack run ~/.llama/config.yaml
 ```
 
 9. Test the API:

--- a/docs/docs/concepts/distributions.mdx
+++ b/docs/docs/concepts/distributions.mdx
@@ -15,10 +15,10 @@ Most users should start with `starter`. It includes all providers and auto-enabl
 
 ```bash
 # With Ollama (local inference)
-OLLAMA_URL=http://localhost:11434 uv run ogx run starter
+OLLAMA_URL=http://localhost:11434 uv run ogx stack run starter
 
 # With OpenAI (remote inference)
-OPENAI_API_KEY=sk-xxx uv run ogx run starter
+OPENAI_API_KEY=sk-xxx uv run ogx stack run starter
 ```
 
 The starter distribution uses FAISS for vector storage, sentence-transformers for embeddings, and pypdf for file processing - all running locally with no external dependencies.

--- a/docs/docs/concepts/evaluation_concepts.mdx
+++ b/docs/docs/concepts/evaluation_concepts.mdx
@@ -47,7 +47,7 @@ We have built-in functionality to run the supported open-benchmarks using ogx-cl
 
 Spin up ogx server with 'open-benchmark' template
 ```bash
-ogx run ogx/distributions/open-benchmark/config.yaml
+ogx stack run ogx/distributions/open-benchmark/config.yaml
 ```
 
 #### Run eval CLI

--- a/docs/docs/distributions/building_distro.mdx
+++ b/docs/docs/distributions/building_distro.mdx
@@ -23,7 +23,7 @@ import TabItem from '@theme/TabItem';
 <Tabs>
 <TabItem value="container" label="Building a container">
 
-Use the Containerfile at `containers/Containerfile`, which installs `ogx`, resolves distribution dependencies via `ogx list-deps`, and sets the entrypoint to `ogx run`.
+Use the Containerfile at `containers/Containerfile`, which installs `ogx`, resolves distribution dependencies via `ogx list-deps`, and sets the entrypoint to `ogx stack run`.
 
 **Single-architecture build:**
 
@@ -195,7 +195,7 @@ tiktoken.get_encoding('p50k_base')
 
 ### Run your stack server
 
-After building the image, launch it directly with Docker or Podman—the entrypoint calls `ogx run` using the baked distribution or the bundled run config:
+After building the image, launch it directly with Docker or Podman—the entrypoint calls `ogx stack run` using the baked distribution or the bundled run config:
 
 ```bash
 docker run -d \

--- a/docs/docs/distributions/configuration.mdx
+++ b/docs/docs/distributions/configuration.mdx
@@ -121,7 +121,7 @@ A few things to note:
 - The id is a string you can choose freely.
 - You can instantiate any number of provider instances of the same type.
 - The configuration dictionary is provider-specific.
-- Notice that configuration can reference environment variables (with default values), which are expanded at runtime. When you run a stack server, you can set environment variables in your shell before running `ogx run` to override the default values.
+- Notice that configuration can reference environment variables (with default values), which are expanded at runtime. When you run a stack server, you can set environment variables in your shell before running `ogx stack run` to override the default values.
 
 ### Environment Variable Substitution
 
@@ -199,7 +199,7 @@ You can override environment variables at runtime by setting them in your shell 
 # Set environment variables in your shell
 export API_KEY=sk-123
 export BASE_URL=https://custom-api.com
-ogx run config.yaml
+ogx stack run config.yaml
 ```
 
 #### Type Safety

--- a/docs/docs/distributions/list_of_distributions.mdx
+++ b/docs/docs/distributions/list_of_distributions.mdx
@@ -19,7 +19,7 @@ sidebar_position: 2
 The starter distribution works for most use cases. It includes all providers and auto-enables them based on available environment variables:
 
 ```bash
-uv run ogx run starter
+uv run ogx stack run starter
 ```
 
 It supports local inference (Ollama), cloud providers (OpenAI, Bedrock, Azure, etc.), and everything in between. See the [Starter Guide](self_hosted_distro/starter) for details.

--- a/docs/docs/distributions/remote_hosted_distro/oci.md
+++ b/docs/docs/distributions/remote_hosted_distro/oci.md
@@ -110,7 +110,7 @@ You can run the OCI distribution via Docker or local virtual environment.
 If you've set up your local development environment, you can also build the image using your local virtual environment.
 
 ```bash
-OCI_AUTH=$OCI_AUTH_TYPE OCI_REGION=$OCI_REGION OCI_COMPARTMENT_OCID=$OCI_COMPARTMENT_OCID ogx run --port 8321 oci
+OCI_AUTH=$OCI_AUTH_TYPE OCI_REGION=$OCI_REGION OCI_COMPARTMENT_OCID=$OCI_COMPARTMENT_OCID ogx stack run --port 8321 oci
 ```
 
 ### Configuration Examples

--- a/docs/docs/distributions/self_hosted_distro/nvidia.md
+++ b/docs/docs/distributions/self_hosted_distro/nvidia.md
@@ -171,7 +171,7 @@ INFERENCE_MODEL=meta-llama/Llama-3.1-8B-Instruct
 ogx list-deps nvidia | xargs -L1 uv pip install
 NVIDIA_API_KEY=$NVIDIA_API_KEY \
 INFERENCE_MODEL=$INFERENCE_MODEL \
-ogx run ./config.yaml \
+ogx stack run ./config.yaml \
   --port 8321
 ```
 

--- a/docs/docs/distributions/self_hosted_distro/starter.md
+++ b/docs/docs/distributions/self_hosted_distro/starter.md
@@ -157,7 +157,7 @@ See [Starting a OGX Server](../starting_ogx_server) for all the ways to run (uv,
 Quick start:
 
 ```bash
-uvx --from 'ogx[starter]' ogx run starter
+uvx --from 'ogx[starter]' ogx stack run starter
 ```
 
 Or run the pre-built container image from [Docker Hub](https://hub.docker.com/r/ogx/distribution-starter):
@@ -175,7 +175,7 @@ docker run -it \
 By default, the starter distribution uses SQLite. For production, use PostgreSQL:
 
 ```bash
-uvx --from 'ogx[starter]' ogx run starter::run-with-postgres-store.yaml
+uvx --from 'ogx[starter]' ogx stack run starter::run-with-postgres-store.yaml
 ```
 
 A pre-built container image with PostgreSQL storage is also available as [`ogx/distribution-postgres-demo`](https://hub.docker.com/r/ogx/distribution-postgres-demo).

--- a/docs/docs/distributions/starting_ogx_server.mdx
+++ b/docs/docs/distributions/starting_ogx_server.mdx
@@ -16,13 +16,13 @@ import TabItem from '@theme/TabItem';
 The fastest way to get started. No global install needed:
 
 ```bash
-uvx --from 'ogx[starter]' ogx run starter
+uvx --from 'ogx[starter]' ogx stack run starter
 ```
 
 Or if you have a project with ogx as a dependency:
 
 ```bash
-uv run ogx run starter
+uv run ogx stack run starter
 ```
 
 </TabItem>
@@ -77,13 +77,13 @@ Control log output via environment variables:
 
 ```bash
 # Per-component levels
-OGX_LOGGING=server=debug,core=info ogx run starter
+OGX_LOGGING=server=debug,core=info ogx stack run starter
 
 # Global level
-OGX_LOGGING=all=debug ogx run starter
+OGX_LOGGING=all=debug ogx stack run starter
 
 # Log to file
-OGX_LOG_FILE=/tmp/ogx.log ogx run starter
+OGX_LOG_FILE=/tmp/ogx.log ogx stack run starter
 ```
 
 Categories: `all`, `core`, `server`, `router`, `inference`, `safety`, `tools`, `client`.

--- a/docs/docs/getting_started/detailed_tutorial.mdx
+++ b/docs/docs/getting_started/detailed_tutorial.mdx
@@ -179,7 +179,7 @@ The same code works with any backend. Just change the server config:
 
 ```bash
 export OLLAMA_URL=http://localhost:11434/v1
-uv run ogx run starter
+uv run ogx stack run starter
 ```
 
 </TabItem>
@@ -187,7 +187,7 @@ uv run ogx run starter
 
 ```bash
 export OPENAI_API_KEY=sk-xxx
-uv run ogx run starter
+uv run ogx stack run starter
 ```
 
 Your client code stays the same. Just update the model name:

--- a/docs/docs/getting_started/quickstart.mdx
+++ b/docs/docs/getting_started/quickstart.mdx
@@ -20,7 +20,7 @@ Install [Ollama](https://ollama.com/download), then pull a model and start the s
 ```bash
 ollama pull llama3.2:3b
 export OLLAMA_URL=http://localhost:11434/v1
-uvx --from 'ogx[starter]' ogx run starter
+uvx --from 'ogx[starter]' ogx stack run starter
 ```
 
 </TabItem>
@@ -28,7 +28,7 @@ uvx --from 'ogx[starter]' ogx run starter
 
 ```bash
 export OPENAI_API_KEY=sk-xxx
-uvx --from 'ogx[starter]' ogx run starter
+uvx --from 'ogx[starter]' ogx stack run starter
 ```
 
 </TabItem>
@@ -54,7 +54,7 @@ The `uvx` command above is great for trying things out. For a real project, inst
 uv init my-ai-app && cd my-ai-app
 uv add 'ogx[starter]' openai
 export OLLAMA_URL=http://localhost:11434/v1
-uv run ogx run starter
+uv run ogx stack run starter
 ```
 :::
 
@@ -166,7 +166,7 @@ That's it. Same OpenAI SDK, local model, your own vector store.
 If you see `Address already in use`, another process is using port 8321. Either stop it or run on a different port:
 
 ```bash
-uvx --from 'ogx[starter]' ogx run starter --port 8322
+uvx --from 'ogx[starter]' ogx stack run starter --port 8322
 ```
 
 </details>

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -114,7 +114,7 @@ curl -LsSf https://github.com/ogx-ai/ogx/raw/main/scripts/install.sh | bash
 pip install ogx
 
 # Start the server
-ogx run
+ogx stack run
 ```
 
 :::tip

--- a/docs/docs/providers/external/external-providers-guide.mdx
+++ b/docs/docs/providers/external/external-providers-guide.mdx
@@ -239,6 +239,6 @@ server:
   port: 8321
 ```
 
-No other steps are required beyond installing dependencies with `ogx list-deps <distro> | xargs -L1 uv pip install` and then running `ogx run`. The CLI will use `module` to install the provider dependencies, retrieve the spec, etc.
+No other steps are required beyond installing dependencies with `ogx list-deps <distro> | xargs -L1 uv pip install` and then running `ogx stack run`. The CLI will use `module` to install the provider dependencies, retrieve the spec, etc.
 
 The provider will now be available in OGX with the type `remote::ramalama`.

--- a/docs/docs/providers/file_processors/inline_docling.mdx
+++ b/docs/docs/providers/file_processors/inline_docling.mdx
@@ -17,7 +17,7 @@ description: |
   Start OGX with the Docling file processor using the `--providers` flag:
 
   ```bash
-  OLLAMA_URL=http://localhost:11434/v1 ogx run \
+  OLLAMA_URL=http://localhost:11434/v1 ogx stack run \
     --providers "file_processors=inline::docling,files=inline::localfs,vector_io=inline::faiss,inference=inline::sentence-transformers,inference=remote::ollama" \
     --port 8321
   ```
@@ -66,7 +66,7 @@ preserves semantic boundaries. It supports PDF, DOCX, PPTX, HTML, and images.
 Start OGX with the Docling file processor using the `--providers` flag:
 
 ```bash
-OLLAMA_URL=http://localhost:11434/v1 ogx run \
+OLLAMA_URL=http://localhost:11434/v1 ogx stack run \
   --providers "file_processors=inline::docling,files=inline::localfs,vector_io=inline::faiss,inference=inline::sentence-transformers,inference=remote::ollama" \
   --port 8321
 ```

--- a/docs/docs/providers/file_processors/remote_docling-serve.mdx
+++ b/docs/docs/providers/file_processors/remote_docling-serve.mdx
@@ -27,7 +27,7 @@ description: |
   Then start OGX with the remote Docling Serve provider:
 
   ```bash
-  DOCLING_SERVE_URL=http://localhost:5001/v1 ogx run \
+  DOCLING_SERVE_URL=http://localhost:5001/v1 ogx stack run \
     --providers "file_processors=remote::docling-serve,files=inline::localfs,vector_io=inline::faiss,inference=inline::sentence-transformers,inference=remote::ollama" \
     --port 8321
   ```
@@ -82,7 +82,7 @@ docker run -p 5001:5001 quay.io/docling-project/docling-serve
 Then start OGX with the remote Docling Serve provider:
 
 ```bash
-DOCLING_SERVE_URL=http://localhost:5001/v1 ogx run \
+DOCLING_SERVE_URL=http://localhost:5001/v1 ogx stack run \
   --providers "file_processors=remote::docling-serve,files=inline::localfs,vector_io=inline::faiss,inference=inline::sentence-transformers,inference=remote::ollama" \
   --port 8321
 ```

--- a/docs/docs/references/evals_reference/index.mdx
+++ b/docs/docs/references/evals_reference/index.mdx
@@ -366,7 +366,7 @@ Secondly, you need to add the new benchmark you just created under the `benchmar
 
 Spin up ogx server with 'open-benchmark' templates
 ```bash
-ogx run ogx/distributions/open-benchmark/config.yaml
+ogx stack run ogx/distributions/open-benchmark/config.yaml
 ```
 
 Run eval benchmark CLI with your new benchmark id

--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -95,7 +95,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
 2. **Start the distribution**:
 
    ```bash
-   ogx run starter
+   ogx stack run starter
    ```
 
 3. **Set the ENV variables by exporting them to the terminal**:
@@ -114,7 +114,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
    INFERENCE_MODEL=$INFERENCE_MODEL \
    SAFETY_MODEL=$SAFETY_MODEL \
    OLLAMA_URL=$OLLAMA_URL \
-   uv run --with ogx ogx run starter \
+   uv run --with ogx ogx stack run starter \
       --port $OGX_PORT
    ```
 

--- a/scripts/telemetry/README.md
+++ b/scripts/telemetry/README.md
@@ -87,7 +87,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 export OTEL_SERVICE_NAME=ogx-server
 
-uv run opentelemetry-instrument ogx run starter
+uv run opentelemetry-instrument ogx stack run starter
 ```
 
 > **Note:** The `opentelemetry-instrument` wrapper automatically instruments the application and sends traces/metrics to the OTel Collector.

--- a/scripts/test_interactions_api.py
+++ b/scripts/test_interactions_api.py
@@ -19,7 +19,7 @@ ADK/Gemini ecosystem clients can call OGX natively.
 
 Usage:
     # Start a OGX server first:
-    OLLAMA_URL=http://localhost:11434/v1 uv run --extra starter ogx run starter --port 8321
+    OLLAMA_URL=http://localhost:11434/v1 uv run --extra starter ogx stack run starter --port 8321
 
     # Then run this script:
     uv run python scripts/test_interactions_api.py --base-url http://localhost:8321 --model ollama/llama3.2:3b

--- a/src/ogx/README.md
+++ b/src/ogx/README.md
@@ -9,7 +9,7 @@ ogx/
   core/               # Server core: routing, resolution, storage, server
   providers/           # All provider implementations (inline + remote)
   distributions/       # Pre-built distribution configurations
-  cli/                 # CLI commands (ogx run, build, configure, etc.)
+  cli/                 # CLI commands (ogx stack run, build, configure, etc.)
   models/              # Model metadata and registries
   testing/             # Test infrastructure (API recorder for record/replay)
   telemetry/           # OpenTelemetry integration

--- a/src/ogx/cli/stack/run.py
+++ b/src/ogx/cli/stack/run.py
@@ -34,7 +34,7 @@ class StackRun(Subcommand):
         super().__init__()
         self.parser = subparsers.add_parser(
             "run",
-            prog="ogx run",
+            prog="ogx stack run",
             description="""Start the server for a OGX Distribution. You should have already built (or downloaded) and configured the distribution.""",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )

--- a/src/ogx/core/start_stack.sh
+++ b/src/ogx/core/start_stack.sh
@@ -106,12 +106,12 @@ if [[ "$env_type" == "venv" ]]; then
         yaml_config_arg=""
     fi
 
-    ogx run \
+    ogx stack run \
     $yaml_config_arg \
     --port "$port" \
     $other_args
 elif [[ "$env_type" == "container" ]]; then
-    echo -e "${RED}Warning: OGX no longer supports running Containers via the 'ogx run' command.${NC}"
+    echo -e "${RED}Warning: OGX no longer supports running Containers via the 'ogx stack run' command.${NC}"
     echo -e "Please refer to the documentation for more information: https://ogx-ai.github.io/latest/distributions/building_distro.html#ogx-build"
     exit 1
 fi

--- a/src/ogx/distributions/README.md
+++ b/src/ogx/distributions/README.md
@@ -48,7 +48,7 @@ Distribution configs use `${env.VAR:=default}` syntax for environment-driven con
 Run a distribution with:
 
 ```bash
-ogx run starter
+ogx stack run starter
 # or
-ogx run --config path/to/config.yaml
+ogx stack run --config path/to/config.yaml
 ```

--- a/src/ogx/distributions/nvidia/doc_template.md
+++ b/src/ogx/distributions/nvidia/doc_template.md
@@ -168,7 +168,7 @@ INFERENCE_MODEL=meta-llama/Llama-3.1-8B-Instruct
 ogx list-deps nvidia | xargs -L1 uv pip install
 NVIDIA_API_KEY=$NVIDIA_API_KEY \
 INFERENCE_MODEL=$INFERENCE_MODEL \
-ogx run ./config.yaml \
+ogx stack run ./config.yaml \
   --port 8321
 ```
 

--- a/src/ogx/distributions/oci/doc_template.md
+++ b/src/ogx/distributions/oci/doc_template.md
@@ -107,7 +107,7 @@ You can run the OCI distribution via Docker or local virtual environment.
 If you've set up your local development environment, you can also build the image using your local virtual environment.
 
 ```bash
-OCI_AUTH=$OCI_AUTH_TYPE OCI_REGION=$OCI_REGION OCI_COMPARTMENT_OCID=$OCI_COMPARTMENT_OCID ogx run --port 8321 oci
+OCI_AUTH=$OCI_AUTH_TYPE OCI_REGION=$OCI_REGION OCI_COMPARTMENT_OCID=$OCI_COMPARTMENT_OCID ogx stack run --port 8321 oci
 ```
 
 ### Configuration Examples

--- a/src/ogx/providers/registry/file_processors.py
+++ b/src/ogx/providers/registry/file_processors.py
@@ -53,7 +53,7 @@ preserves semantic boundaries. It supports PDF, DOCX, PPTX, HTML, and images.
 Start OGX with the Docling file processor using the `--providers` flag:
 
 ```bash
-OLLAMA_URL=http://localhost:11434/v1 ogx run \\
+OLLAMA_URL=http://localhost:11434/v1 ogx stack run \\
   --providers "file_processors=inline::docling,files=inline::localfs,vector_io=inline::faiss,inference=inline::sentence-transformers,inference=remote::ollama" \\
   --port 8321
 ```
@@ -114,7 +114,7 @@ docker run -p 5001:5001 quay.io/docling-project/docling-serve
 Then start OGX with the remote Docling Serve provider:
 
 ```bash
-DOCLING_SERVE_URL=http://localhost:5001/v1 ogx run \\
+DOCLING_SERVE_URL=http://localhost:5001/v1 ogx stack run \\
   --providers "file_processors=remote::docling-serve,files=inline::localfs,vector_io=inline::faiss,inference=inline::sentence-transformers,inference=remote::ollama" \\
   --port 8321
 ```

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -53,7 +53,7 @@ def start_ogx_server(config_name: str, *, log_stderr: bool | None = None) -> sub
     if os.path.exists("server.log"):
         os.remove("server.log")
 
-    cmd = f"ogx run {config_name}"
+    cmd = f"ogx stack run {config_name}"
     devnull = open(os.devnull, "w")
     process = subprocess.Popen(
         shlex.split(cmd),

--- a/tests/unit/cli/test_stack_run.py
+++ b/tests/unit/cli/test_stack_run.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 """
-Unit tests for `ogx run` CLI command.
+Unit tests for `ogx stack run` CLI command.
 
 Categories:
   - Arguments: --providers flag is registered and parsed correctly

--- a/tests/unit/core/test_logging_config.py
+++ b/tests/unit/core/test_logging_config.py
@@ -6,7 +6,7 @@
 
 """
 Regression tests: ensure logging behaves consistently whether the server
-is started via `ogx run` or directly via `uvicorn create_app`.
+is started via `ogx stack run` or directly via `uvicorn create_app`.
 
 These tests verify that:
 1. setup_logging() is called when creating the app


### PR DESCRIPTION
# What does this PR do?

The CLI command is `ogx stack run`, not `ogx run`. This fixes all 42 files across docs, blog posts, scripts, tests, and source code that incorrectly used the old form.

## Test Plan

1. Grep the repo to confirm no remaining `ogx run` without `stack`:
   ```bash
   grep -rn 'ogx run' --include='*.md' --include='*.mdx' --include='*.py' --include='*.sh' --include='*.jsx' | grep -v 'ogx stack run'
   ```
   Expected: no output.

2. Pre-commit checks pass (provider codegen, markdownlint, etc.).