### PR TITLE
fix(conversations): compute has_more from actual record count in list_items

### DIFF
--- a/src/ogx/core/conversations/conversations.py
+++ b/src/ogx/core/conversations/conversations.py
@@ -287,6 +287,9 @@ class ConversationServiceImpl(Conversations):
 
         actual_limit = request.limit or 20
 
+        # Determine has_more BEFORE slicing: if more records exist than the
+        # requested limit there are additional pages the caller has not seen.
+        has_more = len(records) > actual_limit
         records = records[:actual_limit]
         items = [record["item_data"] for record in records]
 
@@ -300,7 +303,7 @@ class ConversationServiceImpl(Conversations):
             data=response_items,
             first_id=first_id,
             last_id=last_id,
-            has_more=False,
+            has_more=has_more,
         )
 
     async def openai_delete_conversation_item(self, request: DeleteItemRequest) -> ConversationItemDeletedResource:


### PR DESCRIPTION
## Summary

`list_items()` in the Conversations API always returned `has_more=False`, so pagination clients (OpenAI Agents SDK, LibreChat, etc.) never fetched additional pages and silently dropped any conversation items beyond the first page (default limit = 20).

## Root cause

`has_more` was hardcoded:

```python
records = records[:actual_limit]
...
return ConversationItemList(
    ...
    has_more=False,   # always False — never paginates
)
```

## Fix

Check the total record count **before** slicing:

```python
has_more = len(records) > actual_limit
records = records[:actual_limit]
...
return ConversationItemList(..., has_more=has_more)
```

The `create_items` path that also returns `has_more=False` is intentionally unchanged — it returns exactly the items just created in that batch, where no further pages exist.

Fixes #5611