### PR TITLE
fix(deps): move CVE-pinned transitive deps to constraint-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,14 @@ fallback_version = "0.8.1.dev0"
 [tool.uv]
 required-version = ">=0.7.0"
 constraint-dependencies = [
+    "aiohttp>=3.13.3",
+    "fonttools>=4.60.2",
+    "h11>=0.16.0",
     "pyasn1>=0.6.3",  # CVE-2026-30922: DoS via unbounded recursion
+    "python-multipart>=0.0.22",
+    "starlette>=0.49.1",
+    "tornado>=6.5.5",
+    "urllib3>=2.6.3",
 ]
 
 [project]
@@ -31,15 +38,12 @@ classifiers = [
 ]
 dependencies = [
     "PyYAML>=6.0",
-    "aiohttp>=3.13.3",
     "fastapi>=0.115.0,<1.0",                          # server
-    "fire",                                           # for MCP in LLS client
     "httpx",
     "jinja2>=3.1.6",
     "jsonschema",
     "ogx-api",                                # API and provider specifications (local dev via tool.uv.sources)
     "openai>=2.30.0",
-    "prompt-toolkit",
     "python-dotenv",
     "pyjwt[crypto]>=2.12.0",                          # Pull crypto to support RS256 for jwt. Requires 2.12.0+ to fix CVE-2026-32597.
     "pydantic>=2.11.9",
@@ -47,8 +51,6 @@ dependencies = [
     "structlog>=24.1.0",
     "termcolor",
     "tiktoken",
-    "h11>=0.16.0",
-    "python-multipart>=0.0.22",                       # For fastapi Form
     "uvicorn>=0.34.0",                                # server
     "opentelemetry-sdk>=1.30.0",                      # server
     "opentelemetry-exporter-otlp-proto-http>=1.30.0", # server
@@ -56,13 +58,7 @@ dependencies = [
     "aiosqlite>=0.21.0",                              # server - for metadata store
     "asyncpg",                                        # for metadata store
     "sqlalchemy[asyncio]>=2.0.41",                    # server - for conversations
-    "starlette>=0.49.1",
     "psycopg2-binary",
-    "tornado>=6.5.5",
-    "urllib3>=2.6.3",
-    "oracledb>=3.4.1",
-    "oci>=2.165.0",
-    "numpy>=2.3.2",
     "mcp>=1.23.0",                                    # for connectors
     "zstandard>=0.23.0",                              # server - zstd request decompression
 ]
@@ -88,9 +84,7 @@ starter = [
     "fastapi",
     "fire",
     "fireworks-ai<=0.17.16",
-    "fonttools>=4.60.2",
     "google-genai>=1.69.0",
-    "h11>=0.16.0",
     "httpx",
     "langdetect",
     "matplotlib",

--- a/src/ogx/core/server/auth.py
+++ b/src/ogx/core/server/auth.py
@@ -8,7 +8,6 @@ import re
 from typing import Any
 
 import httpx
-from aiohttp import hdrs
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ogx.core.access_control.conditions import User as ProtocolUser
@@ -102,7 +101,7 @@ class AuthenticationMiddleware:
         if scope["type"] == "http":
             # Find the route and check if authentication is required
             path = scope.get("path", "")
-            method = scope.get("method", hdrs.METH_GET)
+            method = scope.get("method", "GET")
 
             if not hasattr(self, "route_impls"):
                 self.route_impls = initialize_route_impls(self.impls)

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,16 @@ resolution-markers = [
 ]
 
 [manifest]
-constraints = [{ name = "pyasn1", specifier = ">=0.6.3" }]
+constraints = [
+    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "fonttools", specifier = ">=4.60.2" },
+    { name = "h11", specifier = ">=0.16.0" },
+    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "starlette", specifier = ">=0.49.1" },
+    { name = "tornado", specifier = ">=6.5.5" },
+    { name = "urllib3", specifier = ">=2.6.3" },
+]
 
 [[package]]
 name = "accelerate"
@@ -913,15 +922,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/01/13438ebe3bb4f58816ba32ebfada17b94d4f0f30d20f2880f42970e562b2/chromadb_client-1.5.5.tar.gz", hash = "sha256:28c208e9639c9b43cf2f12292d456163bbf72d443b00fda1b947793db195fa57", size = 21867327, upload-time = "2026-03-10T09:15:10.409Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/59/8c711b8ca32a23d606e31f9fe13a4461f7a3fbd426d027e9665d3d8e0ad6/chromadb_client-1.5.5-py3-none-any.whl", hash = "sha256:1ddab20a4266724da6a2e93fff8dbbaebe34c300875702b212d2cb755894d4c6", size = 786479, upload-time = "2026-03-10T09:15:08.181Z" },
-]
-
-[[package]]
-name = "circuitbreaker"
-version = "2.1.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787, upload-time = "2025-03-31T08:12:08.963Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737, upload-time = "2025-03-31T08:12:07.802Z" },
 ]
 
 [[package]]
@@ -3628,59 +3628,31 @@ wheels = [
 ]
 
 [[package]]
-name = "oci"
-version = "2.165.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "circuitbreaker" },
-    { name = "cryptography" },
-    { name = "pyopenssl" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/20/7cab8a81f81fa1c185e5fa659fc12066a894393bd05920c2523142ba58a3/oci-2.165.0.tar.gz", hash = "sha256:c04586994bad57b3d929ba3f0e640dcd80c7122a074e4fe54f2b4886e2b27529", size = 16302512, upload-time = "2026-01-13T04:51:18.678Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/ec/e65a03afe77c5d96d391f3421b349fa8818e9568ef7b3910cffdc6d1df6b/oci-2.165.0-py3-none-any.whl", hash = "sha256:5dcf32fa3aaf47dde65ca16f0822a1cfd75487a5fc21253ad2045a9dfff4abc7", size = 33227901, upload-time = "2026-01-13T04:51:10.824Z" },
-]
-
-[[package]]
 name = "ogx"
 source = { editable = "." }
 dependencies = [
-    { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "fastapi" },
-    { name = "fire" },
-    { name = "h11" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "mcp" },
-    { name = "numpy" },
-    { name = "oci" },
     { name = "ogx-api" },
     { name = "openai" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
-    { name = "oracledb" },
-    { name = "prompt-toolkit" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
-    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sqlalchemy", extra = ["asyncio"] },
-    { name = "starlette" },
     { name = "structlog" },
     { name = "termcolor" },
     { name = "tiktoken" },
-    { name = "tornado" },
-    { name = "urllib3" },
     { name = "uvicorn" },
     { name = "zstandard" },
 ]
@@ -3707,9 +3679,7 @@ starter = [
     { name = "fastapi" },
     { name = "fire" },
     { name = "fireworks-ai" },
-    { name = "fonttools" },
     { name = "google-genai" },
-    { name = "h11" },
     { name = "httpx" },
     { name = "langdetect" },
     { name = "markitdown", extra = ["all"] },
@@ -3876,7 +3846,6 @@ unit = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiohttp", marker = "extra == 'starter'" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "aiosqlite", marker = "extra == 'starter'" },
@@ -3895,13 +3864,9 @@ requires-dist = [
     { name = "faiss-cpu", marker = "extra == 'starter'" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0" },
     { name = "fastapi", marker = "extra == 'starter'" },
-    { name = "fire" },
     { name = "fire", marker = "extra == 'starter'" },
     { name = "fireworks-ai", marker = "extra == 'starter'", specifier = "<=0.17.16" },
-    { name = "fonttools", marker = "extra == 'starter'", specifier = ">=4.60.2" },
     { name = "google-genai", marker = "extra == 'starter'", specifier = ">=1.69.0" },
-    { name = "h11", specifier = ">=0.16.0" },
-    { name = "h11", marker = "extra == 'starter'", specifier = ">=0.16.0" },
     { name = "httpx" },
     { name = "httpx", marker = "extra == 'starter'" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -3912,9 +3877,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "mcp", marker = "extra == 'starter'", specifier = ">=1.23.0" },
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
-    { name = "numpy", specifier = ">=2.3.2" },
     { name = "numpy", marker = "extra == 'starter'" },
-    { name = "oci", specifier = ">=2.165.0" },
     { name = "ogx-api", editable = "src/ogx_api" },
     { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.8.0" },
     { name = "ollama", marker = "extra == 'starter'" },
@@ -3924,10 +3887,8 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'starter'" },
     { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'starter'" },
-    { name = "oracledb", specifier = ">=3.4.1" },
     { name = "pandas", marker = "extra == 'starter'" },
     { name = "pillow", marker = "extra == 'starter'" },
-    { name = "prompt-toolkit" },
     { name = "psycopg2-binary" },
     { name = "psycopg2-binary", marker = "extra == 'starter'" },
     { name = "pydantic", specifier = ">=2.11.9" },
@@ -3937,7 +3898,6 @@ requires-dist = [
     { name = "pypdf", marker = "extra == 'starter'", specifier = ">=6.7.2" },
     { name = "pythainlp", marker = "extra == 'starter'" },
     { name = "python-dotenv" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'starter'" },
     { name = "redis", marker = "extra == 'starter'" },
@@ -3950,17 +3910,14 @@ requires-dist = [
     { name = "sentencepiece", marker = "extra == 'starter'" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.41" },
     { name = "sqlite-vec", marker = "extra == 'starter'" },
-    { name = "starlette", specifier = ">=0.49.1" },
     { name = "structlog", specifier = ">=24.1.0" },
     { name = "termcolor" },
     { name = "tiktoken" },
     { name = "together", marker = "extra == 'starter'", specifier = ">=2" },
     { name = "tokenizers", marker = "extra == 'starter'" },
     { name = "torch", marker = "extra == 'starter'", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "tornado", specifier = ">=6.5.5" },
     { name = "tqdm", marker = "extra == 'starter'" },
     { name = "tree-sitter", marker = "extra == 'starter'" },
-    { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "uvicorn", marker = "extra == 'starter'" },
     { name = "weaviate-client", marker = "extra == 'starter'", specifier = ">=4.16.5" },
@@ -4418,33 +4375,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
-]
-
-[[package]]
-name = "oracledb"
-version = "3.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/9d/4e86cd410294ebbb1f90a609aaae61c5fa064a5c10e501de3f4c67664e6c/oracledb-3.4.1.tar.gz", hash = "sha256:f5920df5ac9446579e8409607bba31dc2d23a2286a5b0ea17cb0d78d419392a6", size = 852693, upload-time = "2025-11-12T03:21:36.157Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/d9/98367ba2c358de366de70b505531f9717cdfa7e29eff0c9ad113eecfce96/oracledb-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1c3f92c023ef1983e0e7f9a1b4a31df8568974c28c06ab0a574b1126e45083a8", size = 4222133, upload-time = "2025-11-12T03:21:58.212Z" },
-    { url = "https://files.pythonhosted.org/packages/36/52/48ad2f7dae6288a2ddf0ac536d46ce4883d2d10ec7e16afbbd48f1ec0ff3/oracledb-3.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:251211d64b90cc42d00ec2d2893873bc02ff4bc22125e9fc5a7f148a6208fd88", size = 2230374, upload-time = "2025-11-12T03:21:59.656Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/08/60d4301b4f72f099ed2252f8d0eb143e6fe9e5c8f4c2705c3163cea36808/oracledb-3.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea529a5e6036fae3e2bc195fa76b6f48cd9c431e68c74ef78ee6a5e39c855c39", size = 2421755, upload-time = "2025-11-12T03:22:01.543Z" },
-    { url = "https://files.pythonhosted.org/packages/48/35/412a90019a030f5dff0c031319733c6b8dd477832bafa88b733b4b3ec57b/oracledb-3.4.1-cp312-cp312-win32.whl", hash = "sha256:94e8e6d63b45fedd4e243147cb25dea1a0f6599d83852f3979fe725a8533e85a", size = 1449688, upload-time = "2025-11-12T03:22:03.422Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/01/ae9eca3055dc625923564ca653ca99ddd8eda95e44953ce55c18aba55066/oracledb-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:84f15c483f9ec80dcded925df6ff473c69a293cd694d09b69abb911500659df4", size = 1794622, upload-time = "2025-11-12T03:22:04.941Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/4d/e32db901340dc6fc824d0d3b5e4660fe0199fba8adb0e81ac08b639c8ab9/oracledb-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ad817807b293e371c951af8ee67a56a5af88a5680a54fe79dfc7b9393ca128aa", size = 4206469, upload-time = "2025-11-12T03:22:06.881Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/1a038f29523eea19e42f4dd765bf523752408816b5ff21e8b998d8b25457/oracledb-3.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34b9bc25eae217defa3f4b8289b4915cd1101aaeeec33c7bace74f927996d452", size = 2233055, upload-time = "2025-11-12T03:22:08.259Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/66/a51243553ac6b0e1bc2cfd4db8a2f3299b1b60c9231d7c9133ee1442d15b/oracledb-3.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be6575759ba56ab3758f82bfbb74f75288ce69190e19c087793050cb012c0aa1", size = 2443312, upload-time = "2025-11-12T03:22:09.615Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/57/a6056d4432c07a959fd1032dd45bfaff69b91ac7e1204dbccf7bf7b4a91d/oracledb-3.4.1-cp313-cp313-win32.whl", hash = "sha256:635587e5f28be83ec0bf72e4bfb2f3a4544c0f8e303f2327f376d57116894541", size = 1453553, upload-time = "2025-11-12T03:22:11.045Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/57/dca415d8dd18a2a030a9402d49039493cdce6acfd37c8a038a4ede2328e6/oracledb-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:354177708352e124c0f97ceccbe34be05e7f3ce7040a7dd3c2ebd857145ffe74", size = 1794005, upload-time = "2025-11-12T03:22:12.694Z" },
-    { url = "https://files.pythonhosted.org/packages/59/07/dff7b9e6242b627d56f3fa6ad6639802003e1e5fbcc883d0ce27d82455ad/oracledb-3.4.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3ec1f9dd7310da7cbf219c2a05bb52df08da950c95ad2ace8a289854947bdc6b", size = 4247946, upload-time = "2025-11-12T03:22:14.473Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/95/739868c6f312683cc3afe9534644b4ce2d054fe137d8f7a1e7786df9f5aa/oracledb-3.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:337a67d6c91015dfe7a2a1915f65c74adad26fcd428daaead296d91c92f09ad1", size = 2271628, upload-time = "2025-11-12T03:22:15.956Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/7c/307da513f5fb68e6454beb5bc1c715ec09a70d2af70a28b9fa6001c1b09b/oracledb-3.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d5ffe4dd26e8012de433ec69f93be5737d81b04324072ec36dad37eb778fd9d", size = 2455603, upload-time = "2025-11-12T03:22:18.112Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/1a/af5bd7239cebfc33541432cfcba75893a3f2f44fa66648e6d8ce1fe96b0c/oracledb-3.4.1-cp314-cp314-win32.whl", hash = "sha256:693ef5f8c420545511096b3bc9a3861617222717321bc78c776afbbb6c16c5b9", size = 1474932, upload-time = "2025-11-12T03:22:19.574Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ee/79d2ed18fd234bcbd407c1b36372dc898cf68de825ec650df7b1627acb51/oracledb-3.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:6adb483d7120cdd056173b71c901f71dbe2265c5bd402f768b0b1ab27af519b1", size = 1837566, upload-time = "2025-11-12T03:22:20.959Z" },
 ]
 
 [[package]]
@@ -5443,19 +5373,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/fe/7a6a6b331d9f2024ab171028ab53d5d9026959b1d713fe170be591a4d9a8/pymongo-4.15.3-cp314-cp314t-win32.whl", hash = "sha256:e7cde58ef6470c0da922b65e885fb1ffe04deef81e526bd5dea429290fa358ca", size = 1043993, upload-time = "2025-10-07T21:57:28.727Z" },
     { url = "https://files.pythonhosted.org/packages/70/c8/bc64321711e19bd48ea3371f0082f10295c433833245d73e7606d3b9afbe/pymongo-4.15.3-cp314-cp314t-win_amd64.whl", hash = "sha256:fae552767d8e5153ed498f1bca92d905d0d46311d831eefb0f06de38f7695c95", size = 1078481, upload-time = "2025-10-07T21:57:30.372Z" },
     { url = "https://files.pythonhosted.org/packages/39/31/2bb2003bb978eb25dfef7b5f98e1c2d4a86e973e63b367cc508a9308d31c/pymongo-4.15.3-cp314-cp314t-win_arm64.whl", hash = "sha256:47ffb068e16ae5e43580d5c4e3b9437f05414ea80c32a1e5cac44a835859c259", size = 1051179, upload-time = "2025-10-07T21:57:31.829Z" },
-]
-
-[[package]]
-name = "pyopenssl"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/28/2659c02301b9500751f8d42f9a6632e1508aa5120de5e43042b8b30f8d5d/pyopenssl-25.1.0-py3-none-any.whl", hash = "sha256:2b11f239acc47ac2e5aca04fd7fa829800aeee22a2eb30d744572a157bd8a1ab", size = 56771, upload-time = "2025-05-17T16:28:29.197Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

Cleans up `pyproject.toml` core dependencies by moving transitive packages with CVE-driven version pins to `[tool.uv] constraint-dependencies`, where they constrain resolver output without inflating the direct install footprint. Also removes provider-specific packages (`oracledb`, `oci`, `numpy`) that are already declared in their provider registry `pip_packages`, and drops entirely unused deps (`fire`, `prompt-toolkit`). The sole `aiohttp` import in `auth.py` (`hdrs.METH_GET`) is replaced with a `"GET"` literal to eliminate that core dependency.

## Test Plan

1. Verify the lockfile resolves cleanly: `uv lock --check`
2. Run unit tests: `uv run pytest tests/unit/ -x --tb=short`
3. Run pre-commit checks: `uv run pre-commit run --all-files`