### PR TITLE
feat(storage)!: enforce AuthorizedSqlStore usage for APIs requiring access control

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -308,6 +308,26 @@ repos:
             }
             exit 0
 
+      - id: enforce-authorized-sqlstore
+        name: Enforce AuthorizedSqlStore usage
+        entry: bash
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
+        files: ^src/
+        args:
+          - -c
+          - |
+            grep -rn --include="*.py" -E 'sqlstore_impl' src/ \
+              | grep -v 'core/storage/sqlstore/' && {
+              echo;
+              echo "❌ Direct sqlstore_impl usage is not allowed outside core/storage/sqlstore/.";
+              echo "Use authorized_sqlstore() from ogx.core.storage.sqlstore.authorized_sqlstore instead.";
+              echo;
+              exit 1;
+            } || true
+
       - id: check-file-size
         name: Check Python file size limit
         entry: python scripts/check_file_size.py

--- a/docs/docs/providers/responses/inline_builtin.mdx
+++ b/docs/docs/providers/responses/inline_builtin.mdx
@@ -15,9 +15,6 @@ Meta's reference implementation of an agent system that can use tools, access ve
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `persistence` | `ResponsesPersistenceConfig` | No |  |  |
-| `persistence.agent_state` | `KVStoreReference` | No |  |  |
-| `persistence.agent_state.namespace` | `str` | No |  | Key prefix for KVStore backends |
-| `persistence.agent_state.backend` | `str` | No |  | Name of backend from storage.backends |
 | `persistence.responses` | `ResponsesStoreReference` | No |  |  |
 | `persistence.responses.table_name` | `str` | No | openai_responses | Name of the table to use for storing OpenAI responses |
 | `persistence.responses.backend` | `str` | No |  | Name of backend from storage.backends |
@@ -98,9 +95,6 @@ Be concise, structured, and focused on helping the next LLM seamlessly continue 
 
 ```yaml
 persistence:
-  agent_state:
-    namespace: agents
-    backend: kv_default
   responses:
     table_name: responses
     backend: sql_default

--- a/src/ogx/core/connectors/connectors.py
+++ b/src/ogx/core/connectors/connectors.py
@@ -12,8 +12,7 @@ from pydantic import BaseModel, Field
 
 from ogx.core.access_control.datatypes import AccessRule
 from ogx.core.datatypes import StackConfig
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import authorized_sqlstore
 from ogx.log import get_logger
 from ogx.providers.utils.tools.mcp import get_mcp_server_info, list_mcp_tools
 from ogx_api import (
@@ -61,8 +60,7 @@ class ConnectorServiceImpl(Connectors):
         if not connectors_ref:
             raise ServiceNotEnabledError("storage.stores.connectors")
 
-        base_sql_store = sqlstore_impl(connectors_ref)
-        self.sql_store = AuthorizedSqlStore(base_sql_store, self.policy)
+        self.sql_store = authorized_sqlstore(connectors_ref, self.policy)
 
     async def initialize(self) -> None:
         """Initialize the connector service."""

--- a/src/ogx/core/conversations/conversations.py
+++ b/src/ogx/core/conversations/conversations.py
@@ -13,8 +13,7 @@ from pydantic import BaseModel, TypeAdapter
 from ogx.core.access_control.datatypes import AccessRule
 from ogx.core.conversations.validation import CONVERSATION_ID_PATTERN
 from ogx.core.datatypes import StackConfig
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import authorized_sqlstore
 from ogx.log import get_logger
 from ogx_api import (
     Api,
@@ -74,8 +73,7 @@ class ConversationServiceImpl(Conversations):
         if not conversations_ref:
             raise ServiceNotEnabledError("storage.stores.conversations")
 
-        base_sql_store = sqlstore_impl(conversations_ref)
-        self.sql_store = AuthorizedSqlStore(base_sql_store, self.policy)
+        self.sql_store = authorized_sqlstore(conversations_ref, self.policy)
 
     async def initialize(self) -> None:
         """Initialize the store and create tables."""

--- a/src/ogx/core/prompts/prompts.py
+++ b/src/ogx/core/prompts/prompts.py
@@ -11,8 +11,7 @@ from pydantic import BaseModel
 
 from ogx.core.access_control.datatypes import AccessRule
 from ogx.core.datatypes import StackConfig
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import authorized_sqlstore
 from ogx_api import (
     Api,
     CreatePromptRequest,
@@ -62,8 +61,7 @@ class PromptServiceImpl(Prompts):
         if not prompts_ref:
             raise ServiceNotEnabledError("storage.stores.prompts")
 
-        base_sql_store = sqlstore_impl(prompts_ref)
-        self.sql_store = AuthorizedSqlStore(base_sql_store, self.policy)
+        self.sql_store = authorized_sqlstore(prompts_ref, self.policy)
 
     async def initialize(self) -> None:
         await self.sql_store.create_table(

--- a/src/ogx/core/storage/sqlstore/__init__.py
+++ b/src/ogx/core/storage/sqlstore/__init__.py
@@ -14,4 +14,5 @@ from ogx_api.internal.sqlstore import (
     SqlStore as SqlStore,
 )
 
+from .authorized_sqlstore import authorized_sqlstore as authorized_sqlstore
 from .sqlstore import *  # noqa: F401,F403

--- a/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
@@ -20,7 +20,8 @@ from ogx.core.access_control.conditions import ProtectedResource
 from ogx.core.access_control.datatypes import AccessRule, Action, Scope
 from ogx.core.datatypes import User
 from ogx.core.request_headers import get_authenticated_user
-from ogx.core.storage.datatypes import StorageBackendType
+from ogx.core.storage.datatypes import SqlStoreReference, StorageBackendType
+from ogx.core.storage.sqlstore.sqlstore import _sqlstore_impl
 from ogx.log import get_logger
 from ogx_api import PaginatedResponse
 from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, SqlStore
@@ -79,6 +80,14 @@ class SqlRecord(ProtectedResource):
         self.type = f"sql_record::{table_name}"
         self.identifier = record_id
         self.owner = owner
+
+
+def authorized_sqlstore(reference: SqlStoreReference, policy: list[AccessRule]) -> "AuthorizedSqlStore":
+    """Create an AuthorizedSqlStore from a store reference and access policy.
+
+    This is the only supported way to obtain a SQL store for API use.
+    """
+    return AuthorizedSqlStore(_sqlstore_impl(reference), policy)
 
 
 class AuthorizedSqlStore:

--- a/src/ogx/core/storage/sqlstore/sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlstore.py
@@ -45,7 +45,7 @@ def get_pip_packages(store_config: dict | SqlStoreConfig) -> list[str]:
         return store_config.pip_packages()
 
 
-def sqlstore_impl(reference: SqlStoreReference) -> SqlStore:
+def _sqlstore_impl(reference: SqlStoreReference) -> SqlStore:
     """Get or create a SqlStore instance for the given store reference.
 
     Args:

--- a/src/ogx/distributions/ci-tests/config.yaml
+++ b/src/ogx/distributions/ci-tests/config.yaml
@@ -211,9 +211,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
@@ -211,9 +211,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/nvidia/config.yaml
+++ b/src/ogx/distributions/nvidia/config.yaml
@@ -32,9 +32,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/nvidia/run-with-safety.yaml
+++ b/src/ogx/distributions/nvidia/run-with-safety.yaml
@@ -37,9 +37,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/oci/config.yaml
+++ b/src/ogx/distributions/oci/config.yaml
@@ -34,9 +34,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/open-benchmark/config.yaml
+++ b/src/ogx/distributions/open-benchmark/config.yaml
@@ -75,9 +75,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/postgres-demo/config.yaml
+++ b/src/ogx/distributions/postgres-demo/config.yaml
@@ -37,9 +37,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: responses
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/starter/config.yaml
+++ b/src/ogx/distributions/starter/config.yaml
@@ -205,9 +205,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/starter/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/starter/run-with-postgres-store.yaml
@@ -205,9 +205,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/distributions/watsonx/config.yaml
+++ b/src/ogx/distributions/watsonx/config.yaml
@@ -32,9 +32,6 @@ providers:
     provider_type: inline::builtin
     config:
       persistence:
-        agent_state:
-          namespace: agents
-          backend: kv_default
         responses:
           table_name: responses
           backend: sql_default

--- a/src/ogx/providers/inline/batches/reference/__init__.py
+++ b/src/ogx/providers/inline/batches/reference/__init__.py
@@ -7,8 +7,7 @@
 from typing import Any
 
 from ogx.core.datatypes import AccessRule, Api
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import authorized_sqlstore
 from ogx_api import Files, Inference, Models
 
 from .batches import ReferenceBatchesImpl
@@ -18,8 +17,7 @@ __all__ = ["ReferenceBatchesImpl", "ReferenceBatchesImplConfig"]
 
 
 async def get_provider_impl(config: ReferenceBatchesImplConfig, deps: dict[Api, Any], policy: list[AccessRule]):
-    base_sql_store = sqlstore_impl(config.sqlstore)
-    sql_store = AuthorizedSqlStore(base_sql_store, policy)
+    sql_store = authorized_sqlstore(config.sqlstore, policy)
     inference_api: Inference | None = deps.get(Api.inference)
     files_api: Files | None = deps.get(Api.files)
     models_api: Models | None = deps.get(Api.models)

--- a/src/ogx/providers/inline/files/localfs/files.py
+++ b/src/ogx/providers/inline/files/localfs/files.py
@@ -31,8 +31,7 @@ from fastapi import Response, UploadFile
 from ogx.core.access_control.datatypes import Action
 from ogx.core.datatypes import AccessRule
 from ogx.core.id_generation import generate_object_id
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore, authorized_sqlstore
 from ogx.log import get_logger
 from ogx.providers.utils.files.sanitize import sanitize_content_disposition_filename
 from ogx_api import (
@@ -72,7 +71,7 @@ class LocalfsFilesImpl(Files):
         storage_path.mkdir(parents=True, exist_ok=True)
 
         # Initialize SQL store for metadata
-        self.sql_store = AuthorizedSqlStore(sqlstore_impl(self.config.metadata_store), self.policy)
+        self.sql_store = authorized_sqlstore(self.config.metadata_store, self.policy)
         await self.sql_store.create_table(
             "openai_files",
             {

--- a/src/ogx/providers/inline/responses/builtin/config.py
+++ b/src/ogx/providers/inline/responses/builtin/config.py
@@ -9,7 +9,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from ogx.core.datatypes import VectorStoresConfig
-from ogx.core.storage.datatypes import KVStoreReference, ResponsesStoreReference
+from ogx.core.storage.datatypes import ResponsesStoreReference
 
 DEFAULT_SUMMARIZATION_PROMPT = (
     "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary "
@@ -59,7 +59,6 @@ class CompactionConfig(BaseModel):
 class ResponsesPersistenceConfig(BaseModel):
     """Nested persistence configuration for the responses provider."""
 
-    agent_state: KVStoreReference
     responses: ResponsesStoreReference
 
 
@@ -82,10 +81,6 @@ class BuiltinResponsesImplConfig(BaseModel):
     def sample_run_config(cls, __distro_dir__: str) -> dict[str, Any]:
         return {
             "persistence": {
-                "agent_state": KVStoreReference(
-                    backend="kv_default",
-                    namespace="agents",
-                ).model_dump(exclude_none=True),
                 "responses": ResponsesStoreReference(
                     backend="sql_default",
                     table_name="responses",

--- a/src/ogx/providers/inline/responses/builtin/impl.py
+++ b/src/ogx/providers/inline/responses/builtin/impl.py
@@ -9,7 +9,6 @@ from collections.abc import AsyncIterator
 from opentelemetry import metrics
 
 from ogx.core.datatypes import AccessRule
-from ogx.core.storage.kvstore import InmemoryKVStoreImpl, kvstore_impl
 from ogx.log import get_logger
 from ogx.providers.utils.responses.responses_store import ResponsesStore
 from ogx.telemetry.constants import RESPONSES_PARAMETER_USAGE_TOTAL
@@ -88,13 +87,11 @@ class BuiltinResponsesImpl(Responses):
         self.conversations_api = conversations_api
         self.prompts_api = prompts_api
         self.files_api = files_api
-        self.in_memory_store = InmemoryKVStoreImpl()
         self.openai_responses_impl: OpenAIResponsesImpl | None = None
         self.policy = policy
         self.connectors_api = connectors_api
 
     async def initialize(self) -> None:
-        self.persistence_store = await kvstore_impl(self.config.persistence.agent_state)
         self.responses_store = ResponsesStore(self.config.persistence.responses, self.policy)
         await self.responses_store.initialize()
         if not self.responses_store.sql_store:

--- a/src/ogx/providers/remote/files/openai/files.py
+++ b/src/ogx/providers/remote/files/openai/files.py
@@ -11,8 +11,7 @@ from fastapi import Response, UploadFile
 
 from ogx.core.access_control.datatypes import Action
 from ogx.core.datatypes import AccessRule
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore, authorized_sqlstore
 from ogx.providers.utils.files.sanitize import sanitize_content_disposition_filename
 from ogx_api import (
     DeleteFileRequest,
@@ -111,7 +110,7 @@ class OpenAIFilesImpl(Files):
     async def initialize(self) -> None:
         self._client = OpenAI(api_key=self._config.api_key)
 
-        self._sql_store = AuthorizedSqlStore(sqlstore_impl(self._config.metadata_store), self.policy)
+        self._sql_store = authorized_sqlstore(self._config.metadata_store, self.policy)
         await self._sql_store.create_table(
             "openai_files",
             {

--- a/src/ogx/providers/remote/files/s3/files.py
+++ b/src/ogx/providers/remote/files/s3/files.py
@@ -18,8 +18,7 @@ if TYPE_CHECKING:
 from ogx.core.access_control.datatypes import Action
 from ogx.core.datatypes import AccessRule
 from ogx.core.id_generation import generate_object_id
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore, authorized_sqlstore
 from ogx.providers.utils.files.sanitize import sanitize_content_disposition_filename
 from ogx_api import (
     ExpiresAfter,
@@ -184,7 +183,7 @@ class S3FilesImpl(Files):
         self._client = _create_s3_client(self._config)
         await _create_bucket_if_not_exists(self._client, self._config)
 
-        self._sql_store = AuthorizedSqlStore(sqlstore_impl(self._config.metadata_store), self.policy)
+        self._sql_store = authorized_sqlstore(self._config.metadata_store, self.policy)
         await self._sql_store.create_table(
             "openai_files",
             {

--- a/src/ogx/providers/utils/inference/inference_store.py
+++ b/src/ogx/providers/utils/inference/inference_store.py
@@ -10,8 +10,8 @@ from sqlalchemy.exc import IntegrityError
 
 from ogx.core.datatypes import AccessRule
 from ogx.core.storage.datatypes import InferenceStoreReference, StorageBackendType
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import _SQLSTORE_BACKENDS, sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import authorized_sqlstore
+from ogx.core.storage.sqlstore.sqlstore import _SQLSTORE_BACKENDS
 from ogx.core.task import (
     RequestContext,
     activate_request_context,
@@ -114,8 +114,7 @@ class InferenceStore:
 
     async def initialize(self):
         """Create the necessary tables if they don't exist."""
-        base_store = sqlstore_impl(self.reference)
-        self.sql_store = AuthorizedSqlStore(base_store, self.policy)
+        self.sql_store = authorized_sqlstore(self.reference, self.policy)
 
         # Disable write queue for SQLite since WAL mode handles concurrency
         # Keep it enabled for other backends (like Postgres) for performance

--- a/src/ogx/providers/utils/responses/responses_store.py
+++ b/src/ogx/providers/utils/responses/responses_store.py
@@ -6,8 +6,7 @@
 
 from ogx.core.datatypes import AccessRule
 from ogx.core.storage.datatypes import ResponsesStoreReference, SqlStoreReference
-from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import sqlstore_impl
+from ogx.core.storage.sqlstore.authorized_sqlstore import authorized_sqlstore
 from ogx.log import get_logger
 from ogx_api import (
     InvalidParameterError,
@@ -127,8 +126,7 @@ class ResponsesStore:
 
     async def initialize(self):
         """Create the necessary tables if they don't exist."""
-        base_store = sqlstore_impl(self.reference)
-        self.sql_store = AuthorizedSqlStore(base_store, self.policy)
+        self.sql_store = authorized_sqlstore(self.reference, self.policy)
 
         await self.sql_store.create_table(
             self.reference.table_name,

--- a/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
+++ b/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
@@ -17,8 +17,8 @@ from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
 from ogx.core.storage.sqlstore.sqlstore import (
     PostgresSqlStoreConfig,
     SqliteSqlStoreConfig,
+    _sqlstore_impl,
     register_sqlstore_backends,
-    sqlstore_impl,
 )
 from ogx_api.internal.sqlstore import ColumnType
 
@@ -63,7 +63,7 @@ def authorized_store(backend_config):
     config = config_func()
     backend_name = f"sql_{type(config).__name__.lower()}"
     register_sqlstore_backends({backend_name: config})
-    base_sqlstore = sqlstore_impl(SqlStoreReference(backend=backend_name, table_name="authorized_store"))
+    base_sqlstore = _sqlstore_impl(SqlStoreReference(backend=backend_name, table_name="authorized_store"))
     authorized_store = AuthorizedSqlStore(base_sqlstore, default_policy())
 
     yield authorized_store

--- a/tests/unit/core/test_storage_shutdown.py
+++ b/tests/unit/core/test_storage_shutdown.py
@@ -23,9 +23,9 @@ from ogx.core.storage.kvstore.kvstore import (
 from ogx.core.storage.kvstore.sqlite.sqlite import SqliteKVStoreImpl
 from ogx.core.storage.sqlstore.sqlalchemy_sqlstore import SqlAlchemySqlStoreImpl
 from ogx.core.storage.sqlstore.sqlstore import (
+    _sqlstore_impl,
     register_sqlstore_backends,
     shutdown_sqlstore_backends,
-    sqlstore_impl,
 )
 
 
@@ -148,8 +148,8 @@ class TestSqlStoreShutdown:
                 }
             )
 
-            # Create instance by calling sqlstore_impl
-            store = sqlstore_impl(SqlStoreReference(backend="sql_test", table_name="test"))
+            # Create instance by calling _sqlstore_impl
+            store = _sqlstore_impl(SqlStoreReference(backend="sql_test", table_name="test"))
 
             # Verify store is working
             from ogx_api.internal.sqlstore import ColumnType

--- a/tests/unit/prompts/prompts/conftest.py
+++ b/tests/unit/prompts/prompts/conftest.py
@@ -45,7 +45,7 @@ async def temp_prompt_store(tmp_path_factory):
         ),
     )
 
-    # Backends must be registered before PromptServiceImpl constructor calls sqlstore_impl()
+    # Backends must be registered before PromptServiceImpl constructor calls authorized_sqlstore()
     register_kvstore_backends({"kv_test": storage.backends["kv_test"]})
     register_sqlstore_backends({"sql_test": storage.backends["sql_test"]})
 

--- a/tests/unit/providers/batches/conftest.py
+++ b/tests/unit/providers/batches/conftest.py
@@ -14,7 +14,7 @@ import pytest
 
 from ogx.core.storage.datatypes import SqliteSqlStoreConfig, SqlStoreReference
 from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore
-from ogx.core.storage.sqlstore.sqlstore import register_sqlstore_backends, sqlstore_impl
+from ogx.core.storage.sqlstore.sqlstore import _sqlstore_impl, register_sqlstore_backends
 from ogx.providers.inline.batches.reference.batches import ReferenceBatchesImpl
 from ogx.providers.inline.batches.reference.config import ReferenceBatchesImplConfig
 
@@ -29,7 +29,7 @@ async def provider():
         config = ReferenceBatchesImplConfig(sqlstore=SqlStoreReference(backend=backend_name, table_name="batches"))
 
         # Create sql_store and mock APIs
-        base_sql_store = sqlstore_impl(config.sqlstore)
+        base_sql_store = _sqlstore_impl(config.sqlstore)
         sql_store = AuthorizedSqlStore(base_sql_store, policy=[])
         mock_inference = AsyncMock()
         mock_files = AsyncMock()

--- a/tests/unit/providers/responses/builtin/test_safety_optional.py
+++ b/tests/unit/providers/responses/builtin/test_safety_optional.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ogx.core.datatypes import Api
-from ogx.core.storage.datatypes import KVStoreReference, ResponsesStoreReference
+from ogx.core.storage.datatypes import ResponsesStoreReference
 from ogx.providers.inline.responses.builtin import get_provider_impl
 from ogx.providers.inline.responses.builtin.config import (
     BuiltinResponsesImplConfig,
@@ -32,10 +32,6 @@ from ogx.providers.inline.responses.builtin.responses.utils import (
 def mock_persistence_config():
     """Create a mock persistence configuration."""
     return ResponsesPersistenceConfig(
-        agent_state=KVStoreReference(
-            backend="kv_default",
-            namespace="agents",
-        ),
         responses=ResponsesStoreReference(
             backend="sql_default",
             table_name="responses",


### PR DESCRIPTION
## Summary

- Rename `sqlstore_impl` → `_sqlstore_impl` (private) and introduce `authorized_sqlstore()` factory as the only supported way to obtain a SQL store for API use
- Replace all direct `sqlstore_impl` + `AuthorizedSqlStore` two-step patterns across providers with the new single-call `authorized_sqlstore()` factory
- Add a pre-commit hook (`enforce-authorized-sqlstore`) that blocks direct `_sqlstore_impl` usage outside `core/storage/sqlstore/`
- Remove the unused `agent_state` KVStore from responses persistence config, completing the migration from #5757

## Test plan

- [ ] Unit tests pass: `uv run pytest tests/unit/ -x --tb=short`
- [ ] Pre-commit checks pass: `uv run pre-commit run --all-files`
- [ ] Integration tests pass in replay mode
- [ ] Verify the new pre-commit hook catches direct `sqlstore_impl` usage