### PR TITLE
ci(security): add Python SAST via Ruff bandit rules and CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     # PRs are checked for new issues
     branches: [ "main" ]
-    # Limit scans to changes in the .github directory, bash scripts are not scanned anyway
     paths:
       - '.github/**'
+      - 'src/**'
 
 jobs:
   analyze:
@@ -15,10 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # actions is the most specific language option for
-        # codeql does NOT support Bash
-        # In case javascript is used in workflows, that should be added or replace
-        language: [ 'actions' ]
+        language: [ 'actions', 'python' ]
 
     steps:
     - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,9 +346,9 @@ convention = "google"
 # TODO: Fix in follow up PRs
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["DTZ", "D101", "S104", "S105", "S106", "S108", "S110", "S310", "S311", "S603", "S607", "S608"] # Ignore datetime, docstring, and security false positives for tests
-"benchmarking/**/*.py" = ["D101"] # Ignore docstring rules for benchmarking scripts
-"client-sdks/**/*.py" = ["D101"] # Ignore docstring rules for client SDKs
-"scripts/**/*.py" = ["D101"] # Ignore docstring rules for scripts
+"benchmarking/**/*.py" = ["D101", "S104", "S110", "S311"] # Ignore docstring and security rules for benchmarking scripts
+"client-sdks/**/*.py" = ["D101", "S110", "S112", "S113"] # Ignore docstring and security rules for client SDKs
+"scripts/**/*.py" = ["D101", "S110", "S112", "S603", "S607"] # Ignore docstring and security rules for scripts
 "src/ogx/providers/inline/scoring/basic/utils/ifeval_support.py" = [
     "RUF001",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,6 +306,7 @@ select = [
     "F",       # Pyflakes
     "N",       # Naming
     "W",       # Warnings
+    "S",       # flake8-bandit (security)
     "DTZ",     # datetime rules
     "I",       # isort (imports order)
     "RUF001",  # Checks for ambiguous Unicode characters in strings
@@ -330,6 +331,9 @@ ignore = [
 
     # These are the additional ones we started ignoring after moving to ruff. We should look into each one of them later.
     "C901", # Complexity of the function is too high
+
+    # Security rules: assert is used extensively as an internal invariant pattern
+    "S101", # Use of assert detected
 ]
 unfixable = [
     "PLE2515",
@@ -341,7 +345,7 @@ convention = "google"
 # Ignore the following errors for the following files
 # TODO: Fix in follow up PRs
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["DTZ", "D101"] # Ignore datetime and docstring rules for tests
+"tests/**/*.py" = ["DTZ", "D101", "S104", "S105", "S106", "S108", "S110", "S310", "S311", "S603", "S607", "S608"] # Ignore datetime, docstring, and security false positives for tests
 "benchmarking/**/*.py" = ["D101"] # Ignore docstring rules for benchmarking scripts
 "client-sdks/**/*.py" = ["D101"] # Ignore docstring rules for client SDKs
 "scripts/**/*.py" = ["D101"] # Ignore docstring rules for scripts
@@ -364,6 +368,22 @@ convention = "google"
 "src/ogx/apis/**/__init__.py" = [
     "F403",
 ] # Using import * is acceptable (or at least tolerated) in an __init__.py of a package API
+# Security rule suppressions for known false positives
+"src/ogx/core/datatypes.py" = ["S105"] # Enum values like OAUTH2_TOKEN are not hardcoded secrets
+"src/ogx/distributions/**/*.py" = ["S106"] # Env var template defaults (e.g. ${env.PGVECTOR_PASSWORD:=})
+"src/ogx/providers/remote/**/config.py" = ["S107"] # Env var template defaults in provider configs
+"src/ogx/providers/remote/inference/oci/auth.py" = ["S106"] # pass_phrase="none" placeholder
+"src/ogx/cli/**/*.py" = ["S603", "S607"] # CLI tools legitimately invoke subprocesses
+"src/ogx/core/utils/exec.py" = ["S603"] # Command execution utility
+"src/ogx/core/storage/**/*.py" = ["S608"] # Table name interpolation covered by custom SQL injection hook
+"src/ogx/providers/**/vector_io/**/*.py" = ["S608"] # Table name interpolation covered by custom SQL injection hook
+"src/ogx/core/routers/safety.py" = ["S608"] # Error message formatting, not SQL
+"src/ogx/core/library_client.py" = ["S112"] # Intentional try-except-continue for type coercion
+"src/ogx/core/routers/tool_runtime.py" = ["S110"] # Intentional try-except-pass for optional metric context
+"src/ogx/core/routing_tables/models.py" = ["S112"] # Intentional try-except-continue for credential probing
+"src/ogx/providers/inline/messages/impl.py" = ["S110"] # Intentional try-except-pass for optional model lookup
+"src/ogx/providers/utils/memory/openai_vector_store_mixin.py" = ["S112", "S311"] # Intentional retry logic
+"src/ogx/testing/api_recorder.py" = ["S110", "S310"] # Test infrastructure
 
 [tool.mypy]
 mypy_path = ["src"]


### PR DESCRIPTION
## Summary

- Enable Ruff's `S` (flake8-bandit) security rule set for Python SAST, catching issues like hardcoded passwords, unsafe subprocess calls, and SQL injection patterns at lint time
- Add Python to the existing CodeQL workflow for deeper semantic security analysis on PRs touching `src/`
- Add targeted `per-file-ignores` to suppress known false positives (test fixtures, CLI subprocess calls, SQL table name interpolation guarded by existing hooks)

## Test plan

- [x] `uv run ruff check` passes with the new rules enabled
- [x] CodeQL workflow updated to scan Python in addition to GitHub Actions
- [ ] CI validates both ruff and CodeQL on this PR

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>