### PR TITLE
docs: add Codex CLI integration blog post and fix docs page

### DIFF
--- a/docs/blog/2026-05-19-codex-cli-integration.md
+++ b/docs/blog/2026-05-19-codex-cli-integration.md
@@ -29,10 +29,7 @@ OGX acts as a proxy that Codex already knows how to talk to. No patches to Codex
 
 The architecture is straightforward:
 
-```text
-Codex CLI  -->  OGX Server  -->  LLM Provider
-(Responses API)   (translates)     (OpenAI, Ollama, vLLM, Bedrock, etc.)
-```
+![Codex CLI to OGX to LLM Provider flow](./images/codex-cli-flow.svg)
 
 Codex sends Responses API requests to OGX. OGX routes them to whatever inference provider you've configured, translating formats where needed. Codex doesn't know or care what's behind OGX.
 

--- a/docs/blog/2026-05-19-codex-cli-integration.md
+++ b/docs/blog/2026-05-19-codex-cli-integration.md
@@ -1,0 +1,137 @@
+---
+slug: codex-cli-integration
+title: "Use Codex CLI with Any Model Through OGX"
+authors: [leseb, franciscojavierarceo]
+tags: [codex, openai, cli, integration, tutorial]
+date: 2026-05-19
+---
+
+OpenAI's [Codex CLI](https://github.com/openai/codex) is a terminal-native coding agent. It reads your codebase, proposes changes, runs commands, and iterates, all from your shell. The problem: it only talks to OpenAI's API.
+
+OGX fixes that. By placing OGX between Codex and your inference provider, you get Codex's coding workflows with any model OGX supports: Llama via Ollama, Claude via Bedrock, Mistral via vLLM, or OpenAI itself with conversation compaction on top.
+
+This post walks through setup, configuration, and what to expect from this alpha integration.
+
+<!--truncate-->
+
+## Why run Codex through OGX
+
+Codex CLI is opinionated about its API surface. It speaks the OpenAI Responses API and expects a specific wire format. That's fine if you're paying OpenAI directly, but limiting if you want to:
+
+- **Use open models** running on your own hardware via Ollama or vLLM
+- **Route through a corporate proxy** that standardizes API access
+- **Get conversation compaction** so long coding sessions don't blow past context limits
+- **Switch models without reconfiguring Codex** by changing the OGX provider instead
+
+OGX acts as a proxy that Codex already knows how to talk to. No patches to Codex, no forks. Just a config change.
+
+## How the proxy chain works
+
+The architecture is straightforward:
+
+```text
+Codex CLI  -->  OGX Server  -->  LLM Provider
+(Responses API)   (translates)     (OpenAI, Ollama, vLLM, Bedrock, etc.)
+```
+
+Codex sends Responses API requests to OGX. OGX routes them to whatever inference provider you've configured, translating formats where needed. Codex doesn't know or care what's behind OGX.
+
+This means tool execution (shell commands, file reads/writes, code generation) still happens locally in Codex. OGX only handles the inference routing.
+
+## Setup
+
+Three steps. Assumes you have OGX and Codex CLI already installed.
+
+### 1. Start OGX
+
+```bash
+export OPENAI_API_KEY="your-key-here"
+ogx stack run starter
+```
+
+For Ollama instead of OpenAI:
+
+```bash
+OLLAMA_URL=http://localhost:11434/v1 ogx stack run starter
+```
+
+### 2. Configure Codex CLI
+
+Add the following to `~/.codex/config.toml`:
+
+```toml
+model = "openai/gpt-4o"
+model_provider = "ogx"
+
+[model_providers.ogx]
+name = "OpenAI"
+base_url = "http://localhost:8321/v1"
+wire_api = "responses"
+supports_websockets = false
+```
+
+If you're using Ollama, change the model line:
+
+```toml
+model = "ollama/llama3.2:3b"
+```
+
+### 3. Test it
+
+```bash
+codex "Write a hello world function in Python"
+```
+
+If you see Codex generate code and propose changes, the proxy is working.
+
+## Model compatibility
+
+Choose models that are exposed by your OGX server and compatible with the Responses API:
+
+- `openai/gpt-4o`
+- `openai/gpt-4o-mini`
+- `openai/gpt-5.4`
+- `anthropic/claude-3-5-sonnet-20241022`
+- `ollama/llama3.2:3b`
+
+The model ID format depends on which inference provider is backing your OGX server. The prefix (e.g., `openai/`, `ollama/`) tells OGX where to route the request.
+
+Since this setup uses `wire_api = "responses"`, ensure the selected model works with OGX's Responses path.
+
+## What works, what doesn't
+
+This integration is alpha. Here's the honest status.
+
+**Works well:**
+
+- Basic code generation and editing workflows
+- Shell command execution and file operations
+- Multi-turn conversations within a session
+- Conversation compaction for long sessions
+- Streaming responses
+
+**Not yet supported:**
+
+- **Memory persistence**: conversation history doesn't survive between Codex sessions. Each `codex` invocation starts fresh.
+- **Error surfacing**: some provider-specific errors get swallowed by the proxy layer. If Codex hangs or returns empty, check OGX server logs.
+- **Latency**: the extra network hop adds overhead. For local models (Ollama), this is negligible. For remote providers, it's a few hundred milliseconds on top of inference time.
+
+## Troubleshooting
+
+**"Model not found" errors:** check that the model ID includes the provider prefix. `gpt-4o` won't work, `openai/gpt-4o` will.
+
+**Request compression errors:** Codex uses zstd compression by default. Make sure your OGX build supports request decompression. Recent versions do.
+
+**Tool execution failures:** these happen in Codex, not OGX. Check that Codex has proper permissions for the operations it's trying to perform. OGX only handles inference.
+
+**Empty or truncated responses:** check OGX server logs (`ogx` outputs to stderr by default). Provider-specific rate limits or token limits are the usual cause.
+
+## What's next
+
+We're working on closing the gaps in this integration:
+
+- **Memory API integration** for persistent conversation storage across Codex sessions
+- **Better error propagation** so provider failures surface clearly in the Codex UI
+- **Performance optimizations** to reduce proxy overhead
+
+For more details on OGX's provider architecture, see the [Providers Overview](https://ogx-ai.github.io/docs/providers). For Codex CLI documentation, visit the [Codex GitHub repository](https://github.com/openai/codex).

--- a/docs/blog/images/codex-cli-flow.svg
+++ b/docs/blog/images/codex-cli-flow.svg
@@ -1,0 +1,222 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 280" font-family="'Archivo','Public Sans',-apple-system,BlinkMacSystemFont,sans-serif">
+  <style>
+    :root {
+      --bg: #0e1520;
+      --grid-stroke: #fff;
+      --grid-opacity: 0.04;
+      --col-label: #4b6478;
+      --col-divider: #1e2d3d;
+      --flow-stroke: #1a5c5e;
+      --flow-dot: #2dbdc2;
+      --card-bg: #131e2a;
+      --card-stroke: #1e3040;
+      --item-bg: #182838;
+      --item-text: #7fb8c4;
+      --server-bg: #0d1a24;
+      --server-accent: #0d7377;
+      --server-label: #e0f5f5;
+      --section-label: #2dbdc2;
+      --block-bg: #111f2d;
+      --block-stroke: #1a3545;
+      --block-title: #5da8b0;
+      --block-text: #6b8d96;
+      --muted-text: #3d5a6e;
+      --tagline: #3d5a6e;
+      --shadow-opacity: 0.12;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #f8f9fa;
+        --grid-stroke: #000;
+        --grid-opacity: 0.04;
+        --col-label: #6b7d8e;
+        --col-divider: #d8dee4;
+        --flow-stroke: #0d7377;
+        --flow-dot: #0d7377;
+        --card-bg: #ffffff;
+        --card-stroke: #d8dee4;
+        --item-bg: #f0f3f5;
+        --item-text: #2d4a56;
+        --server-bg: #ffffff;
+        --server-accent: #0d7377;
+        --server-label: #ffffff;
+        --section-label: #0b6165;
+        --block-bg: #f5f7f8;
+        --block-stroke: #d8dee4;
+        --block-title: #0b6165;
+        --block-text: #4a6570;
+        --muted-text: #6b7d8e;
+        --tagline: #6b7d8e;
+        --shadow-opacity: 0.06;
+      }
+    }
+  </style>
+  <defs>
+    <filter id="s"><feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#000" flood-opacity="var(--shadow-opacity, 0.12)"/></filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="780" height="280" rx="8" fill="var(--bg)"/>
+
+  <!-- Subtle grid -->
+  <g opacity="var(--grid-opacity)">
+    <pattern id="g" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40,0 L0,0 0,40" fill="none" stroke="var(--grid-stroke)" stroke-width="0.5"/>
+    </pattern>
+    <rect width="780" height="280" fill="url(#g)"/>
+  </g>
+
+  <!-- ========== COLUMN LABELS ========== -->
+  <text x="100" y="28" text-anchor="middle" fill="var(--col-label)" font-size="10" font-weight="700" letter-spacing="1.5">YOUR TERMINAL</text>
+  <text x="390" y="28" text-anchor="middle" fill="var(--col-label)" font-size="10" font-weight="700" letter-spacing="1.5">OGX</text>
+  <text x="665" y="28" text-anchor="middle" fill="var(--col-label)" font-size="10" font-weight="700" letter-spacing="1.5">PROVIDERS</text>
+
+  <!-- Column dividers -->
+  <line x1="220" y1="18" x2="220" y2="255" stroke="var(--col-divider)" stroke-width="1"/>
+  <line x1="540" y1="18" x2="540" y2="255" stroke="var(--col-divider)" stroke-width="1"/>
+
+  <!-- ========== CODEX CLI (left) ========== -->
+  <g filter="url(#s)">
+    <rect x="20" y="44" width="180" height="210" rx="6" fill="var(--card-bg)" stroke="var(--card-stroke)" stroke-width="1"/>
+
+    <!-- Terminal top bar -->
+    <rect x="20" y="44" width="180" height="24" rx="6" fill="var(--item-bg)"/>
+    <rect x="20" y="62" width="180" height="6" fill="var(--item-bg)"/>
+    <circle cx="35" cy="56" r="4" fill="#ff5f57" opacity="0.7"/>
+    <circle cx="49" cy="56" r="4" fill="#ffbd2e" opacity="0.7"/>
+    <circle cx="63" cy="56" r="4" fill="#28c940" opacity="0.7"/>
+    <text x="120" y="60" text-anchor="middle" fill="var(--muted-text)" font-size="8" font-weight="600">codex</text>
+
+    <g transform="translate(32, 78)">
+      <rect width="156" height="24" rx="4" fill="var(--item-bg)"/>
+      <text x="10" y="16" fill="var(--item-text)" font-size="9" font-weight="500">Code generation</text>
+    </g>
+    <g transform="translate(32, 108)">
+      <rect width="156" height="24" rx="4" fill="var(--item-bg)"/>
+      <text x="10" y="16" fill="var(--item-text)" font-size="9" font-weight="500">Shell commands</text>
+    </g>
+    <g transform="translate(32, 138)">
+      <rect width="156" height="24" rx="4" fill="var(--item-bg)"/>
+      <text x="10" y="16" fill="var(--item-text)" font-size="9" font-weight="500">File operations</text>
+    </g>
+    <g transform="translate(32, 168)">
+      <rect width="156" height="24" rx="4" fill="var(--item-bg)"/>
+      <text x="10" y="16" fill="var(--item-text)" font-size="9" font-weight="500">Multi-turn editing</text>
+    </g>
+
+    <text x="110" y="218" text-anchor="middle" fill="var(--muted-text)" font-size="8" font-weight="600" letter-spacing="0.5">Responses API</text>
+    <text x="110" y="230" text-anchor="middle" fill="var(--muted-text)" font-size="7.5">Tools run locally</text>
+  </g>
+
+  <!-- ========== FLOW: Codex → OGX ========== -->
+  <line x1="200" y1="145" x2="250" y2="145" stroke="var(--flow-stroke)" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6"/>
+  <circle r="3" fill="var(--flow-dot)" opacity="0.8">
+    <animateMotion dur="1.6s" repeatCount="indefinite" path="M200,145 L240,145"/>
+  </circle>
+
+  <!-- ========== OGX SERVER (center) ========== -->
+  <g filter="url(#s)">
+    <rect x="250" y="44" width="280" height="210" rx="6" fill="var(--server-bg)" stroke="var(--server-accent)" stroke-width="1.5"/>
+
+    <rect x="250" y="44" width="280" height="26" rx="6" fill="var(--server-accent)"/>
+    <rect x="250" y="64" width="280" height="6" fill="var(--server-accent)"/>
+    <text x="390" y="62" text-anchor="middle" fill="var(--server-label)" font-size="11" font-weight="700" letter-spacing="1">OGX SERVER</text>
+
+    <!-- Responses Engine -->
+    <g transform="translate(262, 78)">
+      <rect width="256" height="38" rx="4" fill="var(--block-bg)" stroke="var(--block-stroke)" stroke-width="0.5"/>
+      <text x="10" y="16" fill="var(--block-title)" font-size="8.5" font-weight="600">Responses Engine</text>
+      <line x1="10" y1="22" x2="246" y2="22" stroke="var(--block-stroke)" stroke-width="0.5"/>
+      <text x="10" y="33" fill="var(--block-text)" font-size="7.5">agentic loop · tool calling · multi-turn · streaming</text>
+    </g>
+
+    <!-- Compaction -->
+    <g transform="translate(262, 122)">
+      <rect width="256" height="38" rx="4" fill="var(--block-bg)" stroke="var(--block-stroke)" stroke-width="0.5"/>
+      <text x="10" y="16" fill="var(--block-title)" font-size="8.5" font-weight="600">Conversation Compaction</text>
+      <line x1="10" y1="22" x2="246" y2="22" stroke="var(--block-stroke)" stroke-width="0.5"/>
+      <text x="10" y="33" fill="var(--block-text)" font-size="7.5">automatic context compression for long sessions</text>
+    </g>
+
+    <!-- Provider Routing -->
+    <g transform="translate(262, 166)">
+      <rect width="256" height="38" rx="4" fill="var(--block-bg)" stroke="var(--block-stroke)" stroke-width="0.5"/>
+      <text x="10" y="16" fill="var(--block-title)" font-size="8.5" font-weight="600">Provider Routing</text>
+      <line x1="10" y1="22" x2="246" y2="22" stroke="var(--block-stroke)" stroke-width="0.5"/>
+      <text x="10" y="33" fill="var(--block-text)" font-size="7.5">format translation · unified config · any backend</text>
+    </g>
+
+    <text x="390" y="228" text-anchor="middle" fill="var(--muted-text)" font-size="8" font-weight="600" letter-spacing="0.5">One config, swap models</text>
+    <text x="390" y="240" text-anchor="middle" fill="var(--muted-text)" font-size="7.5">openai/ · ollama/ · anthropic/ · ...</text>
+  </g>
+
+  <!-- ========== FLOW: OGX → Providers ========== -->
+  <line x1="530" y1="100" x2="560" y2="100" stroke="var(--flow-stroke)" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6"/>
+  <line x1="530" y1="145" x2="560" y2="145" stroke="var(--flow-stroke)" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6"/>
+  <line x1="530" y1="190" x2="560" y2="190" stroke="var(--flow-stroke)" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.6"/>
+
+  <circle r="3" fill="var(--flow-dot)" opacity="0.7">
+    <animateMotion dur="1.4s" repeatCount="indefinite" path="M530,100 L555,100"/>
+  </circle>
+  <circle r="3" fill="var(--flow-dot)" opacity="0.7">
+    <animateMotion dur="1.4s" repeatCount="indefinite" begin="0.5s" path="M530,145 L555,145"/>
+  </circle>
+  <circle r="3" fill="var(--flow-dot)" opacity="0.7">
+    <animateMotion dur="1.4s" repeatCount="indefinite" begin="1.0s" path="M530,190 L555,190"/>
+  </circle>
+
+  <!-- ========== PROVIDERS (right) ========== -->
+  <g filter="url(#s)">
+    <rect x="560" y="44" width="200" height="210" rx="6" fill="var(--card-bg)" stroke="var(--card-stroke)" stroke-width="1"/>
+
+    <text x="575" y="72" fill="var(--section-label)" font-size="9" font-weight="700" letter-spacing="0.5">INFERENCE</text>
+
+    <g transform="translate(572, 80)">
+      <rect width="88" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">OpenAI</text>
+    </g>
+    <g transform="translate(666, 80)">
+      <rect width="82" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">Anthropic</text>
+    </g>
+    <g transform="translate(572, 108)">
+      <rect width="88" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">Ollama</text>
+    </g>
+    <g transform="translate(666, 108)">
+      <rect width="82" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">vLLM</text>
+    </g>
+    <g transform="translate(572, 136)">
+      <rect width="88" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">AWS Bedrock</text>
+    </g>
+    <g transform="translate(666, 136)">
+      <rect width="82" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">Azure</text>
+    </g>
+    <g transform="translate(572, 164)">
+      <rect width="88" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">Fireworks</text>
+    </g>
+    <g transform="translate(666, 164)">
+      <rect width="82" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">Together</text>
+    </g>
+    <g transform="translate(572, 192)">
+      <rect width="88" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">Gemini</text>
+    </g>
+    <g transform="translate(666, 192)">
+      <rect width="82" height="22" rx="3" fill="var(--item-bg)"/>
+      <text x="8" y="15" fill="var(--item-text)" font-size="8.5">+ 14 more</text>
+    </g>
+
+    <text x="660" y="240" text-anchor="middle" fill="var(--muted-text)" font-size="7.5">23 providers total</text>
+  </g>
+
+  <!-- ========== TAGLINE ========== -->
+  <text x="390" y="272" text-anchor="middle" fill="var(--tagline)" font-size="9" font-weight="600" letter-spacing="1.5">
+    CODEX CLI  ·  ANY MODEL  ·  ONE CONFIG CHANGE
+  </text>
+</svg>

--- a/docs/docs/building_applications/codex_cli_integration.mdx
+++ b/docs/docs/building_applications/codex_cli_integration.mdx
@@ -8,13 +8,15 @@ This integration is in early development (alpha status). While core functionalit
 
 ## Quick Start
 
-# 1. Start OGX with Codex support
+### 1. Start OGX with Codex support
+
 ```bash
 export OPENAI_API_KEY="your-key-here"
-ogx run starter
+ogx stack run starter
 ```
 
-# 2. Configure Codex CLI
+### 2. Configure Codex CLI
+
 Add the following to your `~/.codex/config.toml`:
 
 ```toml
@@ -28,7 +30,9 @@ wire_api = "responses"
 supports_websockets = false
 ```
 
-# 3. Test the integration
+### 3. Test the integration
+
+```bash
 codex "Write a hello world function in Python"
 ```
 
@@ -46,10 +50,12 @@ Key benefits:
 
 ### Model Compatibility
 
-Choose models that support OpenAI Chat Completions format:
-- ✅ `openai/gpt-4o`, `openai/gpt-4o-mini`
-- ✅ `anthropic/claude-3-5-sonnet-20241022`
-- ❌ `gpt-5.4` (Responses-only, no Chat Completions support)
+Choose models that are available from your OGX server and compatible with the Responses API:
+- `openai/gpt-4o`, `openai/gpt-4o-mini`, `openai/gpt-5.4`
+- `anthropic/claude-3-5-sonnet-20241022`
+- `ollama/llama3.2:3b`
+
+Use provider-prefixed model IDs (for example `openai/gpt-4o`), and keep `wire_api = "responses"` in your provider config.
 
 ## Known Limitations
 


### PR DESCRIPTION
# What does this PR do?

Adds a blog post for the Codex CLI + OGX integration and fixes issues in the existing docs reference page.

**Blog post** (`docs/blog/2026-05-19-codex-cli-integration.md`): covers the proxy architecture, step-by-step setup, model compatibility, alpha-status limitations, and troubleshooting.

**Docs page fixes** (`docs/docs/building_applications/codex_cli_integration.mdx`): corrects `ogx run` to `ogx stack run`, fixes broken markdown heading levels, adds a missing code fence around the test command, and updates the model compatibility list to use Responses API framing instead of Chat Completions.

## Test Plan

1. Build the docs site locally (`cd docs && npm start`) and verify:
   - The blog post renders at `/blog/codex-cli-integration`
   - The docs page renders at `/docs/building_applications/codex_cli_integration`
   - Code blocks, headings, and the truncation marker all display correctly