### PR TITLE
fix(auth): fetch GitHub org memberships for RBAC attribute mapping

### DIFF
--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -422,8 +422,17 @@ async def _get_github_user_info(access_token: str, github_api_base_url: str) -> 
         user_response.raise_for_status()
         user_data = user_response.json()
 
+        organizations: list[str] = []
+        try:
+            orgs_response = await client.get(f"{github_api_base_url}/user/orgs", headers=headers, timeout=10.0)
+            orgs_response.raise_for_status()
+            organizations = [org["login"] for org in orgs_response.json()]
+        except Exception:
+            logger.warning("Failed to fetch GitHub organization memberships, proceeding without org data")
+
         return {
             "user": user_data,
+            "organizations": organizations,
         }
 
 

--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -424,16 +424,58 @@ async def _get_github_user_info(access_token: str, github_api_base_url: str) -> 
 
         organizations: list[str] = []
         try:
-            orgs_response = await client.get(f"{github_api_base_url}/user/orgs", headers=headers, timeout=10.0)
-            orgs_response.raise_for_status()
-            organizations = [org["login"] for org in orgs_response.json()]
-        except Exception:
-            logger.warning("Failed to fetch GitHub organization memberships, proceeding without org data")
+            organizations = await _fetch_github_organizations(client, github_api_base_url, headers)
+        except (httpx.HTTPError, TypeError, ValueError) as e:
+            logger.warning(
+                "Failed to fetch GitHub organization memberships, proceeding without org data",
+                error=str(e),
+            )
 
         return {
             "user": user_data,
             "organizations": organizations,
         }
+
+
+async def _fetch_github_organizations(
+    client: httpx.AsyncClient, github_api_base_url: str, headers: dict[str, str]
+) -> list[str]:
+    """Fetch all organization logins for a GitHub user, handling pagination."""
+    per_page = 100
+    page = 1
+    organizations: list[str] = []
+
+    while True:
+        try:
+            orgs_response = await client.get(
+                f"{github_api_base_url}/user/orgs",
+                headers=headers,
+                params={"per_page": per_page, "page": page},
+                timeout=10.0,
+            )
+            orgs_response.raise_for_status()
+            orgs_payload = orgs_response.json()
+            if not isinstance(orgs_payload, list):
+                raise ValueError("Failed to parse GitHub organization memberships: expected list response")
+        except (httpx.HTTPError, TypeError, ValueError) as e:
+            if organizations:
+                logger.warning(
+                    "Failed to fetch additional GitHub organization memberships, using partial org data",
+                    page=page,
+                    error=str(e),
+                )
+                break
+            raise
+
+        organizations.extend(
+            org["login"] for org in orgs_payload if isinstance(org, dict) and isinstance(org.get("login"), str)
+        )
+        if len(orgs_payload) < per_page:
+            break
+        page += 1
+
+    # Keep a stable order while removing duplicates in case API pages overlap.
+    return list(dict.fromkeys(organizations))
 
 
 class KubernetesAuthProvider(AuthProvider):

--- a/tests/unit/server/test_auth_github.py
+++ b/tests/unit/server/test_auth_github.py
@@ -117,10 +117,11 @@ def test_authenticated_endpoint_with_valid_github_token(mock_client_class, githu
     assert response.status_code == 200
     assert response.json()["message"] == "Authentication successful"
 
-    # Verify the GitHub API was called correctly
-    assert mock_client.get.call_count == 1
+    # Verify both /user and /user/orgs endpoints were called
+    assert mock_client.get.call_count == 2
     calls = mock_client.get.call_args_list
     assert calls[0][0][0] == "https://api.github.com/user"
+    assert calls[1][0][0] == "https://api.github.com/user/orgs"
 
     # Check authorization header was passed
     assert calls[0][1]["headers"]["Authorization"] == "Bearer github_token_123"
@@ -190,10 +191,110 @@ def test_github_enterprise_support(mock_client_class):
     response = client.get("/test", headers={"Authorization": "Bearer enterprise_token"})
     assert response.status_code == 200
 
-    # Verify the correct GitHub Enterprise URLs were called
-    assert mock_client.get.call_count == 1
+    # Verify both /user and /user/orgs endpoints were called with enterprise URL
+    assert mock_client.get.call_count == 2
     calls = mock_client.get.call_args_list
     assert calls[0][0][0] == "https://github.enterprise.com/api/v3/user"
+    assert calls[1][0][0] == "https://github.enterprise.com/api/v3/user/orgs"
+
+
+@patch("ogx.core.server.auth_providers.httpx.AsyncClient")
+def test_github_token_extracts_org_attributes(mock_client_class):
+    """Test that organization memberships are extracted into user attributes"""
+    from ogx.core.server.auth_providers import GitHubTokenAuthProvider
+
+    config = GitHubTokenAuthConfig(
+        type=AuthProviderType.GITHUB_TOKEN,
+        github_api_base_url="https://api.github.com",
+        claims_mapping={
+            "login": "roles",
+            "organizations": "teams",
+        },
+    )
+    provider = GitHubTokenAuthProvider(config)
+
+    mock_client = AsyncMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client.get.side_effect = [
+        MockResponse(200, {"login": "testuser", "id": 12345}),
+        MockResponse(200, [{"login": "org-a"}, {"login": "org-b"}]),
+    ]
+
+    import asyncio
+
+    user = asyncio.get_event_loop().run_until_complete(provider.validate_token("token123"))
+    assert user.principal == "testuser"
+    assert user.attributes is not None
+    assert "teams" in user.attributes
+    assert "org-a" in user.attributes["teams"]
+    assert "org-b" in user.attributes["teams"]
+
+
+@patch("ogx.core.server.auth_providers.httpx.AsyncClient")
+def test_github_token_handles_org_fetch_failure(mock_client_class, caplog):
+    """Test that authentication succeeds even if fetching orgs fails"""
+    from ogx.core.server.auth_providers import GitHubTokenAuthProvider
+
+    config = GitHubTokenAuthConfig(
+        type=AuthProviderType.GITHUB_TOKEN,
+        github_api_base_url="https://api.github.com",
+        claims_mapping={
+            "login": "roles",
+            "organizations": "teams",
+        },
+    )
+    provider = GitHubTokenAuthProvider(config)
+
+    mock_client = AsyncMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+
+    mock_request = httpx.Request("GET", "https://api.github.com/user/orgs")
+    mock_client.get.side_effect = [
+        MockResponse(200, {"login": "testuser", "id": 12345}),
+        httpx.HTTPStatusError("403 Forbidden", request=mock_request, response=MockResponse(403, {})),
+    ]
+
+    import asyncio
+
+    user = asyncio.get_event_loop().run_until_complete(provider.validate_token("token123"))
+    assert user.principal == "testuser"
+    assert user.attributes is not None
+    assert user.attributes.get("teams", []) == []
+
+
+@patch("ogx.core.server.auth_providers.httpx.AsyncClient")
+def test_github_token_multiple_orgs(mock_client_class):
+    """Test with user who belongs to multiple organizations"""
+    from ogx.core.server.auth_providers import GitHubTokenAuthProvider
+
+    config = GitHubTokenAuthConfig(
+        type=AuthProviderType.GITHUB_TOKEN,
+        github_api_base_url="https://api.github.com",
+        claims_mapping={
+            "login": "roles",
+            "organizations": "teams",
+        },
+    )
+    provider = GitHubTokenAuthProvider(config)
+
+    mock_client = AsyncMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client.get.side_effect = [
+        MockResponse(200, {"login": "multiorguser", "id": 99999}),
+        MockResponse(
+            200,
+            [{"login": "org-1"}, {"login": "org-2"}, {"login": "org-3"}, {"login": "org-4"}],
+        ),
+    ]
+
+    import asyncio
+
+    user = asyncio.get_event_loop().run_until_complete(provider.validate_token("token123"))
+    assert user.principal == "multiorguser"
+    assert user.attributes is not None
+    assert "teams" in user.attributes
+    assert len(user.attributes["teams"]) == 4
+    assert set(user.attributes["teams"]) == {"org-1", "org-2", "org-3", "org-4"}
 
 
 def test_github_token_auth_error_message_format(github_token_client):

--- a/tests/unit/server/test_auth_github.py
+++ b/tests/unit/server/test_auth_github.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import logging  # allow-direct-logging
 from unittest.mock import AsyncMock, patch
 
@@ -122,6 +123,7 @@ def test_authenticated_endpoint_with_valid_github_token(mock_client_class, githu
     calls = mock_client.get.call_args_list
     assert calls[0][0][0] == "https://api.github.com/user"
     assert calls[1][0][0] == "https://api.github.com/user/orgs"
+    assert calls[1][1]["params"] == {"per_page": 100, "page": 1}
 
     # Check authorization header was passed
     assert calls[0][1]["headers"]["Authorization"] == "Bearer github_token_123"
@@ -196,6 +198,7 @@ def test_github_enterprise_support(mock_client_class):
     calls = mock_client.get.call_args_list
     assert calls[0][0][0] == "https://github.enterprise.com/api/v3/user"
     assert calls[1][0][0] == "https://github.enterprise.com/api/v3/user/orgs"
+    assert calls[1][1]["params"] == {"per_page": 100, "page": 1}
 
 
 @patch("ogx.core.server.auth_providers.httpx.AsyncClient")
@@ -220,9 +223,7 @@ def test_github_token_extracts_org_attributes(mock_client_class):
         MockResponse(200, [{"login": "org-a"}, {"login": "org-b"}]),
     ]
 
-    import asyncio
-
-    user = asyncio.get_event_loop().run_until_complete(provider.validate_token("token123"))
+    user = asyncio.run(provider.validate_token("token123"))
     assert user.principal == "testuser"
     assert user.attributes is not None
     assert "teams" in user.attributes
@@ -254,9 +255,7 @@ def test_github_token_handles_org_fetch_failure(mock_client_class, caplog):
         httpx.HTTPStatusError("403 Forbidden", request=mock_request, response=MockResponse(403, {})),
     ]
 
-    import asyncio
-
-    user = asyncio.get_event_loop().run_until_complete(provider.validate_token("token123"))
+    user = asyncio.run(provider.validate_token("token123"))
     assert user.principal == "testuser"
     assert user.attributes is not None
     assert user.attributes.get("teams", []) == []
@@ -287,14 +286,86 @@ def test_github_token_multiple_orgs(mock_client_class):
         ),
     ]
 
-    import asyncio
-
-    user = asyncio.get_event_loop().run_until_complete(provider.validate_token("token123"))
+    user = asyncio.run(provider.validate_token("token123"))
     assert user.principal == "multiorguser"
     assert user.attributes is not None
     assert "teams" in user.attributes
     assert len(user.attributes["teams"]) == 4
     assert set(user.attributes["teams"]) == {"org-1", "org-2", "org-3", "org-4"}
+
+
+@patch("ogx.core.server.auth_providers.httpx.AsyncClient")
+def test_github_token_fetches_paginated_orgs(mock_client_class):
+    """Test that organization memberships are fetched across all GitHub org pages."""
+    from ogx.core.server.auth_providers import GitHubTokenAuthProvider
+
+    config = GitHubTokenAuthConfig(
+        type=AuthProviderType.GITHUB_TOKEN,
+        github_api_base_url="https://api.github.com",
+        claims_mapping={
+            "login": "roles",
+            "organizations": "teams",
+        },
+    )
+    provider = GitHubTokenAuthProvider(config)
+
+    first_page_orgs = [{"login": f"org-{index}"} for index in range(1, 101)]
+    second_page_orgs = [{"login": "org-101"}, {"login": "org-102"}]
+
+    mock_client = AsyncMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client.get.side_effect = [
+        MockResponse(200, {"login": "multiorguser", "id": 99999}),
+        MockResponse(200, first_page_orgs),
+        MockResponse(200, second_page_orgs),
+    ]
+
+    user = asyncio.run(provider.validate_token("token123"))
+    assert user.principal == "multiorguser"
+    assert user.attributes is not None
+    assert "teams" in user.attributes
+    assert len(user.attributes["teams"]) == 102
+    assert "org-101" in user.attributes["teams"]
+    assert "org-102" in user.attributes["teams"]
+
+    calls = mock_client.get.call_args_list
+    assert calls[1][1]["params"] == {"per_page": 100, "page": 1}
+    assert calls[2][1]["params"] == {"per_page": 100, "page": 2}
+
+
+@patch("ogx.core.server.auth_providers.httpx.AsyncClient")
+def test_github_token_preserves_partial_orgs_if_later_page_fails(mock_client_class):
+    """Test that already-fetched organizations are preserved if a later org page fails."""
+    from ogx.core.server.auth_providers import GitHubTokenAuthProvider
+
+    config = GitHubTokenAuthConfig(
+        type=AuthProviderType.GITHUB_TOKEN,
+        github_api_base_url="https://api.github.com",
+        claims_mapping={
+            "login": "roles",
+            "organizations": "teams",
+        },
+    )
+    provider = GitHubTokenAuthProvider(config)
+
+    first_page_orgs = [{"login": f"org-{index}"} for index in range(1, 101)]
+    mock_request = httpx.Request("GET", "https://api.github.com/user/orgs")
+
+    mock_client = AsyncMock()
+    mock_client_class.return_value.__aenter__.return_value = mock_client
+    mock_client.get.side_effect = [
+        MockResponse(200, {"login": "multiorguser", "id": 99999}),
+        MockResponse(200, first_page_orgs),
+        httpx.HTTPStatusError("503 Service Unavailable", request=mock_request, response=MockResponse(503, {})),
+    ]
+
+    user = asyncio.run(provider.validate_token("token123"))
+    assert user.principal == "multiorguser"
+    assert user.attributes is not None
+    assert "teams" in user.attributes
+    assert len(user.attributes["teams"]) == 100
+    assert "org-1" in user.attributes["teams"]
+    assert "org-100" in user.attributes["teams"]
 
 
 def test_github_token_auth_error_message_format(github_token_client):


### PR DESCRIPTION
## Summary

- `GitHubTokenAuthProvider` only called `/user` but the default `claims_mapping` expected an `organizations` field for attribute-based access control, causing org-based RBAC rules to silently fail
- Now also calls `/user/orgs` to populate organization memberships, with graceful degradation if the endpoint is unavailable

Closes #5702

## Test plan

- [x] Existing tests updated to verify both `/user` and `/user/orgs` are called
- [x] New test: org attributes are correctly extracted into user attributes
- [x] New test: authentication succeeds even when org fetch fails (graceful degradation)
- [x] New test: user belonging to multiple orgs gets all orgs in attributes
- [x] GitHub Enterprise custom base URL works with org fetch
- [x] Pre-commit checks pass
- [x] `uv run pytest tests/unit/server/test_auth_github.py` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)