### PR TITLE
fix(vector_io): improve error reporting for file processor rejections

### DIFF
--- a/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
@@ -15,7 +15,7 @@ from collections.abc import AsyncIterator
 from enum import StrEnum
 from typing import Annotated, Any
 
-from fastapi import Body
+from fastapi import Body, HTTPException
 
 from ogx.core.datatypes import VectorStoresConfig
 from ogx.core.id_generation import generate_object_id
@@ -1057,8 +1057,21 @@ class OpenAIVectorStoreMixin(ABC):
                     )
                 )
                 vector_store_file_object.status = "completed"
+        except HTTPException as e:
+            logger.warning(
+                "Failed to attach file to vector store",
+                file_id=file_id,
+                vector_store_id=vector_store_id,
+                status_code=e.status_code,
+                detail=e.detail,
+            )
+            vector_store_file_object.status = "failed"
+            vector_store_file_object.last_error = VectorStoreFileLastError(
+                code="unsupported_file" if e.status_code == 422 else "server_error",
+                message=e.detail if isinstance(e.detail, str) else str(e.detail),
+            )
         except Exception as e:
-            logger.exception("Error attaching file to vector store")
+            logger.exception("Failed to attach file to vector store")
             vector_store_file_object.status = "failed"
             vector_store_file_object.last_error = VectorStoreFileLastError(
                 code="server_error",


### PR DESCRIPTION
# What does this PR do?

Improves error reporting when a file processor rejects a file during vector store attachment. Previously, all exceptions were caught with a generic `except Exception` handler that always set `code="server_error"`. This adds a specific `HTTPException` handler that maps 422 responses to `code="unsupported_file"`, giving callers a meaningful error code when a file type is not supported.

## Test Plan

1. Verify the change passes type checking:
```bash
uv run mypy src/ogx/providers/utils/memory/openai_vector_store_mixin.py
```

2. Run unit tests:
```bash
uv run pytest tests/unit/ -x --tb=short
```

3. Run pre-commit checks:
```bash
uv run pre-commit run --all-files
```