### PR TITLE
fix(auth): make negation access-control conditions fail-closed on missing data

### DIFF
--- a/src/ogx/core/access_control/conditions.py
+++ b/src/ogx/core/access_control/conditions.py
@@ -68,7 +68,15 @@ class UserNotInOwnersList(UserInOwnersList):
         super().__init__(name)
 
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not super().matches(resource, user)
+        # Fail-closed: if owner attribute list is missing or user attributes are missing,
+        # deny access rather than granting it via a vacuous negation.
+        defined = self.owners_values(resource)
+        if not defined:
+            return False
+        if not user.attributes or self.name not in user.attributes or not user.attributes[self.name]:
+            return False
+        user_values = user.attributes[self.name]
+        return not any(value in user_values for value in defined)
 
     def __repr__(self) -> str:
         return f"user not in owners {self.name}"
@@ -98,7 +106,11 @@ class UserWithValueNotInList(UserWithValueInList):
         super().__init__(name, value)
 
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not super().matches(resource, user)
+        # Fail-closed: if user attribute data is missing, deny rather than granting
+        # access through a vacuous negation.
+        if not user.attributes or self.name not in user.attributes:
+            return False
+        return self.value not in user.attributes[self.name]
 
     def __repr__(self) -> str:
         return f"user with {self.value} not in {self.name}"
@@ -118,7 +130,12 @@ class UserIsNotOwner:
     """Condition that checks if the user is NOT the owner of the resource."""
 
     def matches(self, resource: ProtectedResource, user: User) -> bool:
-        return not resource.owner or resource.owner.principal != user.principal
+        # Fail-closed: if ownership data is absent, deny rather than granting access
+        # through a vacuous negation. Use ResourceIsUnowned to explicitly match
+        # resources with no owner.
+        if not resource.owner:
+            return False
+        return resource.owner.principal != user.principal
 
     def __repr__(self) -> str:
         return "user is not owner"

--- a/tests/unit/core/access_control/test_conditions_fail_closed.py
+++ b/tests/unit/core/access_control/test_conditions_fail_closed.py
@@ -1,0 +1,109 @@
+"""Tests that negation access-control conditions fail closed on missing data (issue #5700)."""
+from ogx.core.access_control.conditions import (
+    UserIsNotOwner,
+    UserNotInOwnersList,
+    UserWithValueNotInList,
+)
+
+
+class _User:
+    def __init__(self, principal: str, attributes: dict | None = None):
+        self.principal = principal
+        self.attributes = attributes
+
+
+class _Owner:
+    def __init__(self, principal: str, attributes: dict | None = None):
+        self.principal = principal
+        self.attributes = attributes
+
+
+class _Resource:
+    def __init__(self, owner=None):
+        self.type = "test"
+        self.identifier = "res-1"
+        self.owner = owner
+
+
+class TestUserNotInOwnersListFailClosed:
+    def test_no_owner_denies(self):
+        cond = UserNotInOwnersList("roles")
+        user = _User("alice", {"roles": ["admin"]})
+        resource = _Resource(owner=None)
+        assert cond.matches(resource, user) is False, "no owner → must deny"
+
+    def test_owner_no_attribute_denies(self):
+        cond = UserNotInOwnersList("roles")
+        user = _User("alice", {"roles": ["admin"]})
+        owner = _Owner("bob", attributes=None)
+        resource = _Resource(owner=owner)
+        assert cond.matches(resource, user) is False, "owner has no attributes → must deny"
+
+    def test_user_no_attribute_denies(self):
+        cond = UserNotInOwnersList("roles")
+        user = _User("alice", attributes=None)
+        owner = _Owner("bob", {"roles": ["admin"]})
+        resource = _Resource(owner=owner)
+        assert cond.matches(resource, user) is False, "user has no attributes → must deny"
+
+    def test_user_genuinely_not_in_list_grants(self):
+        cond = UserNotInOwnersList("roles")
+        user = _User("alice", {"roles": ["viewer"]})
+        owner = _Owner("bob", {"roles": ["admin", "editor"]})
+        resource = _Resource(owner=owner)
+        assert cond.matches(resource, user) is True, "user not in list → should grant"
+
+    def test_user_in_list_denies(self):
+        cond = UserNotInOwnersList("roles")
+        user = _User("alice", {"roles": ["admin"]})
+        owner = _Owner("bob", {"roles": ["admin"]})
+        resource = _Resource(owner=owner)
+        assert cond.matches(resource, user) is False, "user in list → should deny"
+
+
+class TestUserWithValueNotInListFailClosed:
+    def test_user_no_attributes_denies(self):
+        cond = UserWithValueNotInList("roles", "admin")
+        user = _User("alice", attributes=None)
+        resource = _Resource()
+        assert cond.matches(resource, user) is False, "user has no attributes → must deny"
+
+    def test_user_missing_attribute_key_denies(self):
+        cond = UserWithValueNotInList("roles", "admin")
+        user = _User("alice", {"teams": ["eng"]})
+        resource = _Resource()
+        assert cond.matches(resource, user) is False, "user missing the key → must deny"
+
+    def test_user_genuinely_not_having_value_grants(self):
+        cond = UserWithValueNotInList("roles", "admin")
+        user = _User("alice", {"roles": ["viewer"]})
+        resource = _Resource()
+        assert cond.matches(resource, user) is True, "user lacks value → should grant"
+
+    def test_user_having_value_denies(self):
+        cond = UserWithValueNotInList("roles", "admin")
+        user = _User("alice", {"roles": ["admin"]})
+        resource = _Resource()
+        assert cond.matches(resource, user) is False, "user has value → should deny"
+
+
+class TestUserIsNotOwnerFailClosed:
+    def test_no_owner_denies(self):
+        cond = UserIsNotOwner()
+        user = _User("alice")
+        resource = _Resource(owner=None)
+        assert cond.matches(resource, user) is False, "no owner → must deny"
+
+    def test_different_owner_grants(self):
+        cond = UserIsNotOwner()
+        user = _User("alice")
+        owner = _Owner("bob")
+        resource = _Resource(owner=owner)
+        assert cond.matches(resource, user) is True, "different owner → should grant"
+
+    def test_same_owner_denies(self):
+        cond = UserIsNotOwner()
+        user = _User("alice")
+        owner = _Owner("alice")
+        resource = _Resource(owner=owner)
+        assert cond.matches(resource, user) is False, "user is owner → should deny"


### PR DESCRIPTION
## Summary

Fixes #5700

Three negation conditions in `src/ogx/core/access_control/conditions.py` used `not super().matches()` or equivalent logic that returned `True` (grant access) when resource ownership or user attribute data was absent. This is fail-open behavior that can silently grant access to users who should be denied.

### Root cause

- **`UserNotInOwnersList.matches`** - if the owner has no attribute list configured for the checked name, `super().matches()` returns `False`, so `not False = True` granted access to any user. Same when the user has no relevant attributes.
- **`UserWithValueNotInList.matches`** - if the user had no attributes at all, `super().matches()` returned `False`, so `not False = True` granted access to unauthenticated/partial users.
- **`UserIsNotOwner.matches`** - `not resource.owner` was `True` for unowned resources, granting every user access to resources with no owner set.

### Fix

Each negation condition now explicitly checks for missing data and returns `False` (deny) instead of delegating to a bare `not`. Use `ResourceIsUnowned` to deliberately match resources with no owner.

## Tests

Added `tests/unit/core/access_control/test_conditions_fail_closed.py` with 12 cases covering the fail-closed paths and the happy paths for all three conditions.
