### PR TITLE
fix(chore): cleanup integration-tests action ref after rename

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -150,7 +150,7 @@ jobs:
       # called from pull_request_target workflows.
       - name: Setup test environment
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}
-        uses: ogx-ai/llama-stack/.github/actions/setup-test-environment@68c0994a790e4f029007f3cce12a744d69a7d435
+        uses: ogx-ai/ogx/.github/actions/setup-test-environment@68c0994a790e4f029007f3cce12a744d69a7d435
         with:
           python-version: ${{ matrix.python-version }}
           client-version: ${{ matrix.client-version }}
@@ -171,13 +171,13 @@ jobs:
       - name: Setup TypeScript client
         if: ${{ matrix.client == 'server' }}
         id: setup-ts-client
-        uses: ogx-ai/llama-stack/.github/actions/setup-typescript-client@fb32709e3b29816b52085c92820531e4e6d94be8
+        uses: ogx-ai/ogx/.github/actions/setup-typescript-client@fb32709e3b29816b52085c92820531e4e6d94be8
         with:
           client-version: ${{ matrix.client-version }}
 
       - name: Run tests
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}
-        uses: ogx-ai/llama-stack/.github/actions/run-and-record-tests@fb32709e3b29816b52085c92820531e4e6d94be8
+        uses: ogx-ai/ogx/.github/actions/run-and-record-tests@fb32709e3b29816b52085c92820531e4e6d94be8
         env:
           OPENAI_API_KEY: dummy
           AZURE_API_KEY: replay-mode-dummy-key


### PR DESCRIPTION
# What does this PR do?
Update reference to github action to ogx project after rename.

## Test Plan
Check links in browser:
* https://github.com/ogx-ai/ogx/tree/68c0994a790e4f029007f3cce12a744d69a7d435/.github/actions/setup-test-environment
* https://github.com/ogx-ai/ogx/tree/fb32709e3b29816b52085c92820531e4e6d94be8/.github/actions/setup-typescript-client 
* https://github.com/ogx-ai/ogx/tree/fb32709e3b29816b52085c92820531e4e6d94be8/.github/actions/run-and-record-tests
