### PR TITLE
fix(openai_mixin): short-circuit /v1/models call when allowed_models is configured

### DIFF
--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -517,6 +517,20 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         """
         self._model_cache = {}
 
+        # Short-circuit: if allowed_models is explicitly configured, use it directly.
+        # This avoids calling /v1/models on providers that do not support that endpoint
+        # (e.g. OpenAI-compatible proxies for Gemini), where the call would crash startup.
+        if self.config.allowed_models:
+            logger.info(
+                "allowed_models configured - using static list, skipping /v1/models",
+                provider=self.__class__.__name__,
+                count=len(self.config.allowed_models),
+            )
+            for provider_model_id in self.config.allowed_models:
+                model = self.construct_model_from_identifier(provider_model_id)
+                self._model_cache[provider_model_id] = model
+            return list(self._model_cache.values())
+
         api_key = self._get_api_key_from_config_or_provider_data()
         if not api_key:
             logger.debug(
@@ -545,9 +559,6 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         for provider_model_id in provider_models_ids:
             if not isinstance(provider_model_id, str):
                 raise ValueError(f"Model ID {provider_model_id} from list_provider_model_ids() is not a string")
-            if self.config.allowed_models is not None and provider_model_id not in self.config.allowed_models:
-                logger.info("Skipping model not in allowed models list", model=provider_model_id)
-                continue
             model = self.construct_model_from_identifier(provider_model_id)
             self._model_cache[provider_model_id] = model
 

--- a/tests/unit/providers/utils/inference/test_openai_mixin_provider_data.py
+++ b/tests/unit/providers/utils/inference/test_openai_mixin_provider_data.py
@@ -70,6 +70,35 @@ class TestOpenAIMixinCustomListProviderModelIds:
         assert len(result) == 1
         assert result[0].identifier == "model-1"
 
+    async def test_allowed_models_skips_provider_call(self, config):
+        """When allowed_models is set, list_provider_model_ids() must NOT be called.
+
+        Providers that do not support /v1/models (e.g. OpenAI-compatible Gemini proxies)
+        crash on startup if list_provider_model_ids() is called. The short-circuit fix
+        ensures those providers work when allowed_models is configured (issue #5573).
+        """
+        mixin = CustomListProviderModelIdsImplementation(
+            config=config, custom_model_ids=[]  # would return nothing if called
+        )
+        mixin.config.allowed_models = ["gemini-2.5-pro", "gemini-2.0-flash"]
+        # Verify that list_provider_model_ids is never called.
+        call_count = 0
+
+        original = mixin.list_provider_model_ids
+
+        async def spy(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return await original(*args, **kwargs)
+
+        mixin.list_provider_model_ids = spy  # type: ignore[method-assign]
+
+        result = await mixin.list_models()
+
+        assert call_count == 0, "list_provider_model_ids() must not be called when allowed_models is set"
+        assert result is not None
+        assert {m.identifier for m in result} == {"gemini-2.5-pro", "gemini-2.0-flash"}
+
     async def test_with_empty_list(self, config):
         """Test that custom list_provider_model_ids() handles empty list correctly"""
         mixin = CustomListProviderModelIdsImplementation(config=config, custom_model_ids=[])


### PR DESCRIPTION
## Summary

`list_models()` always called `list_provider_model_ids()` (which hits `/v1/models`) even when the operator had configured `allowed_models`. For providers that do not expose `/v1/models` (e.g. OpenAI-compatible Gemini proxies via Models.corp), this crashed startup before the filter ever ran.

A second related bug: the post-call filter used **exact** string comparison. Some providers return IDs with a `"models/"` prefix (e.g. `"models/gemini-2.5-pro"`) while the config typically lists bare IDs (`"gemini-2.5-pro"`). This caused all models to be silently skipped and registration to fail with `"Model X is not available from provider"`.

## Root cause

```python
# Before: always called /v1/models, then filtered
iterable = await self.list_provider_model_ids()   # crashes for some providers
...
if self.config.allowed_models is not None and provider_model_id not in self.config.allowed_models:
    continue  # exact match fails for "models/gemini-2.5-pro" vs "gemini-2.5-pro"
```

## Fix

When `allowed_models` is non-empty, return it directly without calling `list_provider_model_ids()`. `allowed_models` is the authoritative list the operator wants — no provider call needed:

```python
if self.config.allowed_models:
    for provider_model_id in self.config.allowed_models:
        model = self.construct_model_from_identifier(provider_model_id)
        self._model_cache[provider_model_id] = model
    return list(self._model_cache.values())
# existing /v1/models path follows for when allowed_models is not set
```

## Tests

Added `test_allowed_models_skips_provider_call` in `tests/unit/providers/utils/inference/test_openai_mixin_provider_data.py` which uses a spy to verify `list_provider_model_ids()` is never invoked when `allowed_models` is configured, and checks the returned model identifiers match the configured list exactly.

Fixes #5573