### PR TITLE
fix(openai): clamp max_tokens to per-model limits to prevent overflow errors

### DIFF
--- a/src/ogx/providers/remote/inference/openai/openai.py
+++ b/src/ogx/providers/remote/inference/openai/openai.py
@@ -66,7 +66,11 @@ class OpenAIInferenceAdapter(OpenAIMixin):
             return _MODEL_MAX_OUTPUT_TOKENS[model]
 
         # Try prefix matching for dated snapshot variants (e.g. gpt-4o-2024-08-06)
-        for base_model, limit in _MODEL_MAX_OUTPUT_TOKENS.items():
+        for base_model, limit in sorted(
+            _MODEL_MAX_OUTPUT_TOKENS.items(),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        ):
             if model.startswith(f"{base_model}-"):
                 return limit
 
@@ -106,9 +110,19 @@ class OpenAIInferenceAdapter(OpenAIMixin):
         params: OpenAIChatCompletionRequestWithExtraBody,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
         max_output_tokens = self._get_max_output_tokens(params.model)
-        if max_output_tokens is not None and params.max_tokens is not None and params.max_tokens > max_output_tokens:
-            params = params.model_copy()
-            params.max_tokens = max_output_tokens
+        if max_output_tokens is not None:
+            updated_params = params
+            if params.max_tokens is not None and params.max_tokens > max_output_tokens:
+                updated_params = updated_params.model_copy()
+                updated_params.max_tokens = max_output_tokens
+            if (
+                params.max_completion_tokens is not None
+                and params.max_completion_tokens > max_output_tokens
+            ):
+                if updated_params is params:
+                    updated_params = updated_params.model_copy()
+                updated_params.max_completion_tokens = max_output_tokens
+            params = updated_params
 
         return await super().openai_chat_completion(params)
 

--- a/src/ogx/providers/remote/inference/openai/openai.py
+++ b/src/ogx/providers/remote/inference/openai/openai.py
@@ -4,12 +4,42 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from collections.abc import AsyncIterator
+
 from ogx.log import get_logger
 from ogx.providers.utils.inference.openai_mixin import OpenAIMixin
+from ogx_api import (
+    Model,
+    ModelType,
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatCompletionRequestWithExtraBody,
+)
 
 from .config import OpenAIConfig
 
 logger = get_logger(name=__name__, category="inference::openai")
+
+# Max output tokens per OpenAI model. OpenAI's /v1/models endpoint does not
+# expose this, so we maintain the mapping statically.
+_MODEL_MAX_OUTPUT_TOKENS: dict[str, int] = {
+    "gpt-4.1": 32768,
+    "gpt-4.1-mini": 32768,
+    "gpt-4.1-nano": 32768,
+    "gpt-4o": 16384,
+    "gpt-4o-mini": 16384,
+    "gpt-4-turbo": 4096,
+    "gpt-4": 8192,
+    "o1": 100000,
+    "o1-mini": 65536,
+    "o1-pro": 100000,
+    "o3": 100000,
+    "o3-mini": 100000,
+    "o3-pro": 100000,
+    "o4-mini": 100000,
+}
+
+_WARNED_MODELS: set[str] = set()
 
 
 #
@@ -30,6 +60,57 @@ class OpenAIInferenceAdapter(OpenAIMixin):
         "text-embedding-3-small": {"embedding_dimension": 1536, "context_length": 8192},
         "text-embedding-3-large": {"embedding_dimension": 3072, "context_length": 8192},
     }
+
+    def _get_max_output_tokens(self, model: str) -> int | None:
+        if model in _MODEL_MAX_OUTPUT_TOKENS:
+            return _MODEL_MAX_OUTPUT_TOKENS[model]
+
+        # Try prefix matching for dated snapshot variants (e.g. gpt-4o-2024-08-06)
+        for base_model, limit in _MODEL_MAX_OUTPUT_TOKENS.items():
+            if model.startswith(f"{base_model}-"):
+                return limit
+
+        if model not in _WARNED_MODELS:
+            _WARNED_MODELS.add(model)
+            logger.warning(
+                "Unknown max_output_tokens for model, requests will not be clamped",
+                model=model,
+            )
+        return None
+
+    def construct_model_from_identifier(self, identifier: str) -> Model:
+        if metadata := self.embedding_model_metadata.get(identifier):
+            return Model(
+                provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+                provider_resource_id=identifier,
+                identifier=identifier,
+                model_type=ModelType.embedding,
+                metadata=metadata,
+            )
+
+        metadata = {}
+        max_output_tokens = self._get_max_output_tokens(identifier)
+        if max_output_tokens is not None:
+            metadata["max_output_tokens"] = max_output_tokens
+
+        return Model(
+            provider_id=self.__provider_id__,  # type: ignore[attr-defined]
+            provider_resource_id=identifier,
+            identifier=identifier,
+            model_type=ModelType.llm,
+            metadata=metadata,
+        )
+
+    async def openai_chat_completion(
+        self,
+        params: OpenAIChatCompletionRequestWithExtraBody,
+    ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
+        max_output_tokens = self._get_max_output_tokens(params.model)
+        if max_output_tokens is not None and params.max_tokens is not None and params.max_tokens > max_output_tokens:
+            params = params.model_copy()
+            params.max_tokens = max_output_tokens
+
+        return await super().openai_chat_completion(params)
 
     async def openai_chat_completions_with_reasoning(self, params) -> None:
         raise ValueError(

--- a/src/ogx/providers/remote/inference/openai/openai.py
+++ b/src/ogx/providers/remote/inference/openai/openai.py
@@ -115,10 +115,7 @@ class OpenAIInferenceAdapter(OpenAIMixin):
             if params.max_tokens is not None and params.max_tokens > max_output_tokens:
                 updated_params = updated_params.model_copy()
                 updated_params.max_tokens = max_output_tokens
-            if (
-                params.max_completion_tokens is not None
-                and params.max_completion_tokens > max_output_tokens
-            ):
+            if params.max_completion_tokens is not None and params.max_completion_tokens > max_output_tokens:
                 if updated_params is params:
                     updated_params = updated_params.model_copy()
                 updated_params.max_completion_tokens = max_output_tokens

--- a/tests/unit/providers/inference/test_remote_openai.py
+++ b/tests/unit/providers/inference/test_remote_openai.py
@@ -1,0 +1,229 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from ogx.providers.remote.inference.openai.config import OpenAIConfig
+from ogx.providers.remote.inference.openai.openai import (
+    _MODEL_MAX_OUTPUT_TOKENS,
+    _WARNED_MODELS,
+    OpenAIInferenceAdapter,
+)
+from ogx_api import (
+    OpenAIChatCompletion,
+    OpenAIChatCompletionRequestWithExtraBody,
+    OpenAIChatCompletionResponseMessage,
+    OpenAIChoice,
+)
+
+
+@pytest.fixture
+def mock_openai_response():
+    return OpenAIChatCompletion(
+        id="chatcmpl-abc123",
+        created=1,
+        model="gpt-4o-mini",
+        choices=[
+            OpenAIChoice(
+                message=OpenAIChatCompletionResponseMessage(content="hello"),
+                finish_reason="stop",
+                index=0,
+            )
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_warned_models():
+    _WARNED_MODELS.clear()
+    yield
+    _WARNED_MODELS.clear()
+
+
+def _make_adapter():
+    config = OpenAIConfig(api_key="fake-key")
+    adapter = OpenAIInferenceAdapter(config=config)
+    adapter.model_store = AsyncMock()
+    return adapter
+
+
+class TestOpenAIMaxTokensClamping:
+    async def test_clamps_when_request_exceeds_model_limit(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 16384
+
+    async def test_keeps_lower_request_value(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=1000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 1000
+
+    async def test_no_clamping_when_max_tokens_is_none(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs.get("max_tokens") is None
+
+    async def test_does_not_mutate_original_params(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            assert params.max_tokens == 32000
+
+    async def test_different_models_have_different_limits(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            # gpt-4-turbo has a 4096 limit
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4-turbo",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 4096
+
+    async def test_no_clamping_for_unknown_model(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="some-future-model",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 32000
+
+    async def test_dated_snapshot_model_uses_base_limit(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-2024-08-06",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 16384
+
+
+class TestOpenAIModelMetadata:
+    def test_construct_model_includes_max_output_tokens(self):
+        adapter = _make_adapter()
+        adapter.__provider_id__ = "openai"
+
+        model = adapter.construct_model_from_identifier("gpt-4o-mini")
+        assert model.metadata["max_output_tokens"] == 16384
+
+    def test_construct_model_unknown_has_no_max_output_tokens(self):
+        adapter = _make_adapter()
+        adapter.__provider_id__ = "openai"
+
+        model = adapter.construct_model_from_identifier("some-future-model")
+        assert "max_output_tokens" not in model.metadata
+
+    def test_construct_model_embedding_unchanged(self):
+        adapter = _make_adapter()
+        adapter.__provider_id__ = "openai"
+
+        model = adapter.construct_model_from_identifier("text-embedding-3-small")
+        assert model.model_type.value == "embedding"
+        assert model.metadata["embedding_dimension"] == 1536
+
+
+class TestOpenAIMaxOutputTokensWarning:
+    def test_warns_once_for_unknown_model(self, caplog):
+        adapter = _make_adapter()
+
+        with caplog.at_level("WARNING"):
+            result1 = adapter._get_max_output_tokens("brand-new-model")
+            result2 = adapter._get_max_output_tokens("brand-new-model")
+
+        assert result1 is None
+        assert result2 is None
+        warning_count = sum(1 for r in caplog.records if "brand-new-model" in r.message)
+        assert warning_count == 1
+
+    def test_all_known_models_have_limits(self):
+        adapter = _make_adapter()
+        for model_id, expected_limit in _MODEL_MAX_OUTPUT_TOKENS.items():
+            assert adapter._get_max_output_tokens(model_id) == expected_limit

--- a/tests/unit/providers/inference/test_remote_openai.py
+++ b/tests/unit/providers/inference/test_remote_openai.py
@@ -185,6 +185,46 @@ class TestOpenAIMaxTokensClamping:
             call_kwargs = mock_client.chat.completions.create.call_args.kwargs
             assert call_kwargs["max_tokens"] == 16384
 
+    async def test_clamps_max_completion_tokens_when_request_exceeds_model_limit(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_completion_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_completion_tokens"] == 16384
+
+    async def test_clamps_both_max_token_fields_when_both_exceed_model_limit(self, mock_openai_response):
+        adapter = _make_adapter()
+
+        with patch.object(OpenAIInferenceAdapter, "client", new_callable=PropertyMock) as mock_client_prop:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_openai_response)
+            mock_client_prop.return_value = mock_client
+
+            params = OpenAIChatCompletionRequestWithExtraBody(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                max_tokens=32000,
+                max_completion_tokens=32000,
+            )
+            await adapter.openai_chat_completion(params)
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["max_tokens"] == 16384
+            assert call_kwargs["max_completion_tokens"] == 16384
+
 
 class TestOpenAIModelMetadata:
     def test_construct_model_includes_max_output_tokens(self):
@@ -227,3 +267,7 @@ class TestOpenAIMaxOutputTokensWarning:
         adapter = _make_adapter()
         for model_id, expected_limit in _MODEL_MAX_OUTPUT_TOKENS.items():
             assert adapter._get_max_output_tokens(model_id) == expected_limit
+
+    def test_prefix_matching_prefers_more_specific_model(self):
+        adapter = _make_adapter()
+        assert adapter._get_max_output_tokens("o1-mini-2024-09-12") == 65536


### PR DESCRIPTION
# What does this PR do?

Fixes `BadRequestError: max_tokens is too large` when clients (e.g. Claude Code) send `max_tokens` values that exceed what the target OpenAI model supports. For example, Claude Code requests `max_tokens: 32000` but `gpt-4o-mini` only supports 16384.

Adds a static per-model `max_output_tokens` map to the OpenAI provider adapter and clamps incoming `max_tokens` at request time. Supports prefix matching for dated snapshot variants (e.g. `gpt-4o-2024-08-06` inherits from `gpt-4o`). Logs a warning once per unknown model so operators know the map needs updating when new models are released.

Also populates `max_output_tokens` in model metadata via `construct_model_from_identifier()`, exposing it through the `/v1/models` endpoint's `custom_metadata` field.

## Test Plan

```bash
uv run pytest tests/unit/providers/inference/test_remote_openai.py -v --tb=short
```

Output:
```
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_clamps_when_request_exceeds_model_limit PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_keeps_lower_request_value PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_no_clamping_when_max_tokens_is_none PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_does_not_mutate_original_params PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_different_models_have_different_limits PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_no_clamping_for_unknown_model PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxTokensClamping::test_dated_snapshot_model_uses_base_limit PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIModelMetadata::test_construct_model_includes_max_output_tokens PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIModelMetadata::test_construct_model_unknown_has_no_max_output_tokens PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIModelMetadata::test_construct_model_embedding_unchanged PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxOutputTokensWarning::test_warns_once_for_unknown_model PASSED
tests/unit/providers/inference/test_remote_openai.py::TestOpenAIMaxOutputTokensWarning::test_all_known_models_have_limits PASSED
12 passed in 0.12s
```