### PR TITLE
fix(nvidia-safety): use provider_resource_id instead of shield_id for NeMoGuardrails model

### DIFF
--- a/src/ogx/providers/remote/safety/nvidia/nvidia.py
+++ b/src/ogx/providers/remote/safety/nvidia/nvidia.py
@@ -58,7 +58,7 @@ class NVIDIASafetyAdapter(ShieldToModerationMixin, Safety, ShieldsProtocolPrivat
         if not shield:
             raise ValueError(f"Shield {request.shield_id} not found")
 
-        self.shield = NeMoGuardrails(self.config, shield.shield_id)
+        self.shield = NeMoGuardrails(self.config, shield.provider_resource_id)
         return await self.shield.run(request.messages)
 
 

--- a/tests/unit/providers/nvidia/test_safety.py
+++ b/tests/unit/providers/nvidia/test_safety.py
@@ -157,7 +157,7 @@ async def test_run_shield_allowed(nvidia_adapter, mock_guardrails_post):
     mock_guardrails_post.assert_called_once_with(
         path="/v1/guardrail/checks",
         data={
-            "model": shield_id,
+            "model": "test-model",  # provider_resource_id, not shield identifier
             "messages": [
                 {"role": "user", "content": "Hello, how are you?"},
                 {"role": "assistant", "content": "I'm doing well, thank you for asking!"},
@@ -212,7 +212,7 @@ async def test_run_shield_blocked(nvidia_adapter, mock_guardrails_post):
     mock_guardrails_post.assert_called_once_with(
         path="/v1/guardrail/checks",
         data={
-            "model": shield_id,
+            "model": "test-model",  # provider_resource_id, not shield identifier
             "messages": [
                 {"role": "user", "content": "Hello, how are you?"},
                 {"role": "assistant", "content": "I'm doing well, thank you for asking!"},
@@ -294,7 +294,7 @@ async def test_run_shield_http_error(nvidia_adapter, mock_guardrails_post):
     mock_guardrails_post.assert_called_once_with(
         path="/v1/guardrail/checks",
         data={
-            "model": shield_id,
+            "model": "test-model",  # provider_resource_id, not shield identifier
             "messages": [
                 {"role": "user", "content": "Hello, how are you?"},
                 {"role": "assistant", "content": "I'm doing well, thank you for asking!"},


### PR DESCRIPTION
## Summary

`NVIDIASafetyAdapter.run_shield()` passed `shield.shield_id` as the model name to `NeMoGuardrails`, but `Shield.shield_id` is a property that returns `self.identifier` — the Llama Stack-level name (e.g. `"my-nvidia-shield"`). The NVIDIA guardrails API needs the **provider model identifier** (e.g. `"meta/llama-guard-3-8b"`) configured by the operator as `provider_resource_id`.

## Root cause

```python
# Before
self.shield = NeMoGuardrails(self.config, shield.shield_id)
#                                         ^^^^^^^^^^^^^^ returns self.identifier
#                                         "my-nvidia-shield" — the LS identifier
```

`register_shield` already validates `shield.provider_resource_id` is set, confirming `provider_resource_id` is the intended model name for NVIDIA.

## Fix

```python
# After
self.shield = NeMoGuardrails(self.config, shield.provider_resource_id)
#                                         ^^^^^^^^^^^^^^^^^^^^^^^^^ "meta/llama-guard-3-8b"
```

## Tests

Updated `tests/unit/providers/nvidia/test_safety.py` to assert the guardrails API receives `"model": "test-model"` (the `provider_resource_id`) instead of `"model": shield_id` (the shield identifier). The existing tests were asserting the wrong — now fixed — behavior across three test cases.

Fixes #4899