### PR TITLE
fix(access-control): prevent fail-open negated ACL conditions

### DIFF
--- a/src/ogx/core/access_control/access_control.py
+++ b/src/ogx/core/access_control/access_control.py
@@ -12,6 +12,7 @@ from ogx.log import get_logger
 
 from .conditions import (
     Condition,
+    ConditionEvaluation,
     ProtectedResource,
     parse_conditions,
 )
@@ -88,26 +89,42 @@ def as_list(obj: Any) -> list[Any]:
     return [obj]
 
 
+def evaluate_conditions(
+    conditions: list[Condition],
+    resource: ProtectedResource,
+    user: User,
+) -> ConditionEvaluation:
+    """Evaluate a list of conditions using AND semantics.
+
+    Args:
+        conditions: List of conditions to evaluate.
+        resource: The protected resource being accessed.
+        user: The user attempting access.
+
+    Returns:
+        MATCH when all conditions match, NO_MATCH when any condition explicitly does not
+        match, and INDETERMINATE when there is no explicit mismatch but at least one
+        condition cannot be evaluated due to missing data.
+    """
+    has_indeterminate = False
+    for condition in conditions:
+        evaluation = condition.evaluate(resource, user)
+        if evaluation is ConditionEvaluation.NO_MATCH:
+            return ConditionEvaluation.NO_MATCH
+        if evaluation is ConditionEvaluation.INDETERMINATE:
+            has_indeterminate = True
+    if has_indeterminate:
+        return ConditionEvaluation.INDETERMINATE
+    return ConditionEvaluation.MATCH
+
+
 def matches_conditions(
     conditions: list[Condition],
     resource: ProtectedResource,
     user: User,
 ) -> bool:
-    """Check if all conditions in a list are satisfied for the given resource and user.
-
-    Args:
-        conditions: List of conditions that must all match.
-        resource: The protected resource being accessed.
-        user: The user attempting access.
-
-    Returns:
-        True if all conditions match, False if any condition fails.
-    """
-    for condition in conditions:
-        # must match all conditions
-        if not condition.matches(resource, user):
-            return False
-    return True
+    """Check if all conditions in a list are satisfied for the given resource and user."""
+    return evaluate_conditions(conditions, resource, user) is ConditionEvaluation.MATCH
 
 
 def default_policy() -> list[AccessRule]:
@@ -169,12 +186,14 @@ def is_action_allowed(
         for index, rule in enumerate(policy):  # noqa: B007
             if rule.forbid and matches_scope(rule.forbid, action, qualified_resource_id, user.principal):
                 if rule.when:
-                    if matches_conditions(parse_conditions(as_list(rule.when)), resource, user):
+                    when_result = evaluate_conditions(parse_conditions(as_list(rule.when)), resource, user)
+                    if when_result is ConditionEvaluation.MATCH:
                         decision = False
                         reason = rule.description or ""
                         break
                 elif rule.unless:
-                    if not matches_conditions(parse_conditions(as_list(rule.unless)), resource, user):
+                    unless_result = evaluate_conditions(parse_conditions(as_list(rule.unless)), resource, user)
+                    if unless_result is not ConditionEvaluation.MATCH:
                         decision = False
                         reason = rule.description or ""
                         break
@@ -184,12 +203,14 @@ def is_action_allowed(
                     break
             elif rule.permit and matches_scope(rule.permit, action, qualified_resource_id, user.principal):
                 if rule.when:
-                    if matches_conditions(parse_conditions(as_list(rule.when)), resource, user):
+                    when_result = evaluate_conditions(parse_conditions(as_list(rule.when)), resource, user)
+                    if when_result is ConditionEvaluation.MATCH:
                         decision = True
                         reason = rule.description or ""
                         break
                 elif rule.unless:
-                    if not matches_conditions(parse_conditions(as_list(rule.unless)), resource, user):
+                    unless_result = evaluate_conditions(parse_conditions(as_list(rule.unless)), resource, user)
+                    if unless_result is ConditionEvaluation.NO_MATCH:
                         decision = True
                         reason = rule.description or ""
                         break

--- a/src/ogx/core/access_control/conditions.py
+++ b/src/ogx/core/access_control/conditions.py
@@ -4,7 +4,12 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from enum import StrEnum
 from typing import Protocol
+
+from ogx.log import get_logger
+
+logger = get_logger(name=__name__, category="core::access_control")
 
 
 class User(Protocol):
@@ -25,7 +30,21 @@ class ProtectedResource(Protocol):
 class Condition(Protocol):
     """Protocol for access control conditions that evaluate resource-user relationships."""
 
+    def evaluate(self, resource: ProtectedResource, user: User) -> "ConditionEvaluation": ...
+
     def matches(self, resource: ProtectedResource, user: User) -> bool: ...
+
+
+class ConditionEvaluation(StrEnum):
+    """Tri-state result for evaluating access control conditions."""
+
+    MATCH = "match"
+    NO_MATCH = "no_match"
+    INDETERMINATE = "indeterminate"
+
+
+def _to_evaluation(matched: bool) -> ConditionEvaluation:
+    return ConditionEvaluation.MATCH if matched else ConditionEvaluation.NO_MATCH
 
 
 class UserInOwnersList:
@@ -45,17 +64,20 @@ class UserInOwnersList:
         else:
             return None
 
-    def matches(self, resource: ProtectedResource, user: User) -> bool:
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
         defined = self.owners_values(resource)
         if not defined:
-            return False
+            return ConditionEvaluation.NO_MATCH
         if not user.attributes or self.name not in user.attributes or not user.attributes[self.name]:
-            return False
+            return ConditionEvaluation.NO_MATCH
         user_values = user.attributes[self.name]
         for value in defined:
             if value in user_values:
-                return True
-        return False
+                return ConditionEvaluation.MATCH
+        return ConditionEvaluation.NO_MATCH
+
+    def matches(self, resource: ProtectedResource, user: User) -> bool:
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return f"user in owners {self.name}"
@@ -67,8 +89,24 @@ class UserNotInOwnersList(UserInOwnersList):
     def __init__(self, name: str):
         super().__init__(name)
 
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
+        if self.owners_values(resource) is None:
+            logger.warning(
+                "Negation condition denied access due to missing owner data",
+                condition=repr(self),
+            )
+            return ConditionEvaluation.INDETERMINATE
+        if not user.attributes or self.name not in user.attributes or not user.attributes[self.name]:
+            logger.warning(
+                "Negation condition denied access due to missing user attributes",
+                condition=repr(self),
+                attribute=self.name,
+            )
+            return ConditionEvaluation.INDETERMINATE
+        return _to_evaluation(super().evaluate(resource, user) is ConditionEvaluation.NO_MATCH)
+
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not super().matches(resource, user)
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return f"user not in owners {self.name}"
@@ -81,11 +119,14 @@ class UserWithValueInList:
         self.name = name
         self.value = value
 
-    def matches(self, resource: ProtectedResource, user: User) -> bool:
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
         if user.attributes and self.name in user.attributes:
-            return self.value in user.attributes[self.name]
-        print(f"User does not have {self.value} in {self.name}")
-        return False
+            return _to_evaluation(self.value in user.attributes[self.name])
+        logger.debug("User does not have attribute", value=self.value, attribute=self.name)
+        return ConditionEvaluation.NO_MATCH
+
+    def matches(self, resource: ProtectedResource, user: User) -> bool:
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return f"user with {self.value} in {self.name}"
@@ -97,8 +138,18 @@ class UserWithValueNotInList(UserWithValueInList):
     def __init__(self, name: str, value: str):
         super().__init__(name, value)
 
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
+        if not user.attributes or self.name not in user.attributes:
+            logger.warning(
+                "Negation condition denied access due to missing user attributes",
+                condition=repr(self),
+                attribute=self.name,
+            )
+            return ConditionEvaluation.INDETERMINATE
+        return _to_evaluation(self.value not in user.attributes[self.name])
+
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not super().matches(resource, user)
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return f"user with {self.value} not in {self.name}"
@@ -107,8 +158,11 @@ class UserWithValueNotInList(UserWithValueInList):
 class UserIsOwner:
     """Condition that checks if the user is the owner of the resource."""
 
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
+        return _to_evaluation(resource.owner.principal == user.principal if resource.owner else False)
+
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return resource.owner.principal == user.principal if resource.owner else False
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return "user is owner"
@@ -117,8 +171,17 @@ class UserIsOwner:
 class UserIsNotOwner:
     """Condition that checks if the user is NOT the owner of the resource."""
 
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
+        if not resource.owner:
+            logger.warning(
+                "Negation condition denied access due to missing resource owner",
+                condition=repr(self),
+            )
+            return ConditionEvaluation.INDETERMINATE
+        return _to_evaluation(resource.owner.principal != user.principal)
+
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not resource.owner or resource.owner.principal != user.principal
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return "user is not owner"
@@ -127,8 +190,11 @@ class UserIsNotOwner:
 class ResourceIsUnowned:
     """Condition that checks if the resource has no owner."""
 
+    def evaluate(self, resource: ProtectedResource, user: User) -> ConditionEvaluation:
+        return _to_evaluation(not resource.owner)
+
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not resource.owner
+        return self.evaluate(resource, user) is ConditionEvaluation.MATCH
 
     def __repr__(self) -> str:
         return "resource is unowned"

--- a/tests/unit/core/access_control/__init__.py
+++ b/tests/unit/core/access_control/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/unit/core/access_control/test_conditions.py
+++ b/tests/unit/core/access_control/test_conditions.py
@@ -1,0 +1,307 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from ogx.core.access_control.conditions import (
+    ResourceIsUnowned,
+    UserInOwnersList,
+    UserIsNotOwner,
+    UserIsOwner,
+    UserNotInOwnersList,
+    UserWithValueInList,
+    UserWithValueNotInList,
+    parse_condition,
+)
+
+
+@dataclass
+class MockUser:
+    principal: str
+    attributes: dict[str, list[str]] | None = None
+
+
+@dataclass
+class MockResource:
+    type: str = "model"
+    identifier: str = "test-model"
+    owner: MockUser | None = None
+
+
+@dataclass
+class MockOwner:
+    principal: str = "owner-1"
+    attributes: dict[str, list[str]] = field(default_factory=lambda: {"roles": ["admin"]})
+
+
+# --- UserIsOwner ---
+
+
+class TestUserIsOwner:
+    def test_user_is_owner(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=MockUser(principal="user-1"))
+        assert UserIsOwner().matches(resource, user) is True
+
+    def test_user_is_not_the_owner(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=MockUser(principal="user-2"))
+        assert UserIsOwner().matches(resource, user) is False
+
+    def test_resource_has_no_owner(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=None)
+        assert UserIsOwner().matches(resource, user) is False
+
+
+# --- UserIsNotOwner ---
+
+
+class TestUserIsNotOwner:
+    def test_user_is_not_the_owner(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=MockUser(principal="user-2"))
+        assert UserIsNotOwner().matches(resource, user) is True
+
+    def test_user_is_the_owner(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=MockUser(principal="user-1"))
+        assert UserIsNotOwner().matches(resource, user) is False
+
+    def test_missing_owner_denies_access(self):
+        """Regression: must fail-closed when resource has no owner."""
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=None)
+        assert UserIsNotOwner().matches(resource, user) is False
+
+    def test_missing_owner_in_route_context(self):
+        """Regression: _RouteContext has owner=None, must not grant access."""
+        user = MockUser(principal="user-1")
+        route_ctx = MockResource(type="route", identifier="route", owner=None)
+        assert UserIsNotOwner().matches(route_ctx, user) is False
+
+
+# --- UserInOwnersList ---
+
+
+class TestUserInOwnersList:
+    def test_user_in_owners_list(self):
+        owner = MockOwner(attributes={"teams": ["ml-team", "nlp-team"]})
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is True
+
+    def test_user_not_in_owners_list(self):
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"teams": ["infra-team"]})
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+    def test_no_owner(self):
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=None)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+    def test_owner_missing_attribute(self):
+        owner = MockOwner(attributes={"roles": ["admin"]})
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+    def test_user_missing_attributes(self):
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes=None)
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+    def test_user_missing_attribute_key(self):
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"roles": ["admin"]})
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+    def test_owner_empty_attribute_list(self):
+        owner = MockOwner(attributes={"teams": []})
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+    def test_user_empty_attribute_list(self):
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"teams": []})
+        resource = MockResource(owner=owner)
+        assert UserInOwnersList("teams").matches(resource, user) is False
+
+
+# --- UserNotInOwnersList ---
+
+
+class TestUserNotInOwnersList:
+    def test_user_not_in_owners_list(self):
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"teams": ["infra-team"]})
+        resource = MockResource(owner=owner)
+        assert UserNotInOwnersList("teams").matches(resource, user) is True
+
+    def test_user_in_owners_list(self):
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=owner)
+        assert UserNotInOwnersList("teams").matches(resource, user) is False
+
+    def test_missing_owner_denies_access(self):
+        """Regression: must fail-closed when resource has no owner."""
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=None)
+        assert UserNotInOwnersList("teams").matches(resource, user) is False
+
+    def test_owner_missing_attribute_denies_access(self):
+        """Regression: must fail-closed when owner lacks the attribute."""
+        owner = MockOwner(attributes={"roles": ["admin"]})
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource(owner=owner)
+        assert UserNotInOwnersList("teams").matches(resource, user) is False
+
+    def test_user_missing_attributes_denies_access(self):
+        """Regression: must fail-closed when user has no attributes."""
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes=None)
+        resource = MockResource(owner=owner)
+        assert UserNotInOwnersList("teams").matches(resource, user) is False
+
+    def test_user_missing_attribute_key_denies_access(self):
+        """Regression: must fail-closed when user lacks the attribute key."""
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"roles": ["admin"]})
+        resource = MockResource(owner=owner)
+        assert UserNotInOwnersList("teams").matches(resource, user) is False
+
+    def test_user_empty_attribute_list_denies_access(self):
+        """Regression: must fail-closed when user has empty attribute list."""
+        owner = MockOwner(attributes={"teams": ["ml-team"]})
+        user = MockUser(principal="user-1", attributes={"teams": []})
+        resource = MockResource(owner=owner)
+        assert UserNotInOwnersList("teams").matches(resource, user) is False
+
+    def test_route_context_missing_owner_denies_access(self):
+        """Regression: _RouteContext has owner=None, must not grant access."""
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        route_ctx = MockResource(type="route", identifier="route", owner=None)
+        assert UserNotInOwnersList("teams").matches(route_ctx, user) is False
+
+
+# --- UserWithValueInList ---
+
+
+class TestUserWithValueInList:
+    def test_user_has_value(self):
+        user = MockUser(principal="user-1", attributes={"roles": ["admin", "user"]})
+        resource = MockResource()
+        assert UserWithValueInList("roles", "admin").matches(resource, user) is True
+
+    def test_user_does_not_have_value(self):
+        user = MockUser(principal="user-1", attributes={"roles": ["user"]})
+        resource = MockResource()
+        assert UserWithValueInList("roles", "admin").matches(resource, user) is False
+
+    def test_user_missing_attributes(self):
+        user = MockUser(principal="user-1", attributes=None)
+        resource = MockResource()
+        assert UserWithValueInList("roles", "admin").matches(resource, user) is False
+
+    def test_user_missing_attribute_key(self):
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource()
+        assert UserWithValueInList("roles", "admin").matches(resource, user) is False
+
+
+# --- UserWithValueNotInList ---
+
+
+class TestUserWithValueNotInList:
+    def test_user_does_not_have_value(self):
+        user = MockUser(principal="user-1", attributes={"roles": ["user"]})
+        resource = MockResource()
+        assert UserWithValueNotInList("roles", "admin").matches(resource, user) is True
+
+    def test_user_has_value(self):
+        user = MockUser(principal="user-1", attributes={"roles": ["admin", "user"]})
+        resource = MockResource()
+        assert UserWithValueNotInList("roles", "admin").matches(resource, user) is False
+
+    def test_missing_attributes_denies_access(self):
+        """Regression: must fail-closed when user has no attributes."""
+        user = MockUser(principal="user-1", attributes=None)
+        resource = MockResource()
+        assert UserWithValueNotInList("roles", "admin").matches(resource, user) is False
+
+    def test_missing_attribute_key_denies_access(self):
+        """Regression: must fail-closed when user lacks the attribute key."""
+        user = MockUser(principal="user-1", attributes={"teams": ["ml-team"]})
+        resource = MockResource()
+        assert UserWithValueNotInList("roles", "admin").matches(resource, user) is False
+
+
+# --- ResourceIsUnowned ---
+
+
+class TestResourceIsUnowned:
+    def test_resource_is_unowned(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=None)
+        assert ResourceIsUnowned().matches(resource, user) is True
+
+    def test_resource_is_owned(self):
+        user = MockUser(principal="user-1")
+        resource = MockResource(owner=MockUser(principal="owner-1"))
+        assert ResourceIsUnowned().matches(resource, user) is False
+
+
+# --- parse_condition ---
+
+
+class TestParseCondition:
+    def test_user_is_owner(self):
+        condition = parse_condition("user is owner")
+        assert isinstance(condition, UserIsOwner)
+
+    def test_user_is_not_owner(self):
+        condition = parse_condition("user is not owner")
+        assert isinstance(condition, UserIsNotOwner)
+
+    def test_user_with_value_in_list(self):
+        condition = parse_condition("user with admin in roles")
+        assert isinstance(condition, UserWithValueInList)
+
+    def test_user_with_value_not_in_list(self):
+        condition = parse_condition("user with admin not in roles")
+        assert isinstance(condition, UserWithValueNotInList)
+
+    def test_user_in_owners_list(self):
+        condition = parse_condition("user in owners teams")
+        assert isinstance(condition, UserInOwnersList)
+
+    def test_user_not_in_owners_list(self):
+        condition = parse_condition("user not in owners teams")
+        assert isinstance(condition, UserNotInOwnersList)
+
+    def test_resource_is_unowned(self):
+        condition = parse_condition("resource is unowned")
+        assert isinstance(condition, ResourceIsUnowned)
+
+    def test_invalid_condition(self):
+        with pytest.raises(ValueError, match="Invalid condition"):
+            parse_condition("something invalid")
+
+    def test_empty_string(self):
+        with pytest.raises(ValueError, match="Invalid condition"):
+            parse_condition("")
+
+    def test_partial_match(self):
+        with pytest.raises(ValueError, match="Invalid condition"):
+            parse_condition("user is")

--- a/tests/unit/server/test_access_control.py
+++ b/tests/unit/server/test_access_control.py
@@ -385,6 +385,22 @@ def test_permit_unless():
     assert not is_action_allowed(policy, "read", model, User("user-2", {"namespaces": ["foo"]}))
 
 
+def test_permit_unless_user_not_in_owners_with_missing_owner_denies():
+    config = """
+    - permit:
+        actions: [read]
+      unless: user not in owners namespaces
+    """
+    policy = TypeAdapter(list[AccessRule]).validate_python(yaml.safe_load(config))
+    model = ModelWithOwner(
+        identifier="mymodel",
+        provider_id="myprovider",
+        model_type=ModelType.llm,
+        owner=None,
+    )
+    assert not is_action_allowed(policy, "read", model, User("user-1", {"namespaces": ["foo"]}))
+
+
 def test_forbid_when():
     config = """
     - forbid:
@@ -501,6 +517,22 @@ def test_is_not_owner():
     assert is_action_allowed(policy, "read", model, User("user-2", {"roles": ["admin"]}))
     assert not is_action_allowed(policy, "read", model, User("user-3", {"namespaces": ["foo"]}))
     assert not is_action_allowed(policy, "read", model, User("user-4", None))
+
+
+def test_is_not_owner_with_unowned_resource_denies():
+    config = """
+    - permit:
+        actions: [read]
+      unless: user is not owner
+    """
+    policy = TypeAdapter(list[AccessRule]).validate_python(yaml.safe_load(config))
+    model = ModelWithOwner(
+        identifier="mymodel",
+        provider_id="myprovider",
+        model_type=ModelType.llm,
+        owner=None,
+    )
+    assert not is_action_allowed(policy, "read", model, User("user-1", {"roles": ["basic"]}))
 
 
 def test_invalid_rule_permit_and_forbid_both_specified():


### PR DESCRIPTION
# What does this PR do?
This PR fixes ACL negation conditions that could fail open in `permit ... unless ...` rules when owner or user attribute data is missing.
It introduces tri-state condition evaluation (`match`, `no_match`, `indeterminate`) and updates rule evaluation so indeterminate results never widen access.
It also replaces a stray `print` with structured logging and adds targeted unit tests for condition behavior and server access-policy regressions.

## Test Plan
- `uv run pytest tests/unit/core/access_control/test_conditions.py tests/unit/server/test_access_control.py -q`
- Result: `74 passed, 2 warnings in 0.58s` (existing AsyncMock coroutine warnings in `tests/unit/server/test_access_control.py`).
