### PR TITLE
fix(docs): tag connector endpoints as Connectors for API docs page

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -3417,6 +3417,7 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Admin
+      - Connectors
       summary: List all connectors.
       description: List all configured connectors.
       operationId: list_connectors_v1alpha_admin_connectors_get
@@ -3443,6 +3444,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: Get a tool by name from a connector.
       description: Get a tool definition by its name from a connector.
       operationId: get_connector_tool_v1alpha_admin_connectors__connector_id__tools__tool_name__get
@@ -3496,6 +3498,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: List tools from a connector.
       description: List all tools available from a connector.
       operationId: list_connector_tools_v1alpha_admin_connectors__connector_id__tools_get
@@ -3541,6 +3544,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: Get a connector by its ID.
       description: Get a connector by its ID.
       operationId: get_connector_v1alpha_admin_connectors__connector_id__get

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -225,6 +225,7 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Admin
+      - Connectors
       summary: List all connectors.
       description: List all configured connectors.
       operationId: list_connectors_v1alpha_admin_connectors_get
@@ -251,6 +252,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: Get a tool by name from a connector.
       description: Get a tool definition by its name from a connector.
       operationId: get_connector_tool_v1alpha_admin_connectors__connector_id__tools__tool_name__get
@@ -304,6 +306,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: List tools from a connector.
       description: List all tools available from a connector.
       operationId: list_connector_tools_v1alpha_admin_connectors__connector_id__tools_get
@@ -349,6 +352,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: Get a connector by its ID.
       description: Get a connector by its ID.
       operationId: get_connector_v1alpha_admin_connectors__connector_id__get

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -3417,6 +3417,7 @@ paths:
           $ref: '#/components/responses/DefaultError'
       tags:
       - Admin
+      - Connectors
       summary: List all connectors.
       description: List all configured connectors.
       operationId: list_connectors_v1alpha_admin_connectors_get
@@ -3443,6 +3444,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: Get a tool by name from a connector.
       description: Get a tool definition by its name from a connector.
       operationId: get_connector_tool_v1alpha_admin_connectors__connector_id__tools__tool_name__get
@@ -3496,6 +3498,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: List tools from a connector.
       description: List all tools available from a connector.
       operationId: list_connector_tools_v1alpha_admin_connectors__connector_id__tools_get
@@ -3541,6 +3544,7 @@ paths:
           description: Default Response
       tags:
       - Admin
+      - Connectors
       summary: Get a connector by its ID.
       description: Get a connector by its ID.
       operationId: get_connector_v1alpha_admin_connectors__connector_id__get

--- a/src/ogx_api/admin/fastapi_routes.py
+++ b/src/ogx_api/admin/fastapi_routes.py
@@ -135,6 +135,7 @@ def create_router(impl: Admin) -> APIRouter:
         response_model=ListConnectorsResponse,
         summary="List all connectors.",
         description="List all configured connectors.",
+        tags=["Connectors"],
     )
     async def list_connectors() -> ListConnectorsResponse:
         return await impl.list_connectors()
@@ -144,6 +145,7 @@ def create_router(impl: Admin) -> APIRouter:
         response_model=ToolDef,
         summary="Get a tool by name from a connector.",
         description="Get a tool definition by its name from a connector.",
+        tags=["Connectors"],
     )
     async def get_connector_tool(
         connector_id: Annotated[str, Path(description="Identifier for the connector")],
@@ -158,6 +160,7 @@ def create_router(impl: Admin) -> APIRouter:
         response_model=ListToolsResponse,
         summary="List tools from a connector.",
         description="List all tools available from a connector.",
+        tags=["Connectors"],
     )
     async def list_connector_tools(
         request: Annotated[ListConnectorToolsRequest, Depends(list_connector_tools_request)],
@@ -170,6 +173,7 @@ def create_router(impl: Admin) -> APIRouter:
         response_model=Connector,
         summary="Get a connector by its ID.",
         description="Get a connector by its ID.",
+        tags=["Connectors"],
     )
     async def get_connector(
         request: Annotated[GetConnectorRequest, Depends(get_connector_request)],


### PR DESCRIPTION
# What does this PR do?

The `/docs/api-experimental/connectors` page returned a 404 because the connector endpoints only had the `Admin` tag (inherited from the `v1alpha_router`). The `Connectors` tag was defined in the OpenAPI spec but no endpoints used it, so the docusaurus OpenAPI plugin never generated a page for it.

This adds `tags=["Connectors"]` to the four connector route decorators in `src/ogx_api/admin/fastapi_routes.py` and regenerates the OpenAPI specs. The endpoints now carry both `Admin` and `Connectors` tags, so the plugin generates a dedicated Connectors page.

## Test Plan

1. Run `uv run ./scripts/run_openapi_generator.sh` and verify the experimental spec has `- Connectors` under each connector endpoint's tags
2. Run `uv run pre-commit run --all-files` — all checks pass
3. Run `uv run pytest tests/unit/core/ -x` — all 261 tests pass including `test_openapi_schema_has_connectors_endpoints`
4. Generate docs with `npm run gen-api-docs all` and start dev server — verify `/docs/api-experimental/connectors` loads correctly