### PR TITLE
fix(nvidia): use proper URL parsing instead of substring check for hostname validation

### DIFF
--- a/src/ogx/providers/remote/inference/nvidia/utils.py
+++ b/src/ogx/providers/remote/inference/nvidia/utils.py
@@ -4,8 +4,13 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from urllib.parse import urlparse
+
 from . import NVIDIAConfig
+
+_NVIDIA_HOSTED_HOSTNAME = "integrate.api.nvidia.com"
 
 
 def _is_nvidia_hosted(config: NVIDIAConfig) -> bool:
-    return "integrate.api.nvidia.com" in str(config.base_url)
+    hostname = urlparse(str(config.base_url)).hostname
+    return hostname == _NVIDIA_HOSTED_HOSTNAME


### PR DESCRIPTION
## Summary

- Replaces substring-based hostname check in `_is_nvidia_hosted()` with proper URL parsing via `urlparse()` to prevent bypass via crafted URLs (e.g. `https://evil.com/integrate.api.nvidia.com`)
- Extracts the hostname constant into `_NVIDIA_HOSTED_HOSTNAME` for clarity
- Addresses CWE-20 (Improper Input Validation)

Fixes: https://github.com/ogx-ai/ogx/security/code-scanning/55

## Test plan

- [ ] Verify `_is_nvidia_hosted()` returns `True` for `https://integrate.api.nvidia.com/v1`
- [ ] Verify `_is_nvidia_hosted()` returns `False` for `https://evil.com/integrate.api.nvidia.com`
- [ ] Run unit tests: `uv run pytest tests/unit/ -x --tb=short`
- [ ] Run pre-commit checks: `uv run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)