### PR TITLE
feat(letsgo): add Claude Code compatibility

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -26,8 +26,57 @@ from ogx.core.build import get_provider_dependencies
 from ogx.core.stack import run_config_from_dynamic_config_spec
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR
 from ogx.log import get_logger
+from ogx_api.models.models import ModelInput
 
 logger = get_logger(name=__name__, category="cli")
+
+# Model IDs that Claude Code looks for.
+_CLAUDE_CODE_ALIASES: list[str] = [
+    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+]
+
+# Inference provider IDs checked in priority order when building Claude Code aliases.
+# Anthropic is preferred because the alias model IDs are native Anthropic identifiers;
+# the others use provider_model_id="auto" to pick whatever model is available.
+_CLAUDE_CODE_PROVIDER_PRIORITY: list[str] = ["anthropic", "ollama", "vllm", "openai"]
+
+
+def _build_claude_code_aliases(providers_spec: str) -> list[ModelInput]:
+    """Return ModelInput entries for Claude Code compatibility.
+
+    Picks the highest-priority active inference provider from
+    _CLAUDE_CODE_PROVIDER_PRIORITY and registers each alias in
+    _CLAUDE_CODE_ALIASES against it. Anthropic providers receive a direct
+    provider_model_id match; all others use "auto" to pick the first
+    available LLM. Returns an empty list when no priority provider is active.
+    """
+    active_inference = {
+        p.split("::", 1)[-1]
+        for p in providers_spec.split(",")
+        if p.startswith("inference=")
+        for p in [p.split("=", 1)[1]]
+    }
+
+    chosen: str | None = None
+    for candidate in _CLAUDE_CODE_PROVIDER_PRIORITY:
+        if candidate in active_inference:
+            chosen = candidate
+            break
+
+    if chosen is None:
+        return []
+
+    return [
+        ModelInput(
+            model_id=alias,
+            provider_id=chosen,
+            provider_model_id=alias if chosen == "anthropic" else "auto",
+            metadata={"_unprefixed_alias": True},
+        )
+        for alias in _CLAUDE_CODE_ALIASES
+    ]
 
 
 class _ProbeStatus(enum.Enum):
@@ -99,6 +148,11 @@ def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
     if not args.skip_install_deps:
         normal_deps, special_deps, _ = get_provider_dependencies(run_config)
         _install_provider_deps(normal_deps, special_deps)
+
+    claude_aliases = _build_claude_code_aliases(providers_spec)
+    if claude_aliases:
+        run_config.registered_resources.models.extend(claude_aliases)
+        cprint(f"  ✓ Claude Code aliases → {claude_aliases[0].provider_id}", color="green")
 
     config_dict = run_config.model_dump(mode="json")
 
@@ -214,12 +268,14 @@ def _autodetect_providers() -> str:
         "tool_runtime=inline::file-search",
         "file_processors=inline::pypdf",
         "responses=inline::builtin",
+        "messages=inline::builtin",
     ]
     cprint("  ✓ inline::localfs (built-in)", color="green")
     cprint("  ✓ inline::faiss (built-in)", color="green")
     cprint("  ✓ inline::file-search (built-in)", color="green")
     cprint("  ✓ inline::pypdf (built-in)", color="green")
     cprint("  ✓ inline::builtin responses (built-in)", color="green")
+    cprint("  ✓ inline::builtin messages (built-in)", color="green")
 
     if passed:
         cprint(f"\nDetected {len(passed)} inference provider(s). Starting stack...", color="cyan")

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -14,7 +14,14 @@ import httpx
 import pytest
 
 from ogx.cli.letsgo import LetsGo
-from ogx.cli.stack.lets_go import StackLetsGo, _probe_endpoint, _ProbeStatus
+from ogx.cli.stack.lets_go import (
+    _CLAUDE_CODE_ALIASES,
+    _CLAUDE_CODE_PROVIDER_PRIORITY,
+    StackLetsGo,
+    _build_claude_code_aliases,
+    _probe_endpoint,
+    _ProbeStatus,
+)
 
 
 @pytest.fixture
@@ -223,7 +230,7 @@ class TestAutodetect:
         assert "inference=remote::anthropic" in parts
         assert "files=inline::localfs" in parts
         assert "responses=inline::builtin" in parts
-        assert len(parts) == 11  # 6 probed + 5 inline
+        assert len(parts) == 12  # 6 probed + 6 inline
 
     @patch("ogx.cli.stack.lets_go._probe_endpoint")
     def test_autodetect_only_ollama(self, mock_probe: MagicMock):
@@ -241,7 +248,7 @@ class TestAutodetect:
         assert "inference=remote::ollama" in parts
         assert "files=inline::localfs" in parts
         assert "responses=inline::builtin" in parts
-        assert len(parts) == 6  # 1 inference + 5 inline
+        assert len(parts) == 7  # 1 inference + 6 inline
 
     @patch("ogx.cli.stack.lets_go._probe_endpoint")
     def test_autodetect_uses_env_var_base_url(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
@@ -443,3 +450,69 @@ class TestDeprecation:
 
         future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
         assert len(future_warnings) == 0
+
+
+class TestClaudeCodeAliases:
+    def test_anthropic_chosen_over_others(self):
+        spec = "inference=remote::anthropic,inference=remote::ollama,files=inline::localfs"
+        aliases = _build_claude_code_aliases(spec)
+        assert len(aliases) == len(_CLAUDE_CODE_ALIASES)
+        assert all(a.provider_id == "anthropic" for a in aliases)
+
+    def test_anthropic_uses_direct_model_id(self):
+        spec = "inference=remote::anthropic"
+        aliases = _build_claude_code_aliases(spec)
+        for alias in aliases:
+            assert alias.provider_model_id == alias.model_id
+
+    def test_ollama_fallback_uses_auto(self):
+        spec = "inference=remote::ollama,files=inline::localfs"
+        aliases = _build_claude_code_aliases(spec)
+        assert all(a.provider_id == "ollama" for a in aliases)
+        assert all(a.provider_model_id == "auto" for a in aliases)
+
+    def test_vllm_fallback_uses_auto(self):
+        spec = "inference=remote::vllm"
+        aliases = _build_claude_code_aliases(spec)
+        assert all(a.provider_id == "vllm" for a in aliases)
+        assert all(a.provider_model_id == "auto" for a in aliases)
+
+    def test_openai_fallback_uses_auto(self):
+        spec = "inference=remote::openai"
+        aliases = _build_claude_code_aliases(spec)
+        assert all(a.provider_id == "openai" for a in aliases)
+        assert all(a.provider_model_id == "auto" for a in aliases)
+
+    def test_priority_order_ollama_before_openai(self):
+        spec = "inference=remote::openai,inference=remote::ollama"
+        aliases = _build_claude_code_aliases(spec)
+        assert all(a.provider_id == "ollama" for a in aliases)
+
+    def test_unknown_provider_returns_empty(self):
+        spec = "inference=remote::llama-openai-compat"
+        aliases = _build_claude_code_aliases(spec)
+        assert aliases == []
+
+    def test_no_inference_returns_empty(self):
+        spec = "files=inline::localfs,vector_io=inline::faiss"
+        aliases = _build_claude_code_aliases(spec)
+        assert aliases == []
+
+    def test_all_aliases_present(self):
+        spec = "inference=remote::anthropic"
+        aliases = _build_claude_code_aliases(spec)
+        alias_model_ids = [a.model_id for a in aliases]
+        for expected in _CLAUDE_CODE_ALIASES:
+            assert expected in alias_model_ids
+
+    def test_aliases_have_unprefixed_metadata(self):
+        spec = "inference=remote::anthropic"
+        aliases = _build_claude_code_aliases(spec)
+        for alias in aliases:
+            assert alias.metadata is not None
+            assert alias.metadata.get("_unprefixed_alias") is True
+
+    def test_priority_list_covers_expected_providers(self):
+        assert "anthropic" in _CLAUDE_CODE_PROVIDER_PRIORITY
+        assert "ollama" in _CLAUDE_CODE_PROVIDER_PRIORITY
+        assert _CLAUDE_CODE_PROVIDER_PRIORITY.index("anthropic") < _CLAUDE_CODE_PROVIDER_PRIORITY.index("ollama")


### PR DESCRIPTION
Register messages=inline::builtin as a standard inline provider so the Anthropic Messages API (/v1/messages) is always available when letsgo starts a stack.

Auto-register Claude Code model aliases (claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7) against the highest-priority detected inference provider. Anthropic providers use the alias directly as the provider model ID; other providers fall back to "auto". Aliases are registered without a provider prefix so Claude Code resolves them as plain names.

After these changes, pointing Claude Code at an OGX server requires no manual model or configuration steps:

    ANTHROPIC_BASE_URL=http://localhost:8321 ANTHROPIC_API_KEY=none claude
