### PR TITLE
fix(storage): filter expired rows in PostgreSQL keys_in_range()

### DIFF
--- a/src/ogx/core/storage/kvstore/postgres/postgres.py
+++ b/src/ogx/core/storage/kvstore/postgres/postgres.py
@@ -121,7 +121,12 @@ class PostgresKVStoreImpl(KVStore):
 
         cursor = self._cursor_or_raise()
         cursor.execute(
-            f"SELECT key FROM {self.config.table_name} WHERE key >= %s AND key < %s",
+            f"""
+            SELECT key FROM {self.config.table_name}
+            WHERE key >= %s AND key < %s
+            AND (expiration IS NULL OR expiration > NOW())
+            ORDER BY key
+            """,
             (start_key, end_key),
         )
         return [row[0] for row in cursor.fetchall()]


### PR DESCRIPTION
# What does this PR do?

`keys_in_range()` was missing the expiration filter that `get()` and `values_in_range()` already apply, causing it to return stale keys that would resolve to nothing via `get()`. This adds the same `(expiration IS NULL OR expiration > NOW())` predicate and `ORDER BY key` for consistency with `values_in_range()`.

Closes #5699

## Test Plan

1. Pre-commit checks pass on the changed file:
```
uv run pre-commit run --files src/ogx/core/storage/kvstore/postgres/postgres.py
```
All hooks passed.

2. Verified the query now matches the structure of `values_in_range()` (same WHERE clause, same ORDER BY).