### PR TITLE
feat(letsgo): use inline::auto file processor

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -212,13 +212,13 @@ def _autodetect_providers() -> str:
         "files=inline::localfs",
         "vector_io=inline::faiss",
         "tool_runtime=inline::file-search",
-        "file_processors=inline::pypdf",
+        "file_processors=inline::auto",
         "responses=inline::builtin",
     ]
     cprint("  ✓ inline::localfs (built-in)", color="green")
     cprint("  ✓ inline::faiss (built-in)", color="green")
     cprint("  ✓ inline::file-search (built-in)", color="green")
-    cprint("  ✓ inline::pypdf (built-in)", color="green")
+    cprint("  ✓ inline::auto (built-in)", color="green")
     cprint("  ✓ inline::builtin responses (built-in)", color="green")
 
     if passed:


### PR DESCRIPTION
Replace inline::pypdf with inline::auto in the letsgo auto-detected inline provider list. The auto processor is a superset of pypdf — it routes PDFs and text files to pypdf and dispatches office documents, images, and audio to MarkItDown, consistent with the starter and ci-tests distributions.