### PR TITLE
fix(python-deps): added missing dev group dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,15 @@ dev = [
     "pre-commit>=4.4.0",
     "ruamel.yaml",                   # needed for openapi generator
     "openapi-spec-validator>=0.7.2",
+    "ollama",
+    "ogx-client>=0.8.0",
+    "chardet",
+    "pypdf>=6.7.2",
+    "together",
+    "boto3",
+    "anthropic",
+    "torch>=2.6.0",
+    "markitdown[all]",
 ]
 # Type checking dependencies - includes type stubs and optional runtime dependencies
 # needed for complete mypy coverage across all optional features

--- a/uv.lock
+++ b/uv.lock
@@ -3756,11 +3756,18 @@ codegen = [
     { name = "rich" },
 ]
 dev = [
+    { name = "anthropic" },
     { name = "black" },
+    { name = "boto3" },
+    { name = "chardet" },
+    { name = "markitdown", extra = ["all"] },
     { name = "mypy" },
     { name = "nbval" },
+    { name = "ogx-client" },
+    { name = "ollama" },
     { name = "openapi-spec-validator" },
     { name = "pre-commit" },
+    { name = "pypdf" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -3770,6 +3777,9 @@ dev = [
     { name = "pytest-timeout" },
     { name = "ruamel-yaml" },
     { name = "ruff" },
+    { name = "together" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 docs = [
     { name = "linkify" },
@@ -3976,11 +3986,18 @@ codegen = [
     { name = "rich" },
 ]
 dev = [
+    { name = "anthropic" },
     { name = "black" },
+    { name = "boto3" },
+    { name = "chardet" },
+    { name = "markitdown", extras = ["all"] },
     { name = "mypy" },
     { name = "nbval" },
+    { name = "ogx-client", specifier = ">=0.8.0" },
+    { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.7.2" },
     { name = "pre-commit", specifier = ">=4.4.0" },
+    { name = "pypdf", specifier = ">=6.7.2" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
     { name = "pytest-cov" },
@@ -3990,6 +4007,8 @@ dev = [
     { name = "pytest-timeout" },
     { name = "ruamel-yaml" },
     { name = "ruff" },
+    { name = "together" },
+    { name = "torch", specifier = ">=2.6.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 docs = [
     { name = "linkify" },


### PR DESCRIPTION
# What does this PR do?
Adds missing dependencies to `dev` dependency group, making the new developer experience better.
CONTRIBUTING.md file will work (copy & paste)

 Closes #[5631]

## Test Plan
To simulate a new developer experience, get a fresh docker container:
```
docker run -ti python:3.12-slim bash
```

And then, add the tools needed to clone the repo and add the `.env` file (my choice is vim):
```
apt update && apt install -y git vim
pip install uv
git clone https://github.com/ogx-ai/ogx.git
```
and then continue with the [CONTRIBUTING.md line-by-line](https://github.com/ogx-ai/ogx/blob/8fcda2fafcd000f489d812665876cdfc769f3876/CONTRIBUTING.md?plain=1#L11-L42).

-> This currently fails on `master` branch with `ModuleNotFoundError`.