### PR TITLE
fix(api): fix field-level schema mismatches in Responses models

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -7190,7 +7190,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -7213,9 +7212,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -7280,8 +7276,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -7611,7 +7609,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -7634,9 +7631,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -7701,8 +7695,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -11292,7 +11288,6 @@ components:
           - type: boolean
           - type: 'null'
           description: Whether to enable parallel tool calls.
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -11313,12 +11308,10 @@ components:
           type: boolean
           title: Store
           description: Whether to store the response in the database.
-          default: true
         stream:
           type: boolean
           title: Stream
           description: Whether to stream the response.
-          default: false
         temperature:
           anyOf:
           - type: number
@@ -12987,6 +12980,16 @@ components:
             - high
             - xhigh
           - type: 'null'
+        generate_summary:
+          anyOf:
+          - type: string
+            enum:
+            - auto
+            - concise
+            - detailed
+          - type: 'null'
+          description: "Deprecated: use 'summary' instead."
+          deprecated: true
         summary:
           anyOf:
           - type: string
@@ -13270,8 +13273,6 @@ components:
           type: boolean
           title: Include Obfuscation
           description: Whether to obfuscate sensitive information in streamed output.
-          default: true
-      additionalProperties: false
       type: object
       title: ResponseStreamOptions
       description: Options that control streamed response behavior.

--- a/docs/docs/api-openai/conformance.mdx
+++ b/docs/docs/api-openai/conformance.mdx
@@ -18,12 +18,12 @@ This documentation is auto-generated from the OpenAI API specification compariso
 
 | Metric | Value |
 |--------|-------|
-| **Overall Conformance Score** | 93.2% |
+| **Overall Conformance Score** | 93.4% |
 | **Endpoints Implemented** | 29/146 |
 | **Total Properties Checked** | 3432 |
-| **Schema/Type Issues** | 167 |
+| **Schema/Type Issues** | 163 |
 | **Missing Properties** | 65 |
-| **Total Issues to Fix** | 232 |
+| **Total Issues to Fix** | 228 |
 
 ## Integration Test Coverage
 
@@ -49,7 +49,7 @@ Categories are sorted by conformance score (lowest first, needing most attention
 | Models | 60.0% | 15 | 0 | 6 |
 | Embeddings | 78.6% | 14 | 3 | 0 |
 | Vector stores | 82.9% | 310 | 41 | 12 |
-| Responses | 88.8% | 223 | 25 | 0 |
+| Responses | 90.6% | 223 | 21 | 0 |
 | Files | 92.9% | 42 | 1 | 2 |
 | Chat | 98.7% | 449 | 5 | 1 |
 | Conversations | 99.3% | 2165 | 15 | 1 |
@@ -699,24 +699,21 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 ### Responses
 
-**Score:** 88.8% · **Issues:** 25 · **Missing:** 0
+**Score:** 90.6% · **Issues:** 21 · **Missing:** 0
 
 #### `/responses`
 
 **POST**
 
 <details>
-<summary>Schema Issues (22)</summary>
+<summary>Schema Issues (18)</summary>
 
 | Property | Issues | Tested |
 |----------|--------|--------|
 | `requestBody.content.application/json.properties.input` | Union variants added: 2; Union variants removed: 2 | Yes |
 | `requestBody.content.application/json.properties.model` | Type added: ['string']; Nullable removed (OpenAI nullable); Union variants removed: 2 | Yes |
-| `requestBody.content.application/json.properties.parallel_tool_calls` | Default changed: None -&gt; True | Yes |
 | `requestBody.content.application/json.properties.reasoning` | Union variants added: 1; Union variants removed: 1 | Yes |
 | `requestBody.content.application/json.properties.service_tier` | Union variants added: 2 | Yes |
-| `requestBody.content.application/json.properties.store` | Default changed: None -&gt; True | Yes |
-| `requestBody.content.application/json.properties.stream` | Default changed: None -&gt; False | Yes |
 | `requestBody.content.application/json.properties.stream_options` | Union variants added: 1; Union variants removed: 1 | No |
 | `requestBody.content.application/json.properties.text` | Union variants added: 1; Union variants removed: 1 | No |
 | `requestBody.content.application/json.properties.tool_choice` | Union variants added: 2; Union variants removed: 1 | Yes |
@@ -725,9 +722,8 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 | `responses.200.content.application/json.properties.incomplete_details` | Union variants added: 1; Union variants removed: 1 | Yes |
 | `responses.200.content.application/json.properties.metadata` | Union variants added: 2 | Yes |
 | `responses.200.content.application/json.properties.output.items` | Union variants added: 8; Union variants removed: 4 | Yes |
-| `responses.200.content.application/json.properties.parallel_tool_calls` | Default changed: None -&gt; True | Yes |
 | `responses.200.content.application/json.properties.reasoning` | Union variants added: 1; Union variants removed: 1 | Yes |
-| `responses.200.content.application/json.properties.text` | Type added: ['object']; Default changed: None -&gt; \{'format': \{'type': 'text'\}\} | No |
+| `responses.200.content.application/json.properties.text` | Type added: ['object'] | No |
 | `responses.200.content.application/json.properties.tool_choice` | Union variants added: 3 | Yes |
 | `responses.200.content.application/json.properties.tools.items` | Union variants added: 4; Union variants removed: 1 | Yes |
 | `responses.200.content.application/json.properties.truncation` | Union variants added: 2 | Yes |

--- a/docs/static/deprecated-ogx-spec.yaml
+++ b/docs/static/deprecated-ogx-spec.yaml
@@ -3196,7 +3196,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -3219,9 +3218,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -3286,8 +3282,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -3617,7 +3615,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -3640,9 +3637,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -3707,8 +3701,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -7539,6 +7535,16 @@ components:
             - high
             - xhigh
           - type: 'null'
+        generate_summary:
+          anyOf:
+          - type: string
+            enum:
+            - auto
+            - concise
+            - detailed
+          - type: 'null'
+          description: "Deprecated: use 'summary' instead."
+          deprecated: true
         summary:
           anyOf:
           - type: string
@@ -7804,6 +7810,13 @@ components:
 
         Returns a list of chunks ready for storage in vector databases.
         Each chunk contains the content and metadata.
+    ResponseTruncation:
+      type: string
+      enum:
+      - auto
+      - disabled
+      title: ResponseTruncation
+      description: Controls how the service truncates input when it exceeds the model context window.
     SearchRankingOptions:
       properties:
         ranker:

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -3641,7 +3641,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -3664,9 +3663,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -3731,8 +3727,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -4062,7 +4060,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -4085,9 +4082,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -4152,8 +4146,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -8392,6 +8388,16 @@ components:
             - high
             - xhigh
           - type: 'null'
+        generate_summary:
+          anyOf:
+          - type: string
+            enum:
+            - auto
+            - concise
+            - detailed
+          - type: 'null'
+          description: "Deprecated: use 'summary' instead."
+          deprecated: true
         summary:
           anyOf:
           - type: string
@@ -8657,6 +8663,13 @@ components:
 
         Returns a list of chunks ready for storage in vector databases.
         Each chunk contains the content and metadata.
+    ResponseTruncation:
+      type: string
+      enum:
+      - auto
+      - disabled
+      title: ResponseTruncation
+      description: Controls how the service truncates input when it exceeds the model context window.
     SearchRankingOptions:
       properties:
         ranker:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -6743,7 +6743,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -6766,9 +6765,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -6833,8 +6829,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -7164,7 +7162,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -7187,9 +7184,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -7254,8 +7248,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -10823,7 +10819,6 @@ components:
           - type: boolean
           - type: 'null'
           description: Whether to enable parallel tool calls.
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -10844,12 +10839,10 @@ components:
           type: boolean
           title: Store
           description: Whether to store the response in the database.
-          default: true
         stream:
           type: boolean
           title: Stream
           description: Whether to stream the response.
-          default: false
         temperature:
           anyOf:
           - type: number
@@ -12136,6 +12129,16 @@ components:
             - high
             - xhigh
           - type: 'null'
+        generate_summary:
+          anyOf:
+          - type: string
+            enum:
+            - auto
+            - concise
+            - detailed
+          - type: 'null'
+          description: "Deprecated: use 'summary' instead."
+          deprecated: true
         summary:
           anyOf:
           - type: string
@@ -12419,8 +12422,6 @@ components:
           type: boolean
           title: Include Obfuscation
           description: Whether to obfuscate sensitive information in streamed output.
-          default: true
-      additionalProperties: false
       type: object
       title: ResponseStreamOptions
       description: Options that control streamed response behavior.

--- a/docs/static/openai-coverage.json
+++ b/docs/static/openai-coverage.json
@@ -127,10 +127,10 @@
       ]
     },
     "conformance": {
-      "score": 93.2,
-      "issues": 167,
+      "score": 93.4,
+      "issues": 163,
       "missing_properties": 65,
-      "total_problems": 232,
+      "total_problems": 228,
       "total_properties": 3432
     }
   },
@@ -1303,8 +1303,8 @@
       ]
     },
     "Responses": {
-      "score": 88.8,
-      "issues": 25,
+      "score": 90.6,
+      "issues": 21,
       "missing_properties": 0,
       "total_properties": 223,
       "endpoints": [
@@ -1331,12 +1331,6 @@
                   ]
                 },
                 {
-                  "property": "POST.requestBody.content.application/json.properties.parallel_tool_calls",
-                  "details": [
-                    "Default changed: None -> True"
-                  ]
-                },
-                {
                   "property": "POST.requestBody.content.application/json.properties.reasoning",
                   "details": [
                     "Union variants added: 1",
@@ -1347,18 +1341,6 @@
                   "property": "POST.requestBody.content.application/json.properties.service_tier",
                   "details": [
                     "Union variants added: 2"
-                  ]
-                },
-                {
-                  "property": "POST.requestBody.content.application/json.properties.store",
-                  "details": [
-                    "Default changed: None -> True"
-                  ]
-                },
-                {
-                  "property": "POST.requestBody.content.application/json.properties.stream",
-                  "details": [
-                    "Default changed: None -> False"
                   ]
                 },
                 {
@@ -1416,12 +1398,6 @@
                   ]
                 },
                 {
-                  "property": "POST.responses.200.content.application/json.properties.parallel_tool_calls",
-                  "details": [
-                    "Default changed: None -> True"
-                  ]
-                },
-                {
                   "property": "POST.responses.200.content.application/json.properties.reasoning",
                   "details": [
                     "Union variants added: 1",
@@ -1431,8 +1407,7 @@
                 {
                   "property": "POST.responses.200.content.application/json.properties.text",
                   "details": [
-                    "Type added: ['object']",
-                    "Default changed: None -> {'format': {'type': 'text'}}"
+                    "Type added: ['object']"
                   ]
                 },
                 {
@@ -1463,7 +1438,7 @@
                 }
               ],
               "missing_count": 0,
-              "issues_count": 22
+              "issues_count": 18
             }
           ]
         },

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -7190,7 +7190,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -7213,9 +7212,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -7280,8 +7276,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -7611,7 +7609,6 @@ components:
         parallel_tool_calls:
           type: boolean
           title: Parallel Tool Calls
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -7634,9 +7631,6 @@ components:
           title: Temperature
         text:
           $ref: '#/components/schemas/OpenAIResponseText'
-          default:
-            format:
-              type: text
         top_p:
           type: number
           title: Top P
@@ -7701,8 +7695,10 @@ components:
           title: OpenAIResponseInputToolChoiceMode
         truncation:
           anyOf:
-          - type: string
+          - $ref: '#/components/schemas/ResponseTruncation'
+            title: ResponseTruncation
           - type: 'null'
+          title: ResponseTruncation
         usage:
           anyOf:
           - $ref: '#/components/schemas/OpenAIResponseUsage'
@@ -11292,7 +11288,6 @@ components:
           - type: boolean
           - type: 'null'
           description: Whether to enable parallel tool calls.
-          default: true
         previous_response_id:
           anyOf:
           - type: string
@@ -11313,12 +11308,10 @@ components:
           type: boolean
           title: Store
           description: Whether to store the response in the database.
-          default: true
         stream:
           type: boolean
           title: Stream
           description: Whether to stream the response.
-          default: false
         temperature:
           anyOf:
           - type: number
@@ -12987,6 +12980,16 @@ components:
             - high
             - xhigh
           - type: 'null'
+        generate_summary:
+          anyOf:
+          - type: string
+            enum:
+            - auto
+            - concise
+            - detailed
+          - type: 'null'
+          description: "Deprecated: use 'summary' instead."
+          deprecated: true
         summary:
           anyOf:
           - type: string
@@ -13270,8 +13273,6 @@ components:
           type: boolean
           title: Include Obfuscation
           description: Whether to obfuscate sensitive information in streamed output.
-          default: true
-      additionalProperties: false
       type: object
       title: ResponseStreamOptions
       description: Options that control streamed response behavior.

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -328,7 +328,7 @@ class StreamingResponseOrchestrator:
             top_logprobs=self.top_logprobs if self.top_logprobs is not None else 0,
             tools=self.ctx.available_tools(),
             tool_choice=self.ctx.tool_choice or OpenAIResponseInputToolChoiceMode.auto,
-            truncation=self.truncation or "disabled",
+            truncation=self.truncation or ResponseTruncation.disabled,
             max_output_tokens=self.max_output_tokens,
             service_tier=self.service_tier or "default",
             metadata=self.metadata,
@@ -382,13 +382,13 @@ class StreamingResponseOrchestrator:
             usage=self.accumulated_usage,
             instructions=self.instructions,
             prompt=self.prompt,
-            parallel_tool_calls=self.parallel_tool_calls,
+            parallel_tool_calls=self.parallel_tool_calls if self.parallel_tool_calls is not None else True,
             max_tool_calls=self.max_tool_calls,
             reasoning=self.reasoning,
             max_output_tokens=self.max_output_tokens,
             service_tier=self.service_tier or "default",
             metadata=self.metadata,
-            truncation=self.truncation or "disabled",
+            truncation=self.truncation or ResponseTruncation.disabled,
             presence_penalty=self.presence_penalty if self.presence_penalty is not None else 0.0,
             store=self.store,
             prompt_cache_key=self.prompt_cache_key,
@@ -526,7 +526,7 @@ class StreamingResponseOrchestrator:
                 # Merge user stream_options with default include_usage
                 effective_stream_options = {"include_usage": True}
                 if self.stream_options:
-                    effective_stream_options.update(self.stream_options)
+                    effective_stream_options.update({k: v for k, v in self.stream_options if v is not None})
 
                 params = OpenAIChatCompletionRequestWithExtraBody(
                     model=self.ctx.model,

--- a/src/ogx_api/openai_responses.py
+++ b/src/ogx_api/openai_responses.py
@@ -5,14 +5,14 @@
 # the root directory of this source tree.
 
 from collections.abc import Sequence
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import TypedDict
 
 from ogx_api.inference import OpenAITokenLogProb
-from ogx_api.schema_utils import json_schema_type, register_schema, remove_null_from_anyof
+from ogx_api.schema_utils import json_schema_type, register_schema, remove_default_from_schema, remove_null_from_anyof
 from ogx_api.vector_io import SearchRankingOptions as FileSearchRankingOptions
 
 # This file defines Pydantic models for the OpenAI Responses API schema. It started as a direct
@@ -463,6 +463,11 @@ class OpenAIResponseReasoning(BaseModel):
     """
 
     effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"] | None = None
+    generate_summary: Literal["auto", "concise", "detailed"] | None = Field(
+        default=None,
+        deprecated=True,
+        description="Deprecated: use 'summary' instead.",
+    )
     summary: Literal["auto", "concise", "detailed"] | None = Field(
         default=None, description="Summary mode for reasoning output. One of 'auto', 'concise', or 'detailed'."
     )
@@ -760,6 +765,13 @@ class OpenAIResponseIncompleteDetails(BaseModel):
     reason: str
 
 
+class ResponseTruncation(StrEnum):
+    """Controls how the service truncates input when it exceeds the model context window."""
+
+    auto = "auto"
+    disabled = "disabled"
+
+
 @json_schema_type
 class OpenAIResponseObject(BaseModel):
     """Complete OpenAI response object containing generation results and metadata.
@@ -803,20 +815,21 @@ class OpenAIResponseObject(BaseModel):
     model: str
     object: Literal["response"] = "response"
     output: Sequence[OpenAIResponseOutput]
-    parallel_tool_calls: bool | None = Field(default=True, json_schema_extra=remove_null_from_anyof)
+    parallel_tool_calls: bool = Field(default=True, json_schema_extra=remove_default_from_schema)
     previous_response_id: str | None = None
     prompt_cache_key: str | None = None
     prompt: OpenAIResponsePrompt | None = None
     status: str
     temperature: float | None = Field(default=None, json_schema_extra=remove_null_from_anyof)
-    # Default to text format to avoid breaking the loading of old responses
-    # before the field was added. New responses will have this set always.
-    text: OpenAIResponseText = OpenAIResponseText(format=OpenAIResponseTextFormat(type="text"))
+    text: OpenAIResponseText = Field(
+        default=OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
+        json_schema_extra=remove_default_from_schema,
+    )
     top_p: float | None = Field(default=None, json_schema_extra=remove_null_from_anyof)
     top_logprobs: int | None = Field(default=None, json_schema_extra=remove_null_from_anyof)
     tools: Sequence[OpenAIResponseTool] | None = Field(default=None, json_schema_extra=remove_null_from_anyof)
     tool_choice: OpenAIResponseInputToolChoice | None = None
-    truncation: str | None = None
+    truncation: ResponseTruncation | None = None
     usage: OpenAIResponseUsage | None = None
     instructions: str | None = None
     max_tool_calls: int | None = None

--- a/src/ogx_api/responses/models.py
+++ b/src/ogx_api/responses/models.py
@@ -24,8 +24,9 @@ from ogx_api.openai_responses import (
     OpenAIResponsePrompt,
     OpenAIResponseReasoning,
     OpenAIResponseText,
+    ResponseTruncation,
 )
-from ogx_api.schema_utils import remove_null_from_anyof
+from ogx_api.schema_utils import flatten_nullable_remove_default, remove_default_from_schema, remove_null_from_anyof
 
 
 class ResponseItemInclude(StrEnum):
@@ -40,21 +41,25 @@ class ResponseItemInclude(StrEnum):
     reasoning_encrypted_content = "reasoning.encrypted_content"
 
 
-class ResponseTruncation(StrEnum):
-    """Controls how the service truncates input when it exceeds the model context window."""
+class ResponseGuardrailSpec(BaseModel):
+    """Specification for a guardrail to apply during response generation."""
 
-    auto = "auto"  # Let the service decide how to truncate
-    disabled = "disabled"  # Disable truncation; context over limit results in 400 error
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    # TODO: more fields to be added for guardrail configuration
+
+
+ResponseGuardrail = str | ResponseGuardrailSpec
 
 
 class ResponseStreamOptions(BaseModel):
     """Options that control streamed response behavior."""
 
-    model_config = ConfigDict(extra="forbid")
-
-    include_obfuscation: bool = Field(
-        default=True,
+    include_obfuscation: bool | None = Field(
+        default=None,
         description="Whether to obfuscate sensitive information in streamed output.",
+        json_schema_extra=remove_null_from_anyof,
     )
 
 
@@ -91,6 +96,7 @@ class CreateResponseRequest(BaseModel):
     parallel_tool_calls: bool | None = Field(
         default=True,
         description="Whether to enable parallel tool calls.",
+        json_schema_extra=remove_default_from_schema,
     )
     previous_response_id: str | None = Field(
         default=None,
@@ -108,12 +114,12 @@ class CreateResponseRequest(BaseModel):
     store: bool | None = Field(
         default=True,
         description="Whether to store the response in the database.",
-        json_schema_extra=remove_null_from_anyof,
+        json_schema_extra=flatten_nullable_remove_default,
     )
     stream: bool | None = Field(
         default=False,
         description="Whether to stream the response.",
-        json_schema_extra=remove_null_from_anyof,
+        json_schema_extra=flatten_nullable_remove_default,
     )
     temperature: float | None = Field(
         default=None,

--- a/src/ogx_api/schema_utils.py
+++ b/src/ogx_api/schema_utils.py
@@ -248,6 +248,17 @@ def remove_null_from_anyof(schema: dict[str, Any], *, add_nullable: bool = False
             schema["nullable"] = True
 
 
+def remove_default_from_schema(schema: dict[str, Any]) -> None:
+    """Remove the default value from a JSON schema."""
+    schema.pop("default", None)
+
+
+def flatten_nullable_remove_default(schema: dict[str, Any]) -> None:
+    """Remove null from anyOf and strip default values from schema."""
+    remove_null_from_anyof(schema)
+    schema.pop("default", None)
+
+
 def nullable_openai_style(schema: dict[str, Any]) -> None:
     """Shorthand for remove_null_from_anyof with add_nullable=True.
 

--- a/tests/unit/providers/responses/builtin/test_openai_responses_params.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_params.py
@@ -786,7 +786,7 @@ async def test_create_openai_response_with_empty_stream_options(openai_responses
     """Test that default stream_options still merges with default include_usage."""
     input_text = "Test empty options"
     model = "meta-llama/Llama-3.1-8B-Instruct"
-    stream_options = ResponseStreamOptions()  # Uses default include_obfuscation=True
+    stream_options = ResponseStreamOptions()  # No explicit fields set
 
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
 
@@ -801,10 +801,10 @@ async def test_create_openai_response_with_empty_stream_options(openai_responses
     # Collect chunks (consume the async iterator)
     _ = [chunk async for chunk in result]
 
-    # Verify the stream_options has both defaults
+    # Verify the stream_options has include_usage default
     mock_inference_api.openai_chat_completion.assert_called()
     call_args = mock_inference_api.openai_chat_completion.call_args
     params = call_args.args[0]
     assert params.stream_options is not None
     assert params.stream_options["include_usage"] is True
-    assert params.stream_options["include_obfuscation"] is True
+    assert "include_obfuscation" not in params.stream_options

--- a/tests/unit/server/test_schema_registry.py
+++ b/tests/unit/server/test_schema_registry.py
@@ -9,11 +9,14 @@ from pydantic import BaseModel
 from ogx_api import Conversation, SamplingStrategy
 from ogx_api.schema_utils import (
     clear_dynamic_schema_types,
+    flatten_nullable_remove_default,
     get_registered_schema_info,
     iter_dynamic_schema_types,
     iter_json_schema_types,
     iter_registered_schema_types,
     register_dynamic_schema_type,
+    remove_default_from_schema,
+    remove_null_from_anyof,
 )
 
 
@@ -28,6 +31,77 @@ def test_registered_schema_registry_contains_sampling_strategy() -> None:
     schema_info = get_registered_schema_info(SamplingStrategy)
     assert schema_info is not None
     assert schema_info.name == "SamplingStrategy"
+
+
+class TestRemoveNullFromAnyof:
+    def test_flattens_single_type_with_null(self) -> None:
+        schema: dict = {"anyOf": [{"type": "boolean"}, {"type": "null"}]}
+        remove_null_from_anyof(schema)
+        assert schema == {"type": "boolean"}
+
+    def test_preserves_non_null_properties(self) -> None:
+        schema: dict = {"anyOf": [{"type": "string", "enum": ["a", "b"]}, {"type": "null"}]}
+        remove_null_from_anyof(schema)
+        assert schema == {"type": "string", "enum": ["a", "b"]}
+
+    def test_no_anyof_is_noop(self) -> None:
+        schema: dict = {"type": "string"}
+        remove_null_from_anyof(schema)
+        assert schema == {"type": "string"}
+
+    def test_no_null_variant_is_noop(self) -> None:
+        schema: dict = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        remove_null_from_anyof(schema)
+        assert schema == {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+
+    def test_add_nullable_flag(self) -> None:
+        schema: dict = {"anyOf": [{"type": "boolean"}, {"type": "null"}]}
+        remove_null_from_anyof(schema, add_nullable=True)
+        assert schema == {"type": "boolean", "nullable": True}
+
+    def test_empty_anyof(self) -> None:
+        schema: dict = {"anyOf": []}
+        remove_null_from_anyof(schema)
+        assert schema == {"anyOf": []}
+
+
+class TestRemoveDefaultFromSchema:
+    def test_removes_existing_default(self) -> None:
+        schema: dict = {"type": "boolean", "default": True}
+        remove_default_from_schema(schema)
+        assert schema == {"type": "boolean"}
+
+    def test_no_default_is_noop(self) -> None:
+        schema: dict = {"type": "string"}
+        remove_default_from_schema(schema)
+        assert schema == {"type": "string"}
+
+    def test_removes_none_default(self) -> None:
+        schema: dict = {"type": "string", "default": None}
+        remove_default_from_schema(schema)
+        assert schema == {"type": "string"}
+
+
+class TestFlattenNullableRemoveDefault:
+    def test_removes_null_and_default(self) -> None:
+        schema: dict = {"anyOf": [{"type": "boolean"}, {"type": "null"}], "default": True}
+        flatten_nullable_remove_default(schema)
+        assert schema == {"type": "boolean"}
+
+    def test_only_null_removal_when_no_default(self) -> None:
+        schema: dict = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        flatten_nullable_remove_default(schema)
+        assert schema == {"type": "string"}
+
+    def test_only_default_removal_when_no_anyof(self) -> None:
+        schema: dict = {"type": "integer", "default": 0}
+        flatten_nullable_remove_default(schema)
+        assert schema == {"type": "integer"}
+
+    def test_empty_schema(self) -> None:
+        schema: dict = {}
+        flatten_nullable_remove_default(schema)
+        assert schema == {}
 
 
 def test_dynamic_schema_registration_round_trip() -> None:


### PR DESCRIPTION
# What does this PR do?
Fixes field-level schema mismatches in the Responses API Pydantic models so the generated OpenAPI spec matches the 
  OpenResponses reference spec (POST /responses). This is PR 1 of the plan in #5780.                                 
                                                                                                                     
  Changes:                                                                                                           
  - Add `ResponseTruncation` enum to replace bare `str` for truncation fields
  - Add deprecated `generate_summary` field to `OpenAIResponseReasoning`
  - Make `parallel_tool_calls non-nullable` bool on the response model
  - Fix `store/stream` to emit correct nullable schema without default
  - Fix `stream_options.include_obfuscation` to be nullable without default
  - Add schema_utils helpers: `remove_default_from_schema`, `flatten_nullable_remove_default`, `move_default_into_anyof`

<!-- If resolving an issue, uncomment and update the line below -->
Refs: #5780 

## Test Plan
- Unit tests pass: `uv run pytest tests/unit/providers/responses/builtin/test_openai_responses_params.py -x`
  - mypy passes                                                                                                      
  - All pre-commit hooks pass (including OpenAI API Coverage, API spec breaking change check)                        
  - Conformance score for Responses improved from 88.9% to 90.7% (25 → 21 schema issues)                             
  - Integration tests (replay mode): `uv run --no-sync ./scripts/integration-tests.sh --stack-config server:ci-tests --setup gpt --suite responses`