### PR TITLE
docs(website): update landing page to promote library mode

### DIFF
--- a/docs/src/components/InstallBlock/index.jsx
+++ b/docs/src/components/InstallBlock/index.jsx
@@ -3,7 +3,7 @@ import styles from './styles.module.css';
 
 const EXAMPLES = [
   {
-    label: 'Local (Ollama)',
+    label: 'Server',
     command: "uvx --from 'ogx[starter]' ogx stack run starter",
     tokens: [
       { text: 'uvx', style: 'tokenBinary' },
@@ -16,21 +16,28 @@ const EXAMPLES = [
     ],
   },
   {
-    label: 'OpenAI',
-    command: "export OPENAI_API_KEY=sk-xxx\nuvx --from 'ogx[starter]' ogx stack run starter",
+    label: 'Library',
+    command: "from ogx.core.library_client import OGXAsLibraryClient\n\nclient = OGXAsLibraryClient(\"starter\")\nresponse = client.responses.create(model=\"llama-3.3-70b\", input=\"Hello\")",
     lines: [
       [
-        { text: 'export', style: 'tokenBinary' },
-        { text: 'OPENAI_API_KEY=sk-xxx', style: 'tokenFlag' },
+        { text: 'from', style: 'tokenBinary' },
+        { text: 'ogx.core.library_client', style: 'tokenPackage' },
+        { text: 'import', style: 'tokenBinary' },
+        { text: 'OGXAsLibraryClient', style: 'tokenCommand' },
+      ],
+      [],
+      [
+        { text: 'client', style: 'tokenSub' },
+        { text: '=', style: 'tokenSub' },
+        { text: 'OGXAsLibraryClient("starter")', style: 'tokenCommand' },
       ],
       [
-        { text: 'uvx', style: 'tokenBinary' },
-        { text: '--from', style: 'tokenFlag' },
-        { text: "'ogx[starter]'", style: 'tokenPackage' },
-        { text: 'ogx', style: 'tokenCommand' },
-        { text: 'stack', style: 'tokenSub' },
-        { text: 'run', style: 'tokenSub' },
-        { text: 'starter', style: 'tokenAccent' },
+        { text: 'response', style: 'tokenSub' },
+        { text: '=', style: 'tokenSub' },
+        { text: 'client.responses.create(', style: 'tokenCommand' },
+        { text: 'model="llama-3.3-70b",', style: 'tokenFlag' },
+        { text: 'input="Hello"', style: 'tokenAccent' },
+        { text: ')', style: 'tokenCommand' },
       ],
     ],
   },
@@ -75,7 +82,7 @@ export default function InstallBlock() {
   return (
     <div className={styles.installBlock}>
       <p className={styles.tagline}>
-        Try it now, no installation required{' '}
+        Run as a server or import as a Python library{' '}
         <a href="https://docs.astral.sh/uv/getting-started/installation/" target="_blank" rel="noopener noreferrer" className={styles.taglineLink}>(requires uv)</a>
       </p>
       <div className={styles.tabRow}>
@@ -95,14 +102,18 @@ export default function InstallBlock() {
           <span className={styles.commandReveal} key={active}>
             {EXAMPLES[active].lines ? (
               EXAMPLES[active].lines.map((line, li) => (
-                <span key={li} className={styles.commandLine}>
-                  {line.map((tok, ti) => (
-                    <span key={ti}>
-                      {ti > 0 && <span className={styles.space}> </span>}
-                      <span className={styles[tok.style]}>{tok.text}</span>
-                    </span>
-                  ))}
-                </span>
+                line.length === 0 ? (
+                  <span key={li} className={styles.commandLineBlank}>{' '}</span>
+                ) : (
+                  <span key={li} className={styles.commandLine}>
+                    {line.map((tok, ti) => (
+                      <span key={ti}>
+                        {ti > 0 && <span className={styles.space}> </span>}
+                        <span className={styles[tok.style]}>{tok.text}</span>
+                      </span>
+                    ))}
+                  </span>
+                )
               ))
             ) : (
               EXAMPLES[active].tokens.map((tok, i) => (

--- a/docs/src/components/InstallBlock/styles.module.css
+++ b/docs/src/components/InstallBlock/styles.module.css
@@ -107,9 +107,9 @@
   font-size: 0.78rem;
   line-height: 1.6;
   color: var(--ifm-font-color-base);
-  white-space: nowrap;
+  white-space: pre;
   overflow-x: auto;
-  text-align: center;
+  text-align: left;
 }
 
 .commandReveal {
@@ -123,6 +123,11 @@
 
 .commandLine + .commandLine {
   margin-top: 0.25rem;
+}
+
+.commandLineBlank {
+  display: block;
+  min-height: 1em;
 }
 
 .space {

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -684,7 +684,7 @@ function Hero() {
             </h1>
             <p className={styles.subtitle}>
               Inference, vector stores, file storage, safety, tool calling,
-              and agentic orchestration in a single OpenAI-compatible server.
+              and agentic orchestration — as a server or a Python library.
               Pluggable providers, any language, deploy anywhere.
             </p>
             <InstallBlock />
@@ -714,10 +714,11 @@ function ApiSurface() {
     <Section className={styles.apiSection}>
       <div className="container">
         <div className={styles.apiHeader}>
-          <h2>Everything your AI app needs. One server.</h2>
+          <h2>Everything your AI app needs. One process.</h2>
           <p>
             More than inference routing. OGX composes inference, storage,
-            safety, and orchestration into a single process. Your agent can search
+            safety, and orchestration into a single process — whether you
+            run it as a server or import it as a library. Your agent can search
             a vector store, call a tool, check safety, and stream the response.
             No glue code. No sidecar services.
           </p>
@@ -748,34 +749,35 @@ function ApiSurface() {
   );
 }
 
-function ServerNotLibrary() {
+function ServerAndLibrary() {
   return (
     <Section className={styles.serverSection}>
       <div className="container">
         <div className={styles.serverLayout}>
           <div>
-            <h2>A server, not a library</h2>
+            <h2>Server or library. Your call.</h2>
             <p>
-              SDK abstractions couple your app to a specific language, release
-              cycle, and import path. OGX is an HTTP server. Your app
-              talks to a standard API.
+              Deploy OGX as an HTTP server for production — any language,
+              any client, standard API. Or import it directly as a Python
+              library for scripts, notebooks, and rapid prototyping with
+              zero network overhead.
             </p>
             <p>
-              Write in Python, Go, TypeScript, curl. Swap the server without
-              touching application code. That's the difference between library
-              abstraction and server abstraction.
+              Same capabilities either way. Start with the library, graduate
+              to the server when you need multi-language access or
+              independent scaling.
             </p>
           </div>
           <div className={styles.serverComparison}>
             <div className={styles.comparisonRow}>
-              <span className={styles.comparisonLabel}>SDK library</span>
-              <code className={styles.comparisonCode}>from sdk import ...</code>
-              <span className={styles.comparisonNote}>coupled</span>
-            </div>
-            <div className={styles.comparisonRow}>
-              <span className={styles.comparisonLabel}>OGX</span>
+              <span className={styles.comparisonLabel}>Server</span>
               <code className={styles.comparisonCode}>POST /v1/responses</code>
               <span className={styles.comparisonGood}>any language</span>
+            </div>
+            <div className={styles.comparisonRow}>
+              <span className={styles.comparisonLabel}>Library</span>
+              <code className={styles.comparisonCode}>client.responses.create(...)</code>
+              <span className={styles.comparisonGood}>zero overhead</span>
             </div>
           </div>
         </div>
@@ -812,10 +814,10 @@ function Architecture() {
       <div className="container">
         <h2>How it works</h2>
         <p className={styles.archDesc}>
-          Your application talks to one server. That server routes
-          to pluggable providers for inference, vector storage, files,
-          safety, and tools. The composition happens at the server level,
-          not in your application code.
+          Your application talks to one process — either an HTTP server
+          or an in-process library client. That process routes to pluggable
+          providers for inference, vector storage, files, safety, and tools.
+          The composition happens at the OGX level, not in your application code.
         </p>
         <div className={styles.archImg}>
           <img src="/img/architecture-animated.svg" alt="OGX Architecture" loading="lazy" />
@@ -858,13 +860,13 @@ function Bottom() {
 
 export default function Home() {
   return (
-    <Layout title="The Open-Source AI Application Server" description="Inference, vector stores, safety, tools, and agentic orchestration. One server, OpenAI + Anthropic + Google compatible, pluggable providers.">
+    <Layout title="The Open-Source AI Application Server & Library" description="Inference, vector stores, safety, tools, and agentic orchestration. Server or Python library, OpenAI + Anthropic + Google compatible, pluggable providers.">
       <main>
         <AnnouncementBanner />
         <Hero />
         <CliShowcase />
         <ApiSurface />
-        <ServerNotLibrary />
+        <ServerAndLibrary />
         <Providers />
         <Architecture />
         <Bottom />


### PR DESCRIPTION
## Summary

- Replace the "OpenAI" install tab with a "Library" tab showing the `OGXAsLibraryClient` Python API
- Reframe the "A server, not a library" section to "Server or library. Your call." with updated comparison rows
- Update taglines, hero subtitle, API surface description, and architecture section to reflect the dual server/library deployment model
- Add support for blank lines in multi-line code blocks in the InstallBlock component

## Test plan

- [ ] Verify the docs site builds without errors (`cd docs && npm run build`)
- [ ] Check the landing page renders correctly in both dark and light mode
- [ ] Confirm the "Server" and "Library" tabs switch correctly in the InstallBlock
- [ ] Verify the Library code block displays with proper formatting and blank lines
- [ ] Check responsive layout on mobile viewports

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>