### PR TITLE
fix(ci): allow conventional commit scope in breaking-change ack regex

### DIFF
--- a/.github/workflows/backward-compat.yml
+++ b/.github/workflows/backward-compat.yml
@@ -117,7 +117,7 @@ jobs:
           fi
 
           # Check PR title for '!:' marker (conventional commits)
-          if [[ "$PR_TITLE" =~ ^[a-z]+\!: ]]; then
+          if [[ "$PR_TITLE" =~ ^[a-z]+(\([a-z0-9_-]+\))?\!: ]]; then
             echo "✓ Breaking change acknowledged in PR title"
             echo "acknowledged=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -224,7 +224,7 @@ jobs:
           fi
 
           # Check PR title for '!:' marker (conventional commits)
-          if [[ "$PR_TITLE" =~ ^[a-z]+\!: ]]; then
+          if [[ "$PR_TITLE" =~ ^[a-z]+(\([a-z0-9_-]+\))?\!: ]]; then
             echo "✓ Breaking change acknowledged in PR title"
             echo "acknowledged=true" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary

The breaking-change acknowledgment check in `.github/workflows/backward-compat.yml` uses the regex `^[a-z]+\!:` to detect a `!:` marker in the PR title. This rejects valid conventional-commit titles that include a scope, e.g. `feat(messages)!: ...`, causing the "Run Integration Tests with main Config" job to fail with "Breaking change NOT acknowledged" even when the title clearly marks the change as breaking.

Update the regex to `^[a-z]+(\([a-z0-9_-]+\))?\!:` so an optional `(scope)` is allowed between the type and `!:`. Both `feat!:` and `feat(messages)!:` now match.

## Test plan

- [x] Verified locally that `feat!: x`, `feat(messages)!: x`, and `fix(api-v2)!: x` all match the new regex
- [x] Verified `feat: x` (non-breaking) still does not match