### PR TITLE
feat(docs): redesign provider cards, DocCardList, and tables site-wide

### DIFF
--- a/docs/docs/providers/index.mdx
+++ b/docs/docs/providers/index.mdx
@@ -5,7 +5,7 @@ sidebar_label: Overview
 sidebar_position: 1
 ---
 
-import DocCardList from '@theme/DocCardList';
+import { ProviderGrid, ProviderReference } from '@site/src/components/ProviderGrid';
 
 # API Providers
 
@@ -22,62 +22,11 @@ At least one inline provider exists for each API so you can run a fully featured
 
 ## Provider categories
 
-<DocCardList items={[
-  {
-    type: 'link',
-    label: 'Inference',
-    href: '/docs/providers/inference/',
-    description: 'Ollama, vLLM, OpenAI, Bedrock, Anthropic, Gemini, WatsonX, and more',
-  },
-  {
-    type: 'link',
-    label: 'Vector IO',
-    href: '/docs/providers/vector_io/',
-    description: 'FAISS, SQLite-Vec, ChromaDB, Qdrant, Milvus, PGVector, Weaviate',
-  },
-  {
-    type: 'link',
-    label: 'Safety',
-    href: '/docs/providers/safety/',
-    description: 'Llama Guard, Prompt Guard, Code Scanner, Bedrock Guardrails',
-  },
-  {
-    type: 'link',
-    label: 'Tool Runtime',
-    href: '/docs/providers/tool_runtime/',
-    description: 'File Search, Brave Search, Tavily, MCP, Wolfram Alpha',
-  },
-  {
-    type: 'link',
-    label: 'Files',
-    href: '/docs/providers/files/',
-    description: 'Local filesystem and S3 storage backends',
-  },
-  {
-    type: 'link',
-    label: 'DatasetIO',
-    href: '/docs/providers/datasetio/',
-    description: 'Local filesystem and HuggingFace dataset loading',
-  },
-  {
-    type: 'link',
-    label: 'External Providers',
-    href: '/docs/providers/external/',
-    description: 'Build your own provider and integrate it with OGX',
-  },
-]} />
+<ProviderGrid />
 
 ## Reference
 
-| Category | Count | Examples | Docs |
-|----------|-------|----------|------|
-| **Inference** | 23 | Ollama, vLLM, OpenAI, Bedrock, Anthropic, Gemini, WatsonX, and more | [Inference Providers](/docs/providers/inference/) |
-| **Vector IO** | 15 | FAISS, ChromaDB, Qdrant, Milvus, PGVector, Weaviate, Elasticsearch | [Vector IO Providers](/docs/providers/vector_io/) |
-| **Safety** | 7 | Llama Guard, Prompt Guard, Code Scanner, Bedrock Guardrails | [Safety Providers](/docs/providers/safety/) |
-| **Tool Runtime** | 6 | File Search, Brave Search, Tavily, MCP, Wolfram Alpha | [Tool Runtime Providers](/docs/providers/tool_runtime/) |
-| **Files** | 3 | Local filesystem, S3, OpenAI Files | [Files Providers](/docs/providers/files/) |
-| **DatasetIO** | 2 | Local filesystem, HuggingFace | [DatasetIO Providers](/docs/providers/datasetio/) |
-| **External** | — | Build your own provider | [External Providers Guide](/docs/providers/external/) |
+<ProviderReference />
 
 ## Why this matters
 

--- a/docs/src/components/ProviderGrid/index.jsx
+++ b/docs/src/components/ProviderGrid/index.jsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import styles from './styles.module.css';
+
+const ICONS = {
+  inference: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="4" width="16" height="16" rx="2"/>
+      <rect x="9" y="9" width="6" height="6"/>
+      <path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/>
+      <path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/>
+    </svg>
+  ),
+  vector_io: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <ellipse cx="12" cy="5" rx="9" ry="3"/>
+      <path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/>
+      <path d="M3 12c0 1.66 4.03 3 9 3s9-1.34 9-3"/>
+    </svg>
+  ),
+  safety: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+    </svg>
+  ),
+  tool_runtime: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/>
+    </svg>
+  ),
+  files: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M15 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V7z"/>
+      <path d="M14 2v4a2 2 0 002 2h4"/><path d="M10 13H8"/><path d="M16 17H8"/><path d="M16 13h-2"/>
+    </svg>
+  ),
+  datasetio: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3v18"/><rect x="3" y="3" width="18" height="18" rx="2"/>
+      <path d="M3 9h18"/><path d="M3 15h18"/>
+    </svg>
+  ),
+  external: (
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a6 6 0 01-12 0V8z"/>
+    </svg>
+  ),
+};
+
+const CATEGORIES = [
+  {
+    id: 'inference',
+    label: 'Inference',
+    count: 23,
+    desc: 'Ollama, vLLM, OpenAI, Bedrock, Anthropic, Gemini, WatsonX, and more',
+    href: '/docs/providers/inference/',
+  },
+  {
+    id: 'vector_io',
+    label: 'Vector IO',
+    count: 15,
+    desc: 'FAISS, SQLite-Vec, ChromaDB, Qdrant, Milvus, PGVector, Weaviate',
+    href: '/docs/providers/vector_io/',
+  },
+  {
+    id: 'safety',
+    label: 'Safety',
+    count: 7,
+    desc: 'Llama Guard, Prompt Guard, Code Scanner, Bedrock Guardrails',
+    href: '/docs/providers/safety/',
+  },
+  {
+    id: 'tool_runtime',
+    label: 'Tool Runtime',
+    count: 6,
+    desc: 'File Search, Brave Search, Tavily, MCP, Wolfram Alpha',
+    href: '/docs/providers/tool_runtime/',
+  },
+  {
+    id: 'files',
+    label: 'Files',
+    count: 3,
+    desc: 'Local filesystem and S3 storage backends',
+    href: '/docs/providers/files/',
+  },
+  {
+    id: 'datasetio',
+    label: 'DatasetIO',
+    count: 2,
+    desc: 'Local filesystem and HuggingFace dataset loading',
+    href: '/docs/providers/datasetio/',
+  },
+];
+
+const EXTERNAL = {
+  id: 'external',
+  label: 'External Providers',
+  desc: 'Build your own provider and integrate it with OGX',
+  href: '/docs/providers/external/',
+};
+
+export function ProviderGrid() {
+  return (
+    <div className={styles.grid}>
+      {CATEGORIES.map((cat) => (
+        <Link key={cat.id} to={cat.href} className={styles.card}>
+          <div className={styles.cardHeader}>
+            <div className={styles.cardIcon}>{ICONS[cat.id]}</div>
+            <span className={styles.cardTitle}>{cat.label}</span>
+            <span className={styles.cardCount}>{cat.count}</span>
+          </div>
+          <p className={styles.cardDesc}>{cat.desc}</p>
+        </Link>
+      ))}
+      <Link to={EXTERNAL.href} className={`${styles.card} ${styles.cardExternal}`}>
+        <div className={styles.cardHeader}>
+          <div className={styles.cardIcon}>{ICONS[EXTERNAL.id]}</div>
+          <span className={styles.cardTitle}>{EXTERNAL.label}</span>
+        </div>
+        <p className={styles.cardDesc}>{EXTERNAL.desc}</p>
+      </Link>
+    </div>
+  );
+}
+
+const REF_DATA = [
+  { id: 'inference', label: 'Inference', count: 23, examples: 'Ollama, vLLM, OpenAI, Bedrock, Anthropic, Gemini, WatsonX, and more', href: '/docs/providers/inference/', linkLabel: 'Inference Providers' },
+  { id: 'vector_io', label: 'Vector IO', count: 15, examples: 'FAISS, ChromaDB, Qdrant, Milvus, PGVector, Weaviate, Elasticsearch', href: '/docs/providers/vector_io/', linkLabel: 'Vector IO Providers' },
+  { id: 'safety', label: 'Safety', count: 7, examples: 'Llama Guard, Prompt Guard, Code Scanner, Bedrock Guardrails', href: '/docs/providers/safety/', linkLabel: 'Safety Providers' },
+  { id: 'tool_runtime', label: 'Tool Runtime', count: 6, examples: 'File Search, Brave Search, Tavily, MCP, Wolfram Alpha', href: '/docs/providers/tool_runtime/', linkLabel: 'Tool Runtime Providers' },
+  { id: 'files', label: 'Files', count: 3, examples: 'Local filesystem, S3, OpenAI Files', href: '/docs/providers/files/', linkLabel: 'Files Providers' },
+  { id: 'datasetio', label: 'DatasetIO', count: 2, examples: 'Local filesystem, HuggingFace', href: '/docs/providers/datasetio/', linkLabel: 'DatasetIO Providers' },
+  { id: 'external', label: 'External', count: null, examples: 'Build your own provider', href: '/docs/providers/external/', linkLabel: 'External Providers Guide' },
+];
+
+export function ProviderReference() {
+  return (
+    <div className={styles.reference}>
+      <table className={styles.refTable}>
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th style={{textAlign: 'center'}}>Count</th>
+            <th>Examples</th>
+            <th>Docs</th>
+          </tr>
+        </thead>
+        <tbody>
+          {REF_DATA.map((row) => (
+            <tr key={row.id} className={styles.refRow}>
+              <td>
+                <div className={styles.refCategory}>
+                  <span className={styles.refCategoryIcon}>{ICONS[row.id]}</span>
+                  {row.label}
+                </div>
+              </td>
+              <td className={styles.refCount}>
+                {row.count != null ? row.count : '—'}
+              </td>
+              <td className={styles.refExamples}>{row.examples}</td>
+              <td className={styles.refLink}>
+                <Link to={row.href}>
+                  {row.linkLabel}
+                  <span className={styles.refArrow}>&rarr;</span>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docs/src/components/ProviderGrid/styles.module.css
+++ b/docs/src/components/ProviderGrid/styles.module.css
@@ -1,0 +1,269 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.06);
+  margin: 1.5rem 0 2.5rem;
+}
+
+:global([data-theme='dark']) .grid {
+  border-color: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1.75rem;
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit !important;
+  transition: background 0.15s;
+  position: relative;
+}
+
+:global([data-theme='dark']) .card {
+  background: var(--ifm-background-color);
+}
+
+.card:hover {
+  background: rgba(13, 115, 119, 0.03);
+}
+
+:global([data-theme='dark']) .card:hover {
+  background: rgba(45, 189, 194, 0.04);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.cardIcon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.cardIcon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.cardTitle {
+  font-family: 'Archivo', 'Public Sans', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.cardCount {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: var(--ifm-color-primary);
+  margin-left: auto;
+  opacity: 0.6;
+  letter-spacing: 0.02em;
+}
+
+.cardDesc {
+  font-size: 0.82rem;
+  color: var(--ifm-font-color-secondary);
+  margin: 0;
+  line-height: 1.5;
+  padding-left: 2.75rem;
+}
+
+/* External provider card - spans full width */
+.cardExternal {
+  grid-column: 1 / -1;
+}
+
+/* ========== Reference Table ========== */
+.reference {
+  margin: 1.5rem 0 2.5rem;
+}
+
+.refTable {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  font-size: 0.88rem;
+}
+
+:global([data-theme='dark']) .refTable {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.refTable th {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ifm-font-color-secondary);
+  padding: 0.7rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.03);
+}
+
+:global([data-theme='dark']) .refTable th {
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.refRow {
+  transition: background 0.1s;
+}
+
+.refRow:nth-child(even) {
+  background: rgba(0, 0, 0, 0.012);
+}
+
+:global([data-theme='dark']) .refRow:nth-child(even) {
+  background: rgba(255, 255, 255, 0.012);
+}
+
+.refRow:hover {
+  background: rgba(13, 115, 119, 0.035);
+}
+
+:global([data-theme='dark']) .refRow:hover {
+  background: rgba(45, 189, 194, 0.04);
+}
+
+.refTable td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  vertical-align: middle;
+}
+
+:global([data-theme='dark']) .refTable td {
+  border-bottom-color: rgba(255, 255, 255, 0.03);
+}
+
+.refTable tr:last-child td {
+  border-bottom: none;
+}
+
+.refCategory {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+
+.refCategoryIcon {
+  width: 18px;
+  height: 18px;
+  opacity: 0.4;
+  flex-shrink: 0;
+  color: var(--ifm-color-primary);
+}
+
+.refCategoryIcon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.refCount {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: var(--ifm-color-primary);
+  text-align: center;
+}
+
+.refExamples {
+  color: var(--ifm-font-color-secondary);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.refLink {
+  font-size: 0.82rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.refLink a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-decoration: none;
+  color: var(--ifm-color-primary);
+  transition: color 0.15s;
+}
+
+.refLink a:hover {
+  color: var(--ifm-color-primary-light);
+}
+
+.refArrow {
+  font-size: 0.72rem;
+  opacity: 0.5;
+  transition: transform 0.15s, opacity 0.15s;
+}
+
+.refLink a:hover .refArrow {
+  transform: translateX(3px);
+  opacity: 0.9;
+}
+
+@media (max-width: 640px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .refTable {
+    display: block;
+    overflow-x: auto;
+  }
+
+  .refTable thead {
+    display: none;
+  }
+
+  .refTable tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .refRow {
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 0.5rem;
+  }
+
+  :global([data-theme='dark']) .refRow {
+    border-color: rgba(255, 255, 255, 0.06);
+  }
+
+  .refTable td {
+    padding: 0.25rem 0;
+    border-bottom: none;
+  }
+
+  .refCount {
+    text-align: left;
+  }
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -619,51 +619,100 @@ h3 {
   background: linear-gradient(90deg, transparent 0%, rgba(45, 189, 194, 0.15) 50%, transparent 100%);
 }
 
-/* Tables — clean, flat, no card wrapping */
+/* Tables — contained, structured, scannable */
 table {
   display: table;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
-  border-radius: 0;
-  border: none;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  overflow: hidden;
   margin: 1.5rem 0;
+  font-size: 0.88rem;
 }
 
+[data-theme='dark'] table {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+/* Header row */
 table th {
-  background: none;
-  font-weight: 700;
-  font-size: 0.82rem;
-  text-transform: none;
-  letter-spacing: 0;
-  color: var(--ifm-font-color-base);
-  border-bottom: 2px solid rgba(0, 0, 0, 0.12);
+  background: rgba(0, 0, 0, 0.03);
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ifm-font-color-secondary);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   text-align: left;
+  padding: 0.7rem 1rem;
 }
 
 [data-theme='dark'] table th {
-  background: none;
-  color: var(--ifm-font-color-base);
-  border-bottom-color: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--ifm-font-color-secondary);
+  border-bottom-color: rgba(255, 255, 255, 0.06);
 }
 
+/* Cells */
 table td, table th {
-  padding: 0.6rem 1rem;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
   border-right: none;
   border-left: none;
   vertical-align: top;
+  line-height: 1.55;
 }
 
 table tr:last-child td {
   border-bottom: none;
 }
 
+/* First column emphasis: make the key/name column scannable */
+table td:first-child {
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+}
+
+/* Alternating row tint for scanability */
+table tbody tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.012);
+}
+
+[data-theme='dark'] table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.012);
+}
+
+/* Hover */
 table tbody tr {
-  transition: none;
+  transition: background 0.1s;
+}
+
+table tbody tr:hover {
+  background: rgba(13, 115, 119, 0.035);
+}
+
+[data-theme='dark'] table tbody tr:hover {
+  background: rgba(45, 189, 194, 0.04);
 }
 
 [data-theme='dark'] table td {
-  border-bottom-color: rgba(255, 255, 255, 0.06);
+  border-bottom-color: rgba(255, 255, 255, 0.03);
+}
+
+/* Inline code inside tables: quieter, more like a label */
+table code {
+  font-size: 0.82em;
+  padding: 0.12em 0.35em;
+  background: rgba(13, 115, 119, 0.05);
+  border-color: rgba(13, 115, 119, 0.06);
+}
+
+[data-theme='dark'] table code {
+  background: rgba(45, 189, 194, 0.07);
+  border-color: rgba(45, 189, 194, 0.08);
 }
 
 /* ========== CODE BLOCKS ========== */
@@ -2701,10 +2750,80 @@ footer.row .col {
   }
 }
 
-/* ========== DOC CARDS (API listing pages) ========== */
-/* Reduce excessive internal padding */
+/* ========== DOC CARDS (unified grid) ========== */
+
+/* Row container becomes 1px-gap grid */
+section.row:has(> [class*='docCardListItem']) {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1px;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.06);
+  margin: 1rem 0 1.5rem;
+}
+
+[data-theme='dark'] section.row:has(> [class*='docCardListItem']) {
+  border-color: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+/* Each card item fills its grid cell */
+[class*='docCardListItem'] {
+  --ifm-col-width: 100% !important;
+  flex: none !important;
+  max-width: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+/* Card anchor: clean cell in the grid */
 .card.padding--lg {
-  padding: 0 0.75rem !important;
+  padding: 1.25rem 1.5rem !important;
+  border-radius: 0 !important;
+  border: none !important;
+  box-shadow: none !important;
+  background: var(--ifm-background-surface-color) !important;
+  transition: background 0.15s !important;
+  height: 100%;
+}
+
+[data-theme='dark'] .card.padding--lg {
+  background: var(--ifm-background-color) !important;
+}
+
+.card.padding--lg:hover {
+  background: rgba(13, 115, 119, 0.03) !important;
+}
+
+[data-theme='dark'] .card.padding--lg:hover {
+  background: rgba(45, 189, 194, 0.04) !important;
+}
+
+/* Card title */
+.card.padding--lg h2[class*='cardTitle'] {
+  font-family: 'Archivo', 'Public Sans', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.25rem;
+  border: none;
+  padding: 0;
+}
+
+/* Card description */
+.card.padding--lg p[class*='cardDescription'] {
+  font-size: 0.82rem;
+  color: var(--ifm-font-color-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  section.row:has(> [class*='docCardListItem']) {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* GitHub link hidden from navbar — already on landing page and footer */


### PR DESCRIPTION
# What does this PR do?

Redesigns the docs site's card grids and tables for a cohesive, polished look that matches the rest of the site's design language.

**Cards (DocCardList):** Replaces the default Docusaurus rounded-box cards with a unified 1px-gap grid panel. Applies globally to all pages using DocCardList (`/docs`, `/docs/concepts`, `/docs/building_applications`, `/docs/distributions`).

**Providers page:** Adds a custom `ProviderGrid` component with Lucide icons, monospace count badges, and a `ProviderReference` table with category icons and arrow links, replacing the generic DocCardList and plain markdown table.

**Tables (site-wide):** Restyles all markdown tables with contained borders and rounded corners, JetBrains Mono uppercase headers with a subtle background tint, alternating row zebra striping, first-column bold emphasis for scanability, row hover highlights, and quieter inline code styling inside table cells.

## Test Plan

- Run `npm install && npx docusaurus gen-api-docs all` in the `docs/` directory
- Start the dev server with `npx docusaurus start`
- Verify the card grid on `/docs`, `/docs/concepts`, `/docs/building_applications`, `/docs/distributions`
- Verify the custom ProviderGrid and ProviderReference on `/docs/providers`
- Verify table styling on `/docs` (API table), `/docs/providers` (reference table), and any provider detail page like `/docs/providers/inference/remote_ollama` (config table)
- Check both light and dark mode