### PR TITLE
feat(cli): add top-level 'ogx run' and 'ogx letsgo' shortcuts

### DIFF
--- a/src/ogx/cli/letsgo.py
+++ b/src/ogx/cli/letsgo.py
@@ -1,0 +1,32 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import argparse
+from typing import Any
+
+from ogx.cli.stack.lets_go import add_letsgo_arguments, run_letsgo_cmd
+from ogx.cli.subcommand import Subcommand
+
+
+class LetsGo(Subcommand):
+    """Auto-detect providers, generate runtime config, and start the stack."""
+
+    def __init__(self, subparsers: Any) -> None:
+        super().__init__()
+        self.parser = subparsers.add_parser(
+            "letsgo",
+            prog="ogx letsgo",
+            description="Auto-detect providers and start the stack",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        self._add_arguments()
+        self.parser.set_defaults(func=self._run_cmd)
+
+    def _add_arguments(self) -> None:
+        add_letsgo_arguments(self.parser)
+
+    def _run_cmd(self, args: argparse.Namespace) -> None:
+        run_letsgo_cmd(args, self.parser)

--- a/src/ogx/cli/ogx.py
+++ b/src/ogx/cli/ogx.py
@@ -12,6 +12,7 @@ from ogx.log import setup_logging
 # Initialize logging early before any loggers get created
 setup_logging()
 
+from .run import Run
 from .stack import StackParser  # type: ignore[attr-defined]
 from .stack.utils import print_subcommand_description
 
@@ -33,6 +34,7 @@ class OGXCLIParser:
         subparsers = self.parser.add_subparsers(title="subcommands")
 
         # Add sub-commands
+        Run.create(subparsers)
         StackParser.create(subparsers)
 
         print_subcommand_description(self.parser, subparsers)

--- a/src/ogx/cli/ogx.py
+++ b/src/ogx/cli/ogx.py
@@ -12,6 +12,7 @@ from ogx.log import setup_logging
 # Initialize logging early before any loggers get created
 setup_logging()
 
+from .letsgo import LetsGo
 from .run import Run
 from .stack import StackParser  # type: ignore[attr-defined]
 from .stack.utils import print_subcommand_description
@@ -34,6 +35,7 @@ class OGXCLIParser:
         subparsers = self.parser.add_subparsers(title="subcommands")
 
         # Add sub-commands
+        LetsGo.create(subparsers)
         Run.create(subparsers)
         StackParser.create(subparsers)
 

--- a/src/ogx/cli/run.py
+++ b/src/ogx/cli/run.py
@@ -1,0 +1,31 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import argparse
+
+from ogx.cli.stack.run import add_run_arguments, run_stack_cmd
+from ogx.cli.subcommand import Subcommand
+
+
+class Run(Subcommand):
+    """CLI subcommand to start a OGX distribution server."""
+
+    def __init__(self, subparsers: argparse._SubParsersAction) -> None:
+        super().__init__()
+        self.parser = subparsers.add_parser(
+            "run",
+            prog="ogx run",
+            description="Start the server for a OGX Distribution. You should have already built (or downloaded) and configured the distribution.",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        self._add_arguments()
+        self.parser.set_defaults(func=self._run_cmd)
+
+    def _add_arguments(self) -> None:
+        add_run_arguments(self.parser)
+
+    def _run_cmd(self, args: argparse.Namespace) -> None:
+        run_stack_cmd(args, self.parser)

--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urljoin
@@ -36,251 +37,252 @@ class _ProbeStatus(enum.Enum):
     UNREACHABLE = "unreachable"
 
 
-class StackLetsGo(Subcommand):
-    """Auto-detect providers, generate runtime config, and start the stack.
+def add_letsgo_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Port to run the server on. It can also be passed via the env var OGX_PORT.",
+        default=int(os.getenv("OGX_PORT", 8321)),
+    )
+    parser.add_argument(
+        "--enable-ui",
+        action="store_true",
+        help="Start the UI server",
+    )
+    parser.add_argument(
+        "--persist-config",
+        action="store_true",
+        help="Persist generated runtime config to the distro directory",
+    )
+    parser.add_argument(
+        "--providers-override",
+        type=str,
+        default=None,
+        help="Explicit providers spec to use instead of auto-detection (e.g. inference=remote::ollama)",
+    )
+    parser.add_argument(
+        "--skip-install-deps",
+        action="store_true",
+        help="Skip automatic installation of provider pip dependencies before starting the server.",
+    )
 
-    Providers fall into three categories:
 
-    - Inline providers (files=inline::localfs, vector_io=inline::faiss,
-      tool_runtime=inline::file-search, file_processors=inline::pypdf,
-      responses=inline::builtin): require no external service and are always
-      included.
-    - Key-free providers (Ollama, vLLM, llama-cpp-server): included when a
-      lightweight HTTP probe to their endpoint succeeds.
-    - API-key providers (OpenAI, Anthropic, ...): included only when the
-      required API key environment variable is set *and* the probe succeeds.
-      A missing key is reported without making a network request.
+def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    if args.enable_ui:
+        try:
+            _start_ui_development_server(args.port)
+        except Exception:
+            logger.warning("Failed to start UI development server", exc_info=True)
+
+    if args.providers_override:
+        providers_spec = args.providers_override
+    else:
+        providers_spec = _autodetect_providers()
+
+    has_inference = any(p.startswith("inference=") for p in (providers_spec or "").split(","))
+    if not has_inference:
+        parser.error("No inference providers detected. Nothing to run.")
+
+    distro_dir = DISTRIBS_BASE_DIR / "letsgo-run" if args.persist_config else Path(tempfile.mkdtemp())
+    os.makedirs(distro_dir, exist_ok=True)
+
+    try:
+        run_config = run_config_from_dynamic_config_spec(
+            dynamic_config_spec=providers_spec,
+            distro_dir=distro_dir,
+            distro_name="letsgo-run",
+        )
+    except ValueError as e:
+        cprint(str(e), color="red", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.skip_install_deps:
+        normal_deps, special_deps, _ = get_provider_dependencies(run_config)
+        _install_provider_deps(normal_deps, special_deps)
+
+    config_dict = run_config.model_dump(mode="json")
+
+    config_file = distro_dir / "config.yaml"
+    logger.info("Writing generated config to", config_file=config_file)
+    with open(config_file, "w") as f:
+        yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+
+    try:
+        stack_args = argparse.Namespace()
+        stack_args.port = args.port
+        stack_args.enable_ui = args.enable_ui
+        stack_args.providers = None
+        _uvicorn_run(config_file, stack_args, parser)
+    except Exception:
+        logger.exception("Failed to start the stack server")
+        raise
+
+
+def _install_provider_deps(normal_deps: list[str], special_deps: list[str]) -> None:
+    """Install provider pip dependencies into the current environment.
+
+    Uses `uv pip install` when uv is available, falling back to `pip install`.
+    A non-zero exit is logged as a warning rather than aborting startup,
+    since packages may already satisfy the declared constraints.
     """
+    if shutil.which("uv"):
+        installer = ["uv", "pip", "install"]
+    else:
+        installer = [sys.executable, "-m", "pip", "install"]
+
+    if normal_deps:
+        cprint("Installing provider dependencies...", color="cyan")
+        result = subprocess.run([*installer, *normal_deps])
+        if result.returncode != 0:
+            logger.warning("Failed to install provider dependencies", returncode=result.returncode)
+
+    for special_dep in special_deps:
+        result = subprocess.run([*installer, *special_dep.split()])
+        if result.returncode != 0:
+            logger.warning(
+                "Failed to install special provider dependency", dep=special_dep, returncode=result.returncode
+            )
+
+
+def _autodetect_providers() -> str:
+    """Probe all candidate providers and return a comma-separated providers spec string.
+
+    Each provider is probed independently; all that pass are included in the
+    result. Providers that require an API key skip the network probe entirely
+    when the key environment variable is not set.
+    """
+    candidates = [
+        # provider_type, env_for_base_url, default_base_url, probe_path, requires_api_key, api_key_env, extra_headers
+        ("remote::ollama", "OLLAMA_URL", "http://localhost:11434/v1", "models", False, None, {}),
+        ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", "health", False, None, {}),
+        ("remote::llama-cpp-server", "LLAMA_CPP_SERVER_URL", "http://localhost:8080/v1", "models", False, None, {}),
+        ("remote::openai", "OPENAI_BASE_URL", "https://api.openai.com/v1", "models", True, "OPENAI_API_KEY", {}),
+        (
+            "remote::llama-openai-compat",
+            "LLAMA_API_BASE_URL",
+            "https://api.llama.com/compat/v1/",
+            "models",
+            True,
+            "LLAMA_API_KEY",
+            {},
+        ),
+        (
+            "remote::anthropic",
+            None,
+            "https://api.anthropic.com/v1",
+            "models",
+            True,
+            "ANTHROPIC_API_KEY",
+            {"anthropic-version": "2023-06-01"},
+        ),
+    ]
+
+    passed: list[str] = []
+    cprint("Scanning for available providers...", color="cyan")
+    for provider_type, base_env, default_base, probe_path, requires_key, key_env, extra_headers in candidates:
+        env_val: str | None = os.getenv(base_env) if base_env else None
+        if env_val:
+            base = env_val
+            base_source = f"from {base_env}"
+        else:
+            base = default_base
+            base_source = "default"
+
+        status = _probe_endpoint(base, probe_path, requires_key, key_env, extra_headers)
+
+        # Build annotation parts
+        parts = [f"{base}, {base_source}"]
+        if requires_key and key_env:
+            parts.append(f"{key_env} {'set' if os.getenv(key_env) else 'not set'}")
+
+        annotation = ", ".join(parts)
+
+        if status == _ProbeStatus.OK:
+            passed.append(f"inference={provider_type}")
+            cprint(f"  ✓ {provider_type} ({annotation})", color="green")
+        elif status == _ProbeStatus.NO_KEY:
+            cprint(f"  ✗ {provider_type} ({annotation})", color="yellow")
+        elif status == _ProbeStatus.AUTH:
+            cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
+        else:
+            cprint(f"  ✗ {provider_type} ({annotation}) — unreachable", color="yellow")
+
+    # Inline providers require no external service — always include them.
+    inline_providers = [
+        "files=inline::localfs",
+        "vector_io=inline::faiss",
+        "tool_runtime=inline::file-search",
+        "file_processors=inline::pypdf",
+        "responses=inline::builtin",
+    ]
+    cprint("  ✓ inline::localfs (built-in)", color="green")
+    cprint("  ✓ inline::faiss (built-in)", color="green")
+    cprint("  ✓ inline::file-search (built-in)", color="green")
+    cprint("  ✓ inline::pypdf (built-in)", color="green")
+    cprint("  ✓ inline::builtin responses (built-in)", color="green")
+
+    if passed:
+        cprint(f"\nDetected {len(passed)} inference provider(s). Starting stack...", color="cyan")
+    else:
+        cprint("\nDetected no inference providers, not starting stack.", color="red")
+    return ",".join(passed + inline_providers)
+
+
+def _probe_endpoint(
+    base_url: str,
+    probe_path: str,
+    requires_key: bool,
+    key_env: str | None,
+    extra_headers: dict[str, str] | None = None,
+) -> _ProbeStatus:
+    """Perform a lightweight HTTP probe for a provider."""
+    if not base_url:
+        return _ProbeStatus.UNREACHABLE
+
+    url = urljoin(base_url.rstrip("/") + "/", probe_path)
+
+    headers: dict[str, str] = dict(extra_headers or {})
+    if requires_key:
+        if not key_env or not os.getenv(key_env):
+            return _ProbeStatus.NO_KEY
+        key: str = os.getenv(key_env, "")
+        headers["Authorization"] = f"Bearer {key}"
+        headers["x-api-key"] = key
+
+    try:
+        resp = cast(httpx.Response, httpx.get(url, headers=headers, timeout=2.0))
+        if resp.status_code in (401, 403):
+            return _ProbeStatus.AUTH
+        if resp.status_code < 400:
+            return _ProbeStatus.OK
+        return _ProbeStatus.UNREACHABLE
+    except Exception:
+        return _ProbeStatus.UNREACHABLE
+
+
+class StackLetsGo(Subcommand):
+    """Auto-detect providers, generate runtime config, and start the stack (deprecated, use 'ogx letsgo' instead)."""
 
     def __init__(self, subparsers: Any) -> None:
         super().__init__()
         self.parser = subparsers.add_parser(
             "letsgo",
-            prog="ogx letsgo",
-            description="Auto-detect providers and start the stack",
+            prog="ogx stack letsgo",
+            description="""Auto-detect providers and start the stack.
+
+NOTE: 'ogx stack letsgo' is deprecated. Use 'ogx letsgo' instead.""",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
         self._add_arguments()
         self.parser.set_defaults(func=self._run_stack_lets_go_cmd)
 
     def _add_arguments(self) -> None:
-        self.parser.add_argument(
-            "--port",
-            type=int,
-            help="Port to run the server on. It can also be passed via the env var OGX_PORT.",
-            default=int(os.getenv("OGX_PORT", 8321)),
-        )
-        self.parser.add_argument(
-            "--enable-ui",
-            action="store_true",
-            help="Start the UI server",
-        )
-        self.parser.add_argument(
-            "--persist-config",
-            action="store_true",
-            help="Persist generated runtime config to the distro directory",
-        )
-        self.parser.add_argument(
-            "--providers-override",
-            type=str,
-            default=None,
-            help="Explicit providers spec to use instead of auto-detection (e.g. inference=remote::ollama)",
-        )
-        self.parser.add_argument(
-            "--skip-install-deps",
-            action="store_true",
-            help="Skip automatic installation of provider pip dependencies before starting the server.",
-        )
+        add_letsgo_arguments(self.parser)
 
     def _run_stack_lets_go_cmd(self, args: argparse.Namespace) -> None:
-        # If user asked to start the UI, attempt to start it (best-effort)
-        if args.enable_ui:
-            try:
-                _start_ui_development_server(args.port)
-            except Exception:
-                # UI is best-effort; do not fail the whole command
-                logger.warning("Failed to start UI development server", exc_info=True)
-
-        # Determine providers spec (either overridden or auto-detected)
-        if args.providers_override:
-            providers_spec = args.providers_override
-        else:
-            providers_spec = self._autodetect_providers()
-
-        has_inference = any(p.startswith("inference=") for p in (providers_spec or "").split(","))
-        if not has_inference:
-            self.parser.error("No inference providers detected. Nothing to run.")
-
-        distro_dir = DISTRIBS_BASE_DIR / "letsgo-run" if args.persist_config else Path(tempfile.mkdtemp())
-        os.makedirs(distro_dir, exist_ok=True)
-
-        try:
-            run_config = run_config_from_dynamic_config_spec(
-                dynamic_config_spec=providers_spec,
-                distro_dir=distro_dir,
-                distro_name="letsgo-run",
-            )
-        except ValueError as e:
-            cprint(str(e), color="red", file=sys.stderr)
-            sys.exit(1)
-
-        if not args.skip_install_deps:
-            normal_deps, special_deps, _ = get_provider_dependencies(run_config)
-            self._install_provider_deps(normal_deps, special_deps)
-
-        config_dict = run_config.model_dump(mode="json")
-
-        config_file = distro_dir / "config.yaml"
-        logger.info("Writing generated config to", config_file=config_file)
-        with open(config_file, "w") as f:
-            yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
-
-        try:
-            stack_args = argparse.Namespace()
-            stack_args.port = args.port
-            stack_args.enable_ui = args.enable_ui
-            stack_args.providers = None
-            _uvicorn_run(config_file, stack_args, self.parser)
-        except Exception:
-            logger.exception("Failed to start the stack server")
-            raise
-
-    def _install_provider_deps(self, normal_deps: list[str], special_deps: list[str]) -> None:
-        """Install provider pip dependencies into the current environment.
-
-        Uses `uv pip install` when uv is available, falling back to `pip install`.
-        A non-zero exit is logged as a warning rather than aborting startup,
-        since packages may already satisfy the declared constraints.
-        """
-        if shutil.which("uv"):
-            installer = ["uv", "pip", "install"]
-        else:
-            installer = [sys.executable, "-m", "pip", "install"]
-
-        if normal_deps:
-            cprint("Installing provider dependencies...", color="cyan")
-            result = subprocess.run([*installer, *normal_deps])
-            if result.returncode != 0:
-                logger.warning("Failed to install provider dependencies", returncode=result.returncode)
-
-        for special_dep in special_deps:
-            result = subprocess.run([*installer, *special_dep.split()])
-            if result.returncode != 0:
-                logger.warning(
-                    "Failed to install special provider dependency", dep=special_dep, returncode=result.returncode
-                )
-
-    def _autodetect_providers(self) -> str:
-        """Probe all candidate providers and return a comma-separated providers spec string.
-
-        Each provider is probed independently; all that pass are included in the
-        result. Providers that require an API key skip the network probe entirely
-        when the key environment variable is not set.
-        """
-        candidates = [
-            # provider_type, env_for_base_url, default_base_url, probe_path, requires_api_key, api_key_env, extra_headers
-            ("remote::ollama", "OLLAMA_URL", "http://localhost:11434/v1", "models", False, None, {}),
-            ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", "health", False, None, {}),
-            ("remote::llama-cpp-server", "LLAMA_CPP_SERVER_URL", "http://localhost:8080/v1", "models", False, None, {}),
-            ("remote::openai", "OPENAI_BASE_URL", "https://api.openai.com/v1", "models", True, "OPENAI_API_KEY", {}),
-            (
-                "remote::llama-openai-compat",
-                "LLAMA_API_BASE_URL",
-                "https://api.llama.com/compat/v1/",
-                "models",
-                True,
-                "LLAMA_API_KEY",
-                {},
-            ),
-            (
-                "remote::anthropic",
-                None,
-                "https://api.anthropic.com/v1",
-                "models",
-                True,
-                "ANTHROPIC_API_KEY",
-                {"anthropic-version": "2023-06-01"},
-            ),
-        ]
-
-        passed: list[str] = []
-        cprint("Scanning for available providers...", color="cyan")
-        for provider_type, base_env, default_base, probe_path, requires_key, key_env, extra_headers in candidates:
-            env_val: str | None = os.getenv(base_env) if base_env else None
-            if env_val:
-                base = env_val
-                base_source = f"from {base_env}"
-            else:
-                base = default_base
-                base_source = "default"
-
-            status = self._probe_endpoint(base, probe_path, requires_key, key_env, extra_headers)
-
-            # Build annotation parts
-            parts = [f"{base}, {base_source}"]
-            if requires_key and key_env:
-                parts.append(f"{key_env} {'set' if os.getenv(key_env) else 'not set'}")
-
-            annotation = ", ".join(parts)
-
-            if status == _ProbeStatus.OK:
-                passed.append(f"inference={provider_type}")
-                cprint(f"  ✓ {provider_type} ({annotation})", color="green")
-            elif status == _ProbeStatus.NO_KEY:
-                cprint(f"  ✗ {provider_type} ({annotation})", color="yellow")
-            elif status == _ProbeStatus.AUTH:
-                cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
-            else:
-                cprint(f"  ✗ {provider_type} ({annotation}) — unreachable", color="yellow")
-
-        # Inline providers require no external service — always include them.
-        inline_providers = [
-            "files=inline::localfs",
-            "vector_io=inline::faiss",
-            "tool_runtime=inline::file-search",
-            "file_processors=inline::pypdf",
-            "responses=inline::builtin",
-        ]
-        cprint("  ✓ inline::localfs (built-in)", color="green")
-        cprint("  ✓ inline::faiss (built-in)", color="green")
-        cprint("  ✓ inline::file-search (built-in)", color="green")
-        cprint("  ✓ inline::pypdf (built-in)", color="green")
-        cprint("  ✓ inline::builtin responses (built-in)", color="green")
-
-        if passed:
-            cprint(f"\nDetected {len(passed)} inference provider(s). Starting stack...", color="cyan")
-        else:
-            cprint("\nDetected no inference providers, not starting stack.", color="red")
-        return ",".join(passed + inline_providers)
-
-    def _probe_endpoint(
-        self,
-        base_url: str,
-        probe_path: str,
-        requires_key: bool,
-        key_env: str | None,
-        extra_headers: dict[str, str] | None = None,
-    ) -> _ProbeStatus:
-        """Perform a lightweight HTTP probe for a provider."""
-        if not base_url:
-            return _ProbeStatus.UNREACHABLE
-
-        url = urljoin(base_url.rstrip("/") + "/", probe_path)
-
-        headers: dict[str, str] = dict(extra_headers or {})
-        if requires_key:
-            if not key_env or not os.getenv(key_env):
-                return _ProbeStatus.NO_KEY
-            key: str = os.getenv(key_env, "")
-            headers["Authorization"] = f"Bearer {key}"
-            headers["x-api-key"] = key
-
-        try:
-            resp = cast(httpx.Response, httpx.get(url, headers=headers, timeout=2.0))
-            if resp.status_code in (401, 403):
-                return _ProbeStatus.AUTH
-            if resp.status_code < 400:
-                return _ProbeStatus.OK
-            return _ProbeStatus.UNREACHABLE
-        except Exception:
-            return _ProbeStatus.UNREACHABLE
+        warnings.warn(
+            "'ogx stack letsgo' is deprecated and will be removed in a future release. Use 'ogx letsgo' instead.",
+            FutureWarning,
+            stacklevel=1,
+        )
+        run_letsgo_cmd(args, self.parser)

--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -19,7 +19,7 @@ import httpx
 import yaml
 from termcolor import cprint
 
-from ogx.cli.stack.run import StackRun
+from ogx.cli.stack.run import _start_ui_development_server, _uvicorn_run
 from ogx.cli.subcommand import Subcommand
 from ogx.core.build import get_provider_dependencies
 from ogx.core.stack import run_config_from_dynamic_config_spec
@@ -96,8 +96,7 @@ class StackLetsGo(Subcommand):
         # If user asked to start the UI, attempt to start it (best-effort)
         if args.enable_ui:
             try:
-                stack_run = StackRun(argparse.ArgumentParser().add_subparsers())
-                stack_run._start_ui_development_server(args.port)
+                _start_ui_development_server(args.port)
             except Exception:
                 # UI is best-effort; do not fail the whole command
                 logger.warning("Failed to start UI development server", exc_info=True)
@@ -136,15 +135,12 @@ class StackLetsGo(Subcommand):
         with open(config_file, "w") as f:
             yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
 
-        # Reuse StackRun's uvicorn startup
         try:
-            stack_run = StackRun(argparse.ArgumentParser().add_subparsers())
-            # Build args similar to stack run
             stack_args = argparse.Namespace()
             stack_args.port = args.port
             stack_args.enable_ui = args.enable_ui
             stack_args.providers = None
-            stack_run._uvicorn_run(config_file, stack_args)
+            _uvicorn_run(config_file, stack_args, self.parser)
         except Exception:
             logger.exception("Failed to start the stack server")
             raise

--- a/src/ogx/cli/stack/run.py
+++ b/src/ogx/cli/stack/run.py
@@ -9,6 +9,7 @@ import os
 import ssl
 import subprocess
 import sys
+import warnings
 from pathlib import Path
 
 import uvicorn
@@ -27,212 +28,211 @@ REPO_ROOT = Path(__file__).parent.parent.parent.parent
 logger = get_logger(name=__name__, category="cli")
 
 
+def add_run_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "config",
+        type=str,
+        nargs="?",
+        metavar="config | distro",
+        help="Path to config file to use for the run or name of known distro (`ogx list` for a list).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Port to run the server on. It can also be passed via the env var OGX_PORT.",
+        default=int(os.getenv("OGX_PORT", 8321)),
+    )
+    parser.add_argument(
+        "--enable-ui",
+        action="store_true",
+        help="Start the UI server",
+    )
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=None,
+        help="Run a stack with only a list of providers. This list is formatted like: api1=provider1,api1=provider2,api2=provider3. Where there can be multiple providers per API.",
+    )
+
+
+def run_stack_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    import yaml
+
+    from ogx.core.configure import parse_and_maybe_upgrade_config
+
+    if args.enable_ui:
+        _start_ui_development_server(args.port)
+
+    if args.config:
+        try:
+            from ogx.core.utils.config_resolution import resolve_config_or_distro
+
+            config_file = resolve_config_or_distro(args.config)
+        except ValueError as e:
+            parser.error(str(e))
+    elif args.providers:
+        distro_dir = DISTRIBS_BASE_DIR / "providers-run"
+        os.makedirs(distro_dir, exist_ok=True)
+        try:
+            run_config = run_config_from_dynamic_config_spec(
+                dynamic_config_spec=args.providers,
+                distro_dir=distro_dir,
+                distro_name="providers-run",
+            )
+        except ValueError as e:
+            cprint(str(e), color="red", file=sys.stderr)
+            sys.exit(1)
+        config_dict = run_config.model_dump(mode="json")
+
+        config_file = distro_dir / "config.yaml"
+        logger.info("Writing generated config to", config_file=config_file)
+        with open(config_file, "w") as f:
+            yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
+
+    else:
+        config_file = None
+
+    if config_file:
+        logger.info("Using stack configuration", config_file=config_file)
+
+        try:
+            config_dict = yaml.safe_load(config_file.read_text())
+        except yaml.parser.ParserError as e:
+            parser.error(f"failed to load config file '{config_file}':\n {e}")
+
+        try:
+            config = parse_and_maybe_upgrade_config(config_dict)
+            if config.external_providers_dir and not os.path.exists(str(config.external_providers_dir)):
+                os.makedirs(str(config.external_providers_dir), exist_ok=True)
+        except AttributeError as e:
+            parser.error(f"failed to parse config file '{config_file}':\n {e}")
+
+    _uvicorn_run(config_file, args, parser)
+
+
+def _uvicorn_run(config_file: Path | None, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    if not config_file:
+        parser.error("Config file is required")
+
+    config_file = resolve_config_or_distro(str(config_file))
+    with open(config_file) as fp:
+        config_contents = yaml.safe_load(fp)
+        config = StackConfig(**cast_distro_name_to_string(replace_env_vars(config_contents)))
+
+    port = args.port or config.server.port
+    workers = config.server.workers
+
+    host = ""
+    if config.server.host:
+        host = config.server.host
+    elif workers and workers > 1:
+        host = "::"
+
+    os.environ["OGX_CONFIG"] = str(config_file)
+
+    uvicorn_config = {
+        "factory": True,
+        "host": host,
+        "port": port,
+        "lifespan": "on",
+        "log_level": logger.getEffectiveLevel(),
+        "workers": workers,
+    }
+
+    keyfile = config.server.tls_keyfile
+    certfile = config.server.tls_certfile
+    if keyfile and certfile:
+        uvicorn_config["ssl_keyfile"] = config.server.tls_keyfile
+        uvicorn_config["ssl_certfile"] = config.server.tls_certfile
+        if config.server.tls_cafile:
+            uvicorn_config["ssl_ca_certs"] = config.server.tls_cafile
+            uvicorn_config["ssl_cert_reqs"] = ssl.CERT_REQUIRED
+
+        logger.info(
+            "HTTPS enabled with certificates", keyfile=keyfile, certfile=certfile, cafile=config.server.tls_cafile
+        )
+    else:
+        logger.info("HTTPS enabled with certificates", keyfile=keyfile, certfile=certfile)
+
+    logger.info("Listening on", host=host, port=port)
+
+    try:
+        uvicorn.run("ogx.core.server.server:create_app", **uvicorn_config)  # type: ignore[arg-type]
+    except OSError as e:
+        if e.errno in (97, 99):
+            logger.error(
+                f"Failed to bind to {host}:{port}. "
+                "If you're on an IPv4-only system, set 'server.host: \"0.0.0.0\"' in your config."
+            )
+            raise
+        raise
+    except (KeyboardInterrupt, SystemExit):
+        logger.info("Received interrupt signal, shutting down gracefully...")
+
+
+def _start_ui_development_server(stack_server_port: int) -> None:
+    logger.info("Attempting to start UI development server...")
+    npm_check = subprocess.run(["npm", "--version"], capture_output=True, text=True, check=False)
+    if npm_check.returncode != 0:
+        logger.warning(
+            "npm command not found or not executable, UI development server will not be started",
+            error=npm_check.stderr,
+        )
+        return
+
+    ui_dir = REPO_ROOT / "ogx_ui"
+    logs_dir = UI_LOGS_DIR
+    try:
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        ui_stdout_log_path = logs_dir / "stdout.log"
+        ui_stderr_log_path = logs_dir / "stderr.log"
+
+        stdout_log_file = open(ui_stdout_log_path, "a")
+        stderr_log_file = open(ui_stderr_log_path, "a")
+
+        process = subprocess.Popen(
+            ["npm", "run", "dev"],
+            cwd=str(ui_dir),
+            stdout=stdout_log_file,
+            stderr=stderr_log_file,
+            env={**os.environ, "NEXT_PUBLIC_OGX_BASE_URL": f"http://localhost:{stack_server_port}"},
+        )
+        logger.info("UI development server process started", ui_dir=ui_dir, pid=process.pid)
+        logger.info("UI server logs", stdout=ui_stdout_log_path, stderr=ui_stderr_log_path)
+        logger.info("UI will be available", port=os.getenv("OGX_UI_PORT", 8322))
+
+    except FileNotFoundError:
+        logger.error(
+            "Failed to start UI development server: 'npm' command not found. Make sure npm is installed and in your PATH."
+        )
+    except Exception as e:
+        logger.error("Failed to start UI development server", ui_dir=ui_dir, error=str(e))
+
+
 class StackRun(Subcommand):
-    """CLI subcommand to start a OGX distribution server."""
+    """CLI subcommand to start a OGX distribution server (deprecated, use 'ogx run' instead)."""
 
     def __init__(self, subparsers: argparse._SubParsersAction) -> None:
         super().__init__()
         self.parser = subparsers.add_parser(
             "run",
             prog="ogx stack run",
-            description="""Start the server for a OGX Distribution. You should have already built (or downloaded) and configured the distribution.""",
+            description="""Start the server for a OGX Distribution. You should have already built (or downloaded) and configured the distribution.
+
+NOTE: 'ogx stack run' is deprecated. Use 'ogx run' instead.""",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
         self._add_arguments()
         self.parser.set_defaults(func=self._run_stack_run_cmd)
 
     def _add_arguments(self) -> None:
-        self.parser.add_argument(
-            "config",
-            type=str,
-            nargs="?",  # Make it optional
-            metavar="config | distro",
-            help="Path to config file to use for the run or name of known distro (`ogx list` for a list).",
-        )
-        self.parser.add_argument(
-            "--port",
-            type=int,
-            help="Port to run the server on. It can also be passed via the env var OGX_PORT.",
-            default=int(os.getenv("OGX_PORT", 8321)),
-        )
-        self.parser.add_argument(
-            "--enable-ui",
-            action="store_true",
-            help="Start the UI server",
-        )
-        self.parser.add_argument(
-            "--providers",
-            type=str,
-            default=None,
-            help="Run a stack with only a list of providers. This list is formatted like: api1=provider1,api1=provider2,api2=provider3. Where there can be multiple providers per API.",
-        )
+        add_run_arguments(self.parser)
 
     def _run_stack_run_cmd(self, args: argparse.Namespace) -> None:
-        import yaml
-
-        from ogx.core.configure import parse_and_maybe_upgrade_config
-
-        if args.enable_ui:
-            self._start_ui_development_server(args.port)
-
-        if args.config:
-            try:
-                from ogx.core.utils.config_resolution import resolve_config_or_distro
-
-                config_file = resolve_config_or_distro(args.config)
-            except ValueError as e:
-                self.parser.error(str(e))
-        elif args.providers:
-            distro_dir = DISTRIBS_BASE_DIR / "providers-run"
-            os.makedirs(distro_dir, exist_ok=True)
-            try:
-                run_config = run_config_from_dynamic_config_spec(
-                    dynamic_config_spec=args.providers,
-                    distro_dir=distro_dir,
-                    distro_name="providers-run",
-                )
-            except ValueError as e:
-                cprint(str(e), color="red", file=sys.stderr)
-                sys.exit(1)
-            config_dict = run_config.model_dump(mode="json")
-
-            config_file = distro_dir / "config.yaml"
-            logger.info("Writing generated config to", config_file=config_file)
-            with open(config_file, "w") as f:
-                yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
-
-        else:
-            config_file = None
-
-        if config_file:
-            logger.info("Using stack configuration", config_file=config_file)
-
-            try:
-                config_dict = yaml.safe_load(config_file.read_text())
-            except yaml.parser.ParserError as e:
-                self.parser.error(f"failed to load config file '{config_file}':\n {e}")
-
-            try:
-                config = parse_and_maybe_upgrade_config(config_dict)
-                # Create external_providers_dir if it's specified and doesn't exist
-                if config.external_providers_dir and not os.path.exists(str(config.external_providers_dir)):
-                    os.makedirs(str(config.external_providers_dir), exist_ok=True)
-            except AttributeError as e:
-                self.parser.error(f"failed to parse config file '{config_file}':\n {e}")
-
-        self._uvicorn_run(config_file, args)
-
-    def _uvicorn_run(self, config_file: Path | None, args: argparse.Namespace) -> None:
-        if not config_file:
-            self.parser.error("Config file is required")
-
-        config_file = resolve_config_or_distro(str(config_file))
-        with open(config_file) as fp:
-            config_contents = yaml.safe_load(fp)
-            config = StackConfig(**cast_distro_name_to_string(replace_env_vars(config_contents)))
-
-        port = args.port or config.server.port
-        workers = config.server.workers
-
-        # Dual-stack binding (IPv4+IPv6) depends on worker count:
-        # - workers>1: use "::" (creates single dual-stack socket)
-        # - workers=1: use "" (creates separate IPv4 and IPv6 sockets)
-        host = ""
-        if config.server.host:
-            host = config.server.host
-        elif workers and workers > 1:
-            host = "::"
-
-        # Set the config file in environment so create_app can find it
-        os.environ["OGX_CONFIG"] = str(config_file)
-
-        # Let create_app() handle logging setup instead of passing config to uvicorn
-        uvicorn_config = {
-            "factory": True,
-            "host": host,
-            "port": port,
-            "lifespan": "on",
-            "log_level": logger.getEffectiveLevel(),
-            "workers": workers,
-        }
-
-        keyfile = config.server.tls_keyfile
-        certfile = config.server.tls_certfile
-        if keyfile and certfile:
-            uvicorn_config["ssl_keyfile"] = config.server.tls_keyfile
-            uvicorn_config["ssl_certfile"] = config.server.tls_certfile
-            if config.server.tls_cafile:
-                uvicorn_config["ssl_ca_certs"] = config.server.tls_cafile
-                uvicorn_config["ssl_cert_reqs"] = ssl.CERT_REQUIRED
-
-            logger.info(
-                "HTTPS enabled with certificates", keyfile=keyfile, certfile=certfile, cafile=config.server.tls_cafile
-            )
-        else:
-            logger.info("HTTPS enabled with certificates", keyfile=keyfile, certfile=certfile)
-
-        logger.info("Listening on", host=host, port=port)
-
-        # We need to catch KeyboardInterrupt because uvicorn's signal handling
-        # re-raises SIGINT signals using signal.raise_signal(), which Python
-        # converts to KeyboardInterrupt. Without this catch, we'd get a confusing
-        # stack trace when using Ctrl+C or kill -2 (SIGINT).
-        # SIGTERM (kill -15) works fine without this because Python doesn't
-        # have a default handler for it.
-        #
-        # Another approach would be to ignore SIGINT entirely - let uvicorn handle it through its own
-        # signal handling but this is quite intrusive and not worth the effort.
-        try:
-            uvicorn.run("ogx.core.server.server:create_app", **uvicorn_config)  # type: ignore[arg-type]
-        except OSError as e:
-            if e.errno in (97, 99):  # Address family not supported / Cannot assign requested address
-                logger.error(
-                    f"Failed to bind to {host}:{port}. "
-                    "If you're on an IPv4-only system, set 'server.host: \"0.0.0.0\"' in your config."
-                )
-                raise
-            raise
-        except (KeyboardInterrupt, SystemExit):
-            logger.info("Received interrupt signal, shutting down gracefully...")
-
-    def _start_ui_development_server(self, stack_server_port: int) -> None:
-        logger.info("Attempting to start UI development server...")
-        # Check if npm is available
-        npm_check = subprocess.run(["npm", "--version"], capture_output=True, text=True, check=False)
-        if npm_check.returncode != 0:
-            logger.warning(
-                "npm command not found or not executable, UI development server will not be started",
-                error=npm_check.stderr,
-            )
-            return
-
-        ui_dir = REPO_ROOT / "ogx_ui"
-        logs_dir = UI_LOGS_DIR
-        try:
-            # Create logs directory if it doesn't exist
-            logs_dir.mkdir(parents=True, exist_ok=True)
-
-            ui_stdout_log_path = logs_dir / "stdout.log"
-            ui_stderr_log_path = logs_dir / "stderr.log"
-
-            # Open log files in append mode
-            stdout_log_file = open(ui_stdout_log_path, "a")
-            stderr_log_file = open(ui_stderr_log_path, "a")
-
-            process = subprocess.Popen(
-                ["npm", "run", "dev"],
-                cwd=str(ui_dir),
-                stdout=stdout_log_file,
-                stderr=stderr_log_file,
-                env={**os.environ, "NEXT_PUBLIC_OGX_BASE_URL": f"http://localhost:{stack_server_port}"},
-            )
-            logger.info("UI development server process started", ui_dir=ui_dir, pid=process.pid)
-            logger.info("UI server logs", stdout=ui_stdout_log_path, stderr=ui_stderr_log_path)
-            logger.info("UI will be available", port=os.getenv("OGX_UI_PORT", 8322))
-
-        except FileNotFoundError:
-            logger.error(
-                "Failed to start UI development server: 'npm' command not found. Make sure npm is installed and in your PATH."
-            )
-        except Exception as e:
-            logger.error("Failed to start UI development server", ui_dir=ui_dir, error=str(e))
+        warnings.warn(
+            "'ogx stack run' is deprecated and will be removed in a future release. Use 'ogx run' instead.",
+            FutureWarning,
+            stacklevel=1,
+        )
+        run_stack_cmd(args, self.parser)

--- a/tests/unit/cli/test_stack_config.py
+++ b/tests/unit/cli/test_stack_config.py
@@ -280,7 +280,7 @@ def test_providers_flag_generates_config_with_api_keys():
     )
 
     # Mock _uvicorn_run to prevent starting a server
-    with patch.object(stack_run, "_uvicorn_run"):
+    with patch("ogx.cli.stack.run._uvicorn_run"):
         stack_run._run_stack_run_cmd(args)
 
     # Read the generated config file

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -4,27 +4,29 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) The OGX Contributors.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
-"""Unit tests for `ogx letsgo` CLI command."""
+"""Unit tests for `ogx letsgo` and `ogx stack letsgo` CLI commands."""
 
 import argparse
+import warnings
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
-from ogx.cli.stack.lets_go import StackLetsGo, _ProbeStatus
+from ogx.cli.letsgo import LetsGo
+from ogx.cli.stack.lets_go import StackLetsGo, _probe_endpoint, _ProbeStatus
 
 
 @pytest.fixture
 def lets_go() -> StackLetsGo:
     subparsers = argparse.ArgumentParser().add_subparsers()
     return StackLetsGo(subparsers)
+
+
+@pytest.fixture
+def top_level_letsgo() -> LetsGo:
+    subparsers = argparse.ArgumentParser().add_subparsers()
+    return LetsGo(subparsers)
 
 
 class TestArguments:
@@ -67,11 +69,38 @@ class TestArguments:
         assert args.port == 9999
 
 
-class TestProbeEndpoint:
-    def test_empty_base_url_returns_unreachable(self, lets_go: StackLetsGo):
-        assert lets_go._probe_endpoint("", "models", False, None) == _ProbeStatus.UNREACHABLE
+class TestTopLevelLetsGoArguments:
+    def test_defaults(self, top_level_letsgo: LetsGo):
+        args = top_level_letsgo.parser.parse_args([])
+        assert args.port == 8321
+        assert args.enable_ui is False
+        assert args.persist_config is False
+        assert args.providers_override is None
 
-    def test_url_construction_preserves_v1_path(self, lets_go: StackLetsGo):
+    def test_all_options(self, top_level_letsgo: LetsGo):
+        args = top_level_letsgo.parser.parse_args(
+            [
+                "--port",
+                "9000",
+                "--enable-ui",
+                "--persist-config",
+                "--providers-override",
+                "inference=remote::ollama",
+                "--skip-install-deps",
+            ]
+        )
+        assert args.port == 9000
+        assert args.enable_ui is True
+        assert args.persist_config is True
+        assert args.providers_override == "inference=remote::ollama"
+        assert args.skip_install_deps is True
+
+
+class TestProbeEndpoint:
+    def test_empty_base_url_returns_unreachable(self):
+        assert _probe_endpoint("", "models", False, None) == _ProbeStatus.UNREACHABLE
+
+    def test_url_construction_preserves_v1_path(self):
         """Without a trailing slash urljoin strips the last path segment."""
         captured: list[str] = []
 
@@ -80,84 +109,70 @@ class TestProbeEndpoint:
             raise OSError("offline")
 
         with patch("ogx.cli.stack.lets_go.httpx.get", side_effect=fake_get):
-            lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None)
+            _probe_endpoint("http://localhost:11434/v1", "models", False, None)
 
         assert captured[0] == "http://localhost:11434/v1/models"
 
-    def test_ok_on_200(self, lets_go: StackLetsGo):
+    def test_ok_on_200(self):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 200
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.OK
+            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.OK
 
-    def test_ok_on_204(self, lets_go: StackLetsGo):
+    def test_ok_on_204(self):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 204
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert lets_go._probe_endpoint("http://localhost:8000/v1", "health", False, None) == _ProbeStatus.OK
+            assert _probe_endpoint("http://localhost:8000/v1", "health", False, None) == _ProbeStatus.OK
 
-    def test_no_key_when_env_var_unset(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+    def test_no_key_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        result = lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
+        result = _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
         assert result == _ProbeStatus.NO_KEY
 
-    def test_no_key_when_key_env_is_none(self, lets_go: StackLetsGo):
-        result = lets_go._probe_endpoint("https://example.com/v1", "models", True, None)
+    def test_no_key_when_key_env_is_none(self):
+        result = _probe_endpoint("https://example.com/v1", "models", True, None)
         assert result == _ProbeStatus.NO_KEY
 
-    def test_auth_on_401(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+    def test_auth_on_401(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 401
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert (
-                lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
-                == _ProbeStatus.AUTH
-            )
+            assert _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY") == _ProbeStatus.AUTH
 
-    def test_auth_on_403(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+    def test_auth_on_403(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 403
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert (
-                lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
-                == _ProbeStatus.AUTH
-            )
+            assert _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY") == _ProbeStatus.AUTH
 
-    def test_unreachable_on_400(self, lets_go: StackLetsGo):
+    def test_unreachable_on_400(self):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 400
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert (
-                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-            )
+            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
 
-    def test_unreachable_on_500(self, lets_go: StackLetsGo):
+    def test_unreachable_on_500(self):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 500
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert (
-                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-            )
+            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
 
-    def test_unreachable_on_connection_error(self, lets_go: StackLetsGo):
+    def test_unreachable_on_connection_error(self):
         with patch("ogx.cli.stack.lets_go.httpx.get", side_effect=OSError("connection refused")):
-            assert (
-                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-            )
+            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
 
-    def test_unreachable_on_timeout(self, lets_go: StackLetsGo):
+    def test_unreachable_on_timeout(self):
         with patch("ogx.cli.stack.lets_go.httpx.get", side_effect=httpx.TimeoutException("timeout")):
-            assert (
-                lets_go._probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-            )
+            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
 
-    def test_extra_headers_forwarded(self, lets_go: StackLetsGo):
+    def test_extra_headers_forwarded(self):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 200
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
-            lets_go._probe_endpoint(
+            _probe_endpoint(
                 "https://api.anthropic.com/v1",
                 "models",
                 False,
@@ -166,38 +181,43 @@ class TestProbeEndpoint:
             )
         assert mock_get.call_args.kwargs["headers"].get("anthropic-version") == "2023-06-01"
 
-    def test_auth_headers_set_when_key_present(self, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch):
+    def test_auth_headers_set_when_key_present(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 200
         with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
-            lets_go._probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
+            _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
         headers = mock_get.call_args.kwargs["headers"]
         assert headers["Authorization"] == "Bearer sk-secret"
         assert headers["x-api-key"] == "sk-secret"
 
 
 class TestAutodetect:
-    @patch("ogx.cli.stack.lets_go.StackLetsGo._probe_endpoint", return_value=_ProbeStatus.UNREACHABLE)
-    def test_autodetect_no_providers(self, mock_probe: MagicMock, lets_go: StackLetsGo):
-        # inline providers are always included even when all probes fail
-        parts = lets_go._autodetect_providers().split(",")
+    @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.UNREACHABLE)
+    def test_autodetect_no_providers(self, mock_probe: MagicMock):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
+        parts = _autodetect_providers().split(",")
         assert "files=inline::localfs" in parts
         assert "vector_io=inline::faiss" in parts
         assert "tool_runtime=inline::file-search" in parts
         assert "responses=inline::builtin" in parts
 
-    @patch("ogx.cli.stack.lets_go.StackLetsGo._probe_endpoint", return_value=_ProbeStatus.NO_KEY)
-    def test_no_key_providers_excluded(self, mock_probe: MagicMock, lets_go: StackLetsGo):
-        parts = lets_go._autodetect_providers().split(",")
+    @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.NO_KEY)
+    def test_no_key_providers_excluded(self, mock_probe: MagicMock):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
+        parts = _autodetect_providers().split(",")
         assert "files=inline::localfs" in parts
         assert "vector_io=inline::faiss" in parts
         assert "tool_runtime=inline::file-search" in parts
         assert "responses=inline::builtin" in parts
 
-    @patch("ogx.cli.stack.lets_go.StackLetsGo._probe_endpoint", return_value=_ProbeStatus.OK)
-    def test_autodetect_all_ok(self, mock_probe: MagicMock, lets_go: StackLetsGo):
-        result = lets_go._autodetect_providers()
+    @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.OK)
+    def test_autodetect_all_ok(self, mock_probe: MagicMock):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
+        result = _autodetect_providers()
         parts = result.split(",")
         assert "inference=remote::ollama" in parts
         assert "inference=remote::anthropic" in parts
@@ -205,8 +225,10 @@ class TestAutodetect:
         assert "responses=inline::builtin" in parts
         assert len(parts) == 11  # 6 probed + 5 inline
 
-    @patch("ogx.cli.stack.lets_go.StackLetsGo._probe_endpoint")
-    def test_autodetect_only_ollama(self, mock_probe: MagicMock, lets_go: StackLetsGo):
+    @patch("ogx.cli.stack.lets_go._probe_endpoint")
+    def test_autodetect_only_ollama(self, mock_probe: MagicMock):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
         def side_effect(
             base_url: str, probe_path: str, requires_key: bool, key_env: object, extra_headers: object = None
         ) -> _ProbeStatus:
@@ -215,16 +237,16 @@ class TestAutodetect:
             return _ProbeStatus.UNREACHABLE
 
         mock_probe.side_effect = side_effect
-        parts = lets_go._autodetect_providers().split(",")
+        parts = _autodetect_providers().split(",")
         assert "inference=remote::ollama" in parts
         assert "files=inline::localfs" in parts
         assert "responses=inline::builtin" in parts
         assert len(parts) == 6  # 1 inference + 5 inline
 
-    @patch("ogx.cli.stack.lets_go.StackLetsGo._probe_endpoint")
-    def test_autodetect_uses_env_var_base_url(
-        self, mock_probe: MagicMock, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch
-    ):
+    @patch("ogx.cli.stack.lets_go._probe_endpoint")
+    def test_autodetect_uses_env_var_base_url(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
         monkeypatch.setenv("OLLAMA_URL", "http://myhost:11434/v1")
         captured: list[str] = []
 
@@ -235,13 +257,15 @@ class TestAutodetect:
             return _ProbeStatus.UNREACHABLE
 
         mock_probe.side_effect = side_effect
-        lets_go._autodetect_providers()
+        _autodetect_providers()
         assert captured[0] == "http://myhost:11434/v1"
 
-    @patch("ogx.cli.stack.lets_go.StackLetsGo._probe_endpoint")
+    @patch("ogx.cli.stack.lets_go._probe_endpoint")
     def test_autodetect_result_order_matches_candidate_order(
-        self, mock_probe: MagicMock, lets_go: StackLetsGo, monkeypatch: pytest.MonkeyPatch
+        self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch
     ):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
         def side_effect(
@@ -252,27 +276,33 @@ class TestAutodetect:
             return _ProbeStatus.UNREACHABLE
 
         mock_probe.side_effect = side_effect
-        parts = lets_go._autodetect_providers().split(",")
+        parts = _autodetect_providers().split(",")
         assert parts.index("inference=remote::ollama") < parts.index("inference=remote::openai")
 
 
 class TestRunCommand:
     def test_no_inference_provider_exits(self, lets_go: StackLetsGo):
         args = lets_go.parser.parse_args([])
-        # files-only spec has no inference provider — should exit
-        with patch.object(
-            lets_go,
-            "_autodetect_providers",
-            return_value="files=inline::localfs,vector_io=inline::faiss,tool_runtime=inline::file-search,responses=inline::builtin",
+        with (
+            patch(
+                "ogx.cli.stack.lets_go._autodetect_providers",
+                return_value="files=inline::localfs,vector_io=inline::faiss,tool_runtime=inline::file-search,responses=inline::builtin",
+            ),
+            warnings.catch_warnings(),
+            pytest.raises(SystemExit),
         ):
-            with pytest.raises(SystemExit):
-                lets_go._run_stack_lets_go_cmd(args)
+            warnings.simplefilter("ignore", FutureWarning)
+            lets_go._run_stack_lets_go_cmd(args)
 
     def test_empty_spec_exits(self, lets_go: StackLetsGo):
         args = lets_go.parser.parse_args([])
-        with patch.object(lets_go, "_autodetect_providers", return_value=""):
-            with pytest.raises(SystemExit):
-                lets_go._run_stack_lets_go_cmd(args)
+        with (
+            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=""),
+            warnings.catch_warnings(),
+            pytest.raises(SystemExit),
+        ):
+            warnings.simplefilter("ignore", FutureWarning)
+            lets_go._run_stack_lets_go_cmd(args)
 
     @patch("ogx.cli.stack.lets_go._uvicorn_run")
     @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
@@ -289,10 +319,14 @@ class TestRunCommand:
         mock_cfg.model_dump.return_value = {}
         mock_build_config.return_value = mock_cfg
 
-        with patch.object(lets_go, "_autodetect_providers") as mock_detect:
-            with patch("builtins.open", MagicMock()):
-                with patch("ogx.cli.stack.lets_go.yaml.dump"):
-                    lets_go._run_stack_lets_go_cmd(args)
+        with (
+            patch("ogx.cli.stack.lets_go._autodetect_providers") as mock_detect,
+            patch("builtins.open", MagicMock()),
+            patch("ogx.cli.stack.lets_go.yaml.dump"),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", FutureWarning)
+            lets_go._run_stack_lets_go_cmd(args)
         mock_detect.assert_not_called()
 
     @patch("ogx.cli.stack.lets_go._uvicorn_run")
@@ -310,10 +344,14 @@ class TestRunCommand:
         mock_cfg.model_dump.return_value = {}
         mock_build_config.return_value = mock_cfg
 
-        with patch.object(lets_go, "_autodetect_providers", return_value="inference=remote::ollama"):
-            with patch("builtins.open", MagicMock()):
-                with patch("ogx.cli.stack.lets_go.yaml.dump"):
-                    lets_go._run_stack_lets_go_cmd(args)
+        with (
+            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value="inference=remote::ollama"),
+            patch("builtins.open", MagicMock()),
+            patch("ogx.cli.stack.lets_go.yaml.dump"),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", FutureWarning)
+            lets_go._run_stack_lets_go_cmd(args)
 
         mock_build_config.assert_called_once()
         assert mock_build_config.call_args.kwargs["dynamic_config_spec"] == "inference=remote::ollama"
@@ -336,10 +374,14 @@ class TestRunCommand:
         mock_build_config.return_value = mock_cfg
         mock_subprocess.return_value = MagicMock(returncode=0)
 
-        with patch.object(lets_go, "_autodetect_providers", return_value="inference=remote::ollama"):
-            with patch("builtins.open", MagicMock()):
-                with patch("ogx.cli.stack.lets_go.yaml.dump"):
-                    lets_go._run_stack_lets_go_cmd(args)
+        with (
+            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value="inference=remote::ollama"),
+            patch("builtins.open", MagicMock()),
+            patch("ogx.cli.stack.lets_go.yaml.dump"),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", FutureWarning)
+            lets_go._run_stack_lets_go_cmd(args)
 
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args[0][0]
@@ -363,9 +405,41 @@ class TestRunCommand:
         mock_cfg.model_dump.return_value = {}
         mock_build_config.return_value = mock_cfg
 
-        with patch.object(lets_go, "_autodetect_providers", return_value="inference=remote::ollama"):
-            with patch("builtins.open", MagicMock()):
-                with patch("ogx.cli.stack.lets_go.yaml.dump"):
-                    lets_go._run_stack_lets_go_cmd(args)
+        with (
+            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value="inference=remote::ollama"),
+            patch("builtins.open", MagicMock()),
+            patch("ogx.cli.stack.lets_go.yaml.dump"),
+            warnings.catch_warnings(),
+        ):
+            warnings.simplefilter("ignore", FutureWarning)
+            lets_go._run_stack_lets_go_cmd(args)
 
         mock_subprocess.assert_not_called()
+
+
+class TestDeprecation:
+    def test_stack_letsgo_emits_deprecation_warning(self, lets_go: StackLetsGo):
+        with (
+            patch("ogx.cli.stack.lets_go.run_letsgo_cmd"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            args = lets_go.parser.parse_args([])
+            lets_go._run_stack_lets_go_cmd(args)
+
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert "deprecated" in str(future_warnings[0].message)
+        assert "ogx letsgo" in str(future_warnings[0].message)
+
+    def test_top_level_letsgo_no_deprecation_warning(self, top_level_letsgo: LetsGo):
+        with (
+            patch("ogx.cli.letsgo.run_letsgo_cmd"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            args = top_level_letsgo.parser.parse_args([])
+            top_level_letsgo._run_cmd(args)
+
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 0

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -274,14 +274,14 @@ class TestRunCommand:
             with pytest.raises(SystemExit):
                 lets_go._run_stack_lets_go_cmd(args)
 
-    @patch("ogx.cli.stack.lets_go.StackRun")
+    @patch("ogx.cli.stack.lets_go._uvicorn_run")
     @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
     @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
     def test_providers_override_skips_autodetect(
         self,
         mock_build_config: MagicMock,
         mock_get_deps: MagicMock,
-        mock_stack_run_cls: MagicMock,
+        mock_uvicorn_run: MagicMock,
         lets_go: StackLetsGo,
     ):
         args = lets_go.parser.parse_args(["--providers-override", "inference=remote::ollama"])
@@ -295,14 +295,14 @@ class TestRunCommand:
                     lets_go._run_stack_lets_go_cmd(args)
         mock_detect.assert_not_called()
 
-    @patch("ogx.cli.stack.lets_go.StackRun")
+    @patch("ogx.cli.stack.lets_go._uvicorn_run")
     @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
     @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
     def test_run_command_uses_autodetected_providers(
         self,
         mock_build_config: MagicMock,
         mock_get_deps: MagicMock,
-        mock_stack_run_cls: MagicMock,
+        mock_uvicorn_run: MagicMock,
         lets_go: StackLetsGo,
     ):
         args = lets_go.parser.parse_args([])
@@ -318,7 +318,7 @@ class TestRunCommand:
         mock_build_config.assert_called_once()
         assert mock_build_config.call_args.kwargs["dynamic_config_spec"] == "inference=remote::ollama"
 
-    @patch("ogx.cli.stack.lets_go.StackRun")
+    @patch("ogx.cli.stack.lets_go._uvicorn_run")
     @patch("ogx.cli.stack.lets_go.subprocess.run")
     @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=(["httpx", "faiss-cpu"], [], []))
     @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
@@ -327,7 +327,7 @@ class TestRunCommand:
         mock_build_config: MagicMock,
         mock_get_deps: MagicMock,
         mock_subprocess: MagicMock,
-        mock_stack_run_cls: MagicMock,
+        mock_uvicorn_run: MagicMock,
         lets_go: StackLetsGo,
     ):
         args = lets_go.parser.parse_args([])
@@ -346,7 +346,7 @@ class TestRunCommand:
         assert "httpx" in call_args
         assert "faiss-cpu" in call_args
 
-    @patch("ogx.cli.stack.lets_go.StackRun")
+    @patch("ogx.cli.stack.lets_go._uvicorn_run")
     @patch("ogx.cli.stack.lets_go.subprocess.run")
     @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=(["httpx"], [], []))
     @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
@@ -355,7 +355,7 @@ class TestRunCommand:
         mock_build_config: MagicMock,
         mock_get_deps: MagicMock,
         mock_subprocess: MagicMock,
-        mock_stack_run_cls: MagicMock,
+        mock_uvicorn_run: MagicMock,
         lets_go: StackLetsGo,
     ):
         args = lets_go.parser.parse_args(["--skip-install-deps"])

--- a/tests/unit/cli/test_stack_run.py
+++ b/tests/unit/cli/test_stack_run.py
@@ -5,20 +5,24 @@
 # the root directory of this source tree.
 
 """
-Unit tests for `ogx stack run` CLI command.
+Unit tests for `ogx run` and `ogx stack run` CLI commands.
 
 Categories:
   - Arguments: --providers flag is registered and parsed correctly
   - Delegation: --providers delegates to run_config_from_dynamic_config_spec
   - Error propagation: ValueError from the unified impl is printed and causes exit
+  - Deprecation: `ogx stack run` emits a FutureWarning
+  - Top-level run: `ogx run` works without the `stack` subcommand
 """
 
 import argparse
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ogx.cli.run import Run
 from ogx.cli.stack.run import StackRun
 
 
@@ -26,6 +30,12 @@ from ogx.cli.stack.run import StackRun
 def stack_run() -> StackRun:
     subparsers = argparse.ArgumentParser().add_subparsers()
     return StackRun(subparsers)
+
+
+@pytest.fixture
+def top_level_run() -> Run:
+    subparsers = argparse.ArgumentParser().add_subparsers()
+    return Run(subparsers)
 
 
 class TestArguments:
@@ -42,6 +52,26 @@ class TestArguments:
         assert args.providers == "inference=fireworks,safety=llama-guard"
 
 
+class TestTopLevelRunArguments:
+    def test_providers_flag_registered(self, top_level_run: Run):
+        args = top_level_run.parser.parse_args(["--providers", "inference=fireworks"])
+        assert args.providers == "inference=fireworks"
+
+    def test_providers_default_is_none(self, top_level_run: Run):
+        args = top_level_run.parser.parse_args([])
+        assert args.providers is None
+
+    def test_config_positional(self, top_level_run: Run):
+        args = top_level_run.parser.parse_args(["starter"])
+        assert args.config == "starter"
+
+    def test_all_options(self, top_level_run: Run):
+        args = top_level_run.parser.parse_args(["starter", "--port", "9000", "--enable-ui"])
+        assert args.config == "starter"
+        assert args.port == 9000
+        assert args.enable_ui is True
+
+
 class TestDelegation:
     def test_providers_calls_dynamic_config_spec(self, stack_run: StackRun, tmp_path: Path):
         mock_config = MagicMock()
@@ -54,8 +84,10 @@ class TestDelegation:
                 "ogx.core.configure.parse_and_maybe_upgrade_config",
                 return_value=MagicMock(external_providers_dir=None),
             ),
-            patch.object(stack_run, "_uvicorn_run"),
+            patch("ogx.cli.stack.run._uvicorn_run"),
+            warnings.catch_warnings(),
         ):
+            warnings.simplefilter("ignore", FutureWarning)
             args = stack_run.parser.parse_args(["--providers", "inference=fireworks"])
             stack_run._run_stack_run_cmd(args)
 
@@ -76,13 +108,37 @@ class TestDelegation:
                 "ogx.core.configure.parse_and_maybe_upgrade_config",
                 return_value=MagicMock(external_providers_dir=None),
             ),
-            patch.object(stack_run, "_uvicorn_run"),
+            patch("ogx.cli.stack.run._uvicorn_run"),
+            warnings.catch_warnings(),
         ):
+            warnings.simplefilter("ignore", FutureWarning)
             args = stack_run.parser.parse_args(["--providers", "inference=fireworks"])
             stack_run._run_stack_run_cmd(args)
 
         config_file = tmp_path / "providers-run" / "config.yaml"
         assert config_file.exists()
+
+    def test_top_level_run_delegates(self, top_level_run: Run, tmp_path: Path):
+        mock_config = MagicMock()
+        mock_config.model_dump.return_value = {}
+
+        with (
+            patch("ogx.cli.stack.run.run_config_from_dynamic_config_spec", return_value=mock_config) as mock_fn,
+            patch("ogx.cli.stack.run.DISTRIBS_BASE_DIR", tmp_path),
+            patch(
+                "ogx.core.configure.parse_and_maybe_upgrade_config",
+                return_value=MagicMock(external_providers_dir=None),
+            ),
+            patch("ogx.cli.stack.run._uvicorn_run"),
+        ):
+            args = top_level_run.parser.parse_args(["--providers", "inference=fireworks"])
+            top_level_run._run_cmd(args)
+
+        mock_fn.assert_called_once_with(
+            dynamic_config_spec="inference=fireworks",
+            distro_dir=tmp_path / "providers-run",
+            distro_name="providers-run",
+        )
 
 
 class TestErrorPropagation:
@@ -93,9 +149,39 @@ class TestErrorPropagation:
                 side_effect=ValueError("Failed to parse provider spec 'bad'. Expected format: api=provider"),
             ),
             patch("ogx.cli.stack.run.DISTRIBS_BASE_DIR", tmp_path),
+            warnings.catch_warnings(),
             pytest.raises(SystemExit) as exc_info,
         ):
+            warnings.simplefilter("ignore", FutureWarning)
             args = stack_run.parser.parse_args(["--providers", "bad"])
             stack_run._run_stack_run_cmd(args)
 
         assert exc_info.value.code == 1
+
+
+class TestDeprecation:
+    def test_stack_run_emits_deprecation_warning(self, stack_run: StackRun, tmp_path: Path):
+        with (
+            patch("ogx.cli.stack.run.run_stack_cmd"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            args = stack_run.parser.parse_args(["starter"])
+            stack_run._run_stack_run_cmd(args)
+
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 1
+        assert "deprecated" in str(future_warnings[0].message)
+        assert "ogx run" in str(future_warnings[0].message)
+
+    def test_top_level_run_no_deprecation_warning(self, top_level_run: Run, tmp_path: Path):
+        with (
+            patch("ogx.cli.run.run_stack_cmd"),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            args = top_level_run.parser.parse_args(["starter"])
+            top_level_run._run_cmd(args)
+
+        future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
+        assert len(future_warnings) == 0


### PR DESCRIPTION
# What does this PR do?

Adds `ogx run <distro>` and `ogx letsgo` as top-level shortcuts so users no longer need the intermediate `stack` subcommand. The existing `ogx stack run` and `ogx stack letsgo` continue to work but now emit a `FutureWarning` directing users to the shorter forms.

For both commands, the implementation logic is extracted from the class instance methods into shared module-level functions so both entry points share the same code without duplication. The `lets_go` command's internal helper methods (`_autodetect_providers`, `_probe_endpoint`, `_install_provider_deps`) are also extracted to module-level functions.

## Test Plan

All 73 CLI unit tests pass, including new tests for both commands covering argument parsing, delegation, deprecation warnings, and the absence of warnings on the new top-level variants.

```bash
uv run pytest tests/unit/cli/ -x --tb=short -v
```

Output:
```
73 passed, 1 warning in 0.37s
```

Pre-commit checks all pass (`ruff`, `mypy`, logging guards, etc.).