### PR TITLE
ci(integration-tests): run only server client on PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        client: [library, server]
+        client: ${{ github.event_name == 'pull_request' && fromJSON('["server"]') || fromJSON('["library", "server"]') }}
         # Use Python 3.13 only on nightly schedule (daily latest client test), otherwise use 3.12
         python-version: ${{ github.event.schedule == '0 0 * * *' && fromJSON('["3.12", "3.13"]') || fromJSON('["3.12"]') }}
         node-version: [22]


### PR DESCRIPTION
# What does this PR do?

Reduces integration test CI runner usage on pull requests by restricting the client matrix to `server` only, instead of running both `library` and `server`. All 16 provider configurations still run, so missing recordings are caught early. The full two-client matrix continues to run on pushes to main, merge queue, scheduled, and manual triggers.

This cuts the number of integration test jobs roughly in half per PR (~15 fewer jobs).

## Test Plan

1. Verify the workflow YAML is valid:
```
uv run pre-commit run actionlint --files .github/workflows/integration-tests.yml
# Result: Passed
```

2. On a PR, confirm only `server` client jobs are spawned (no `library` client jobs).
3. On a push to `main` or merge queue, confirm both `library` and `server` client jobs run.