### PR TITLE
fix: Harden secret handling and passthrough fallbacks

### DIFF
--- a/src/ogx/core/datatypes.py
+++ b/src/ogx/core/datatypes.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal, Self
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 from ogx.core.access_control.datatypes import AccessRule, RouteAccessRule
 from ogx.core.storage.datatypes import (
@@ -193,7 +193,7 @@ class OAuth2IntrospectionConfig(BaseModel):
 
     url: str
     client_id: str
-    client_secret: str
+    client_secret: SecretStr
     send_secret_in_body: bool = False
 
 

--- a/src/ogx/core/resolver.py
+++ b/src/ogx/core/resolver.py
@@ -132,7 +132,6 @@ def additional_protocols_map() -> dict[Api, Any]:
     }
 
 
-# TODO: make all this naming far less atrocious. Provider. ProviderSpec. ProviderWithSpec. WTF!
 class ProviderWithSpec(Provider):
     """A Provider paired with its resolved ProviderSpec for instantiation."""
 

--- a/src/ogx/core/routers/vector_io.py
+++ b/src/ogx/core/routers/vector_io.py
@@ -103,9 +103,7 @@ class VectorIORouter(VectorIO):
                 return "unknown"
             return obj.provider_id
         except Exception:
-            logger.warning(
-                "Could not resolve provider for vector store", vector_store_id=vector_store_id, exc_info=True
-            )
+            logger.exception("Could not resolve provider for vector store", vector_store_id=vector_store_id)
             return "unknown"
 
     async def _rewrite_query_for_search(self, query: str) -> str:

--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -246,12 +246,12 @@ class OAuth2TokenAuthProvider(AuthProvider):
 
         if self.config.introspection.send_secret_in_body:
             form["client_id"] = self.config.introspection.client_id
-            form["client_secret"] = self.config.introspection.client_secret
+            form["client_secret"] = self.config.introspection.client_secret.get_secret_value()
         else:
             # httpx auth parameter expects tuple[str | bytes, str | bytes]
             post_kwargs["auth"] = (
                 self.config.introspection.client_id,
-                self.config.introspection.client_secret,
+                self.config.introspection.client_secret.get_secret_value(),
             )
 
         try:

--- a/src/ogx/providers/inline/messages/impl.py
+++ b/src/ogx/providers/inline/messages/impl.py
@@ -155,7 +155,7 @@ class BuiltinMessagesImpl(Messages):
                     base_url = base_url[:-3]
                 logger.info("Using native /v1/messages passthrough", model=model, base_url=base_url)
                 return base_url
-        except Exception:
+        except (KeyError, ValueError, AttributeError):
             logger.debug("Failed to resolve passthrough, falling back to translation", model=model)
 
         return None
@@ -175,8 +175,8 @@ class BuiltinMessagesImpl(Messages):
                 obj = await router.routing_table.get_object_by_identifier("model", request.model)
                 if obj:
                     provider_model = obj.provider_resource_id
-            except Exception:
-                pass
+            except (KeyError, ValueError, AttributeError):
+                logger.debug("Failed to resolve provider model name, using original", model=request.model)
 
         body = request.model_dump(exclude_none=True)
         body["model"] = provider_model
@@ -268,8 +268,8 @@ class BuiltinMessagesImpl(Messages):
                 obj = await router.routing_table.get_object_by_identifier("model", request.model)
                 if obj:
                     provider_model = obj.provider_resource_id
-            except Exception:
-                pass
+            except (KeyError, ValueError, AttributeError):
+                logger.debug("Failed to resolve provider model name, using original", model=request.model)
 
         body = request.model_dump(exclude_none=True)
         body["model"] = provider_model

--- a/src/ogx_api/__init__.py
+++ b/src/ogx_api/__init__.py
@@ -881,7 +881,6 @@ __all__ = [
     "ResponseFormatType",
     "ResponseItemInclude",
     "ResponseTruncation",
-    "ResponseNotFoundError",
     "ResponseStreamOptions",
     "RetrieveFileContentRequest",
     "RetrieveFileRequest",


### PR DESCRIPTION
# What does this PR do?
This PR hardens OAuth2 introspection secret handling by using `SecretStr` in config and unwrapping secret values only when sending introspection requests.
It tightens messages passthrough fallbacks by catching only expected lookup errors and adding debug logs instead of silently swallowing failures.
It also improves vector-store provider lookup error logging, removes a duplicate `ResponseNotFoundError` export, and drops an outdated TODO comment.

## Test Plan
- `uv run pytest tests/unit/server/test_auth_oauth2_introspection.py tests/unit/providers/inline/messages/test_impl.py tests/unit/telemetry/test_vector_io_metrics.py -q --maxfail=1`
- Result: `36 passed in 0.32s`
