### PR TITLE
fix: improve async safety in routers and Redis KV reads

### DIFF
--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -17,7 +17,6 @@ from pydantic import TypeAdapter
 from ogx.core.access_control.access_control import is_action_allowed
 from ogx.core.datatypes import ModelWithOwner
 from ogx.core.request_headers import get_authenticated_user
-from ogx.core.task import create_detached_background_task
 from ogx.log import get_logger
 from ogx.providers.utils.inference.inference_store import InferenceStore
 from ogx.telemetry.inference_metrics import (
@@ -64,6 +63,11 @@ from ogx_api import (
 from ogx_api.inference.models import RerankRequest
 
 logger = get_logger(name=__name__, category="core::routers")
+
+
+def _log_background_task_error(task: asyncio.Task) -> None:
+    if not task.cancelled() and (exc := task.exception()):
+        logger.error("Failed to store chat completion in background", error=str(exc))
 
 
 class InferenceRouter(Inference):
@@ -269,7 +273,8 @@ class InferenceRouter(Inference):
 
         # Store the response with the ID that will be returned to the client
         if self.store:
-            create_detached_background_task(self.store.store_chat_completion(response, params.messages))
+            task = asyncio.create_task(self.store.store_chat_completion(response, params.messages))
+            task.add_done_callback(_log_background_task_error)
 
         return response
 
@@ -556,4 +561,5 @@ class InferenceRouter(Inference):
                     object="chat.completion",
                 )
                 logger.debug("InferenceRouter.completion_response", final_response=final_response)
-                create_detached_background_task(self.store.store_chat_completion(final_response, messages))
+                task = asyncio.create_task(self.store.store_chat_completion(final_response, messages))
+                task.add_done_callback(_log_background_task_error)

--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -17,6 +17,7 @@ from pydantic import TypeAdapter
 from ogx.core.access_control.access_control import is_action_allowed
 from ogx.core.datatypes import ModelWithOwner
 from ogx.core.request_headers import get_authenticated_user
+from ogx.core.task import create_detached_background_task
 from ogx.log import get_logger
 from ogx.providers.utils.inference.inference_store import InferenceStore
 from ogx.telemetry.inference_metrics import (
@@ -268,7 +269,7 @@ class InferenceRouter(Inference):
 
         # Store the response with the ID that will be returned to the client
         if self.store:
-            asyncio.create_task(self.store.store_chat_completion(response, params.messages))
+            create_detached_background_task(self.store.store_chat_completion(response, params.messages))
 
         return response
 
@@ -555,4 +556,4 @@ class InferenceRouter(Inference):
                     object="chat.completion",
                 )
                 logger.debug("InferenceRouter.completion_response", final_response=final_response)
-                asyncio.create_task(self.store.store_chat_completion(final_response, messages))
+                create_detached_background_task(self.store.store_chat_completion(final_response, messages))

--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -354,7 +354,7 @@ class InferenceRouter(Inference):
     async def health(self) -> dict[str, HealthResponse]:
         health_statuses = {}
         timeout = 1  # increasing the timeout to 1 second for health checks
-        for provider_id, impl in self.routing_table.impls_by_provider_id.items():
+        for provider_id, impl in dict(self.routing_table.impls_by_provider_id).items():
             try:
                 # check if the provider has a health method
                 if not hasattr(impl, "health"):

--- a/src/ogx/core/routers/vector_io.py
+++ b/src/ogx/core/routers/vector_io.py
@@ -669,7 +669,7 @@ class VectorIORouter(VectorIO):
     async def health(self) -> dict[str, HealthResponse]:
         health_statuses = {}
         timeout = 1  # increasing the timeout to 1 second for health checks
-        for provider_id, impl in self.routing_table.impls_by_provider_id.items():
+        for provider_id, impl in dict(self.routing_table.impls_by_provider_id).items():
             try:
                 # check if the provider has a health method
                 if not hasattr(impl, "health"):

--- a/src/ogx/core/storage/kvstore/redis/redis.py
+++ b/src/ogx/core/storage/kvstore/redis/redis.py
@@ -46,7 +46,6 @@ class RedisKVStoreImpl(KVStore):
         value = await client.get(key)
         if value is None:
             return None
-        await client.ttl(key)
         if isinstance(value, bytes):
             return value.decode("utf-8")
         if isinstance(value, str):


### PR DESCRIPTION
# What does this PR do?
This PR hardens async behavior in router/storage paths and removes an unnecessary Redis read round-trip. It adds done-callback error logging for fire-and-forget chat completion persistence tasks in the inference router. It snapshots provider implementation maps before health-check iteration to avoid `RuntimeError` from concurrent dict mutation. It also removes an unused `ttl` call from Redis KV `get()`.

## Test Plan
`uv run pytest tests/unit/core/routers/test_inference_router.py tests/unit/core/routers/test_vector_io.py -q`
Result: `12 passed in 0.47s`.

`uv run pytest tests/unit/utils/kvstore -q`
Result: `60 passed, 3 xfailed in 0.44s`.
