### PR TITLE
fix(storage): asyncio.Lock for SQLStore and MongoDB expiration enforcement

### DIFF
--- a/src/ogx/core/connectors/connectors.py
+++ b/src/ogx/core/connectors/connectors.py
@@ -60,10 +60,11 @@ class ConnectorServiceImpl(Connectors):
         if not connectors_ref:
             raise ServiceNotEnabledError("storage.stores.connectors")
 
-        self.sql_store = authorized_sqlstore(connectors_ref, self.policy)
+        self._connectors_ref = connectors_ref
 
     async def initialize(self) -> None:
         """Initialize the connector service."""
+        self.sql_store = await authorized_sqlstore(self._connectors_ref, self.policy)
         await self.sql_store.create_table(
             TABLE_CONNECTORS,
             {

--- a/src/ogx/core/conversations/conversations.py
+++ b/src/ogx/core/conversations/conversations.py
@@ -73,10 +73,11 @@ class ConversationServiceImpl(Conversations):
         if not conversations_ref:
             raise ServiceNotEnabledError("storage.stores.conversations")
 
-        self.sql_store = authorized_sqlstore(conversations_ref, self.policy)
+        self._conversations_ref = conversations_ref
 
     async def initialize(self) -> None:
         """Initialize the store and create tables."""
+        self.sql_store = await authorized_sqlstore(self._conversations_ref, self.policy)
         await self.sql_store.create_table(
             "openai_conversations",
             {

--- a/src/ogx/core/prompts/prompts.py
+++ b/src/ogx/core/prompts/prompts.py
@@ -61,9 +61,10 @@ class PromptServiceImpl(Prompts):
         if not prompts_ref:
             raise ServiceNotEnabledError("storage.stores.prompts")
 
-        self.sql_store = authorized_sqlstore(prompts_ref, self.policy)
+        self._prompts_ref = prompts_ref
 
     async def initialize(self) -> None:
+        self.sql_store = await authorized_sqlstore(self._prompts_ref, self.policy)
         await self.sql_store.create_table(
             TABLE_PROMPTS,
             {

--- a/src/ogx/core/storage/kvstore/mongodb/mongodb.py
+++ b/src/ogx/core/storage/kvstore/mongodb/mongodb.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Any
 
 from pymongo import AsyncMongoClient
 from pymongo.asynchronous.collection import AsyncCollection
@@ -43,10 +44,18 @@ class MongoDBKVStoreImpl(KVStore):
             log.exception("Could not connect to MongoDB database server")
             raise RuntimeError("Could not connect to MongoDB database server") from e
 
+        await self.collection.create_index("key", unique=True)
+        await self.collection.create_index([("expiration", 1)], expireAfterSeconds=0)
+
     def _namespaced_key(self, key: str) -> str:
         if not self.config.namespace:
             return key
         return f"{self.config.namespace}:{key}"
+
+    def _strip_namespace(self, key: str) -> str:
+        if self.config.namespace and key.startswith(f"{self.config.namespace}:"):
+            return key[len(self.config.namespace) + 1 :]
+        return key
 
     async def set(self, key: str, value: str, expiration: datetime | None = None) -> None:
         key = self._namespaced_key(key)
@@ -55,7 +64,11 @@ class MongoDBKVStoreImpl(KVStore):
 
     async def get(self, key: str) -> str | None:
         key = self._namespaced_key(key)
-        query = {"key": key}
+        now = datetime.now(tz=UTC)
+        query: dict[str, Any] = {
+            "key": key,
+            "$or": [{"expiration": None}, {"expiration": {"$gt": now}}],
+        }
         result = await self.collection.find_one(query, {"value": 1, "_id": 0})
         return result["value"] if result else None
 
@@ -66,8 +79,10 @@ class MongoDBKVStoreImpl(KVStore):
     async def values_in_range(self, start_key: str, end_key: str) -> list[str]:
         start_key = self._namespaced_key(start_key)
         end_key = self._namespaced_key(end_key)
-        query = {
+        now = datetime.now(tz=UTC)
+        query: dict[str, Any] = {
             "key": {"$gte": start_key, "$lt": end_key},
+            "$or": [{"expiration": None}, {"expiration": {"$gt": now}}],
         }
         cursor = self.collection.find(query, {"value": 1, "_id": 0}).sort("key", 1)
         result = []
@@ -78,12 +93,15 @@ class MongoDBKVStoreImpl(KVStore):
     async def keys_in_range(self, start_key: str, end_key: str) -> list[str]:
         start_key = self._namespaced_key(start_key)
         end_key = self._namespaced_key(end_key)
-        query = {"key": {"$gte": start_key, "$lt": end_key}}
+        now = datetime.now(tz=UTC)
+        query: dict[str, Any] = {
+            "key": {"$gte": start_key, "$lt": end_key},
+            "$or": [{"expiration": None}, {"expiration": {"$gt": now}}],
+        }
         cursor = self.collection.find(query, {"key": 1, "_id": 0}).sort("key", 1)
-        # AsyncCursor requires async iteration
         result = []
         async for doc in cursor:
-            result.append(doc["key"])
+            result.append(self._strip_namespace(doc["key"]))
         return result
 
     async def shutdown(self) -> None:

--- a/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
@@ -82,12 +82,12 @@ class SqlRecord(ProtectedResource):
         self.owner = owner
 
 
-def authorized_sqlstore(reference: SqlStoreReference, policy: list[AccessRule]) -> "AuthorizedSqlStore":
+async def authorized_sqlstore(reference: SqlStoreReference, policy: list[AccessRule]) -> "AuthorizedSqlStore":
     """Create an AuthorizedSqlStore from a store reference and access policy.
 
     This is the only supported way to obtain a SQL store for API use.
     """
-    return AuthorizedSqlStore(_sqlstore_impl(reference), policy)
+    return AuthorizedSqlStore(await _sqlstore_impl(reference), policy)
 
 
 class AuthorizedSqlStore:

--- a/src/ogx/core/storage/sqlstore/sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlstore.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from threading import Lock
+import asyncio
 from typing import Annotated, cast
 
 from pydantic import Field
@@ -22,7 +22,7 @@ sql_store_pip_packages = ["sqlalchemy[asyncio]", "aiosqlite", "asyncpg"]
 
 _SQLSTORE_BACKENDS: dict[str, StorageBackendConfig] = {}
 _SQLSTORE_INSTANCES: dict[str, SqlStore] = {}
-_SQLSTORE_LOCKS: dict[str, Lock] = {}
+_SQLSTORE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 SqlStoreConfig = Annotated[
@@ -45,7 +45,7 @@ def get_pip_packages(store_config: dict | SqlStoreConfig) -> list[str]:
         return store_config.pip_packages()
 
 
-def _sqlstore_impl(reference: SqlStoreReference) -> SqlStore:
+async def _sqlstore_impl(reference: SqlStoreReference) -> SqlStore:
     """Get or create a SqlStore instance for the given store reference.
 
     Args:
@@ -69,8 +69,8 @@ def _sqlstore_impl(reference: SqlStoreReference) -> SqlStore:
     if existing:
         return existing
 
-    lock = _SQLSTORE_LOCKS.setdefault(backend_name, Lock())
-    with lock:
+    lock = _SQLSTORE_LOCKS.setdefault(backend_name, asyncio.Lock())
+    async with lock:
         existing = _SQLSTORE_INSTANCES.get(backend_name)
         if existing:
             return existing

--- a/src/ogx/providers/inline/batches/reference/__init__.py
+++ b/src/ogx/providers/inline/batches/reference/__init__.py
@@ -17,7 +17,7 @@ __all__ = ["ReferenceBatchesImpl", "ReferenceBatchesImplConfig"]
 
 
 async def get_provider_impl(config: ReferenceBatchesImplConfig, deps: dict[Api, Any], policy: list[AccessRule]):
-    sql_store = authorized_sqlstore(config.sqlstore, policy)
+    sql_store = await authorized_sqlstore(config.sqlstore, policy)
     inference_api: Inference | None = deps.get(Api.inference)
     files_api: Files | None = deps.get(Api.files)
     models_api: Models | None = deps.get(Api.models)

--- a/src/ogx/providers/inline/files/localfs/files.py
+++ b/src/ogx/providers/inline/files/localfs/files.py
@@ -71,7 +71,7 @@ class LocalfsFilesImpl(Files):
         storage_path.mkdir(parents=True, exist_ok=True)
 
         # Initialize SQL store for metadata
-        self.sql_store = authorized_sqlstore(self.config.metadata_store, self.policy)
+        self.sql_store = await authorized_sqlstore(self.config.metadata_store, self.policy)
         await self.sql_store.create_table(
             "openai_files",
             {

--- a/src/ogx/providers/inline/vector_io/faiss/faiss.py
+++ b/src/ogx/providers/inline/vector_io/faiss/faiss.py
@@ -367,7 +367,7 @@ class FaissVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoco
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
         # Load existing banks from kvstore
         start_key = VECTOR_DBS_PREFIX
         end_key = f"{VECTOR_DBS_PREFIX}\xff"

--- a/src/ogx/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
+++ b/src/ogx/providers/inline/vector_io/sqlite_vec/sqlite_vec.py
@@ -557,7 +557,7 @@ class SQLiteVecVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresPro
         self.kvstore = await kvstore_impl(self.config.persistence)
 
         if self.config.metadata_store:
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         start_key = VECTOR_DBS_PREFIX
         end_key = f"{VECTOR_DBS_PREFIX}\xff"

--- a/src/ogx/providers/remote/files/openai/files.py
+++ b/src/ogx/providers/remote/files/openai/files.py
@@ -111,7 +111,7 @@ class OpenAIFilesImpl(Files):
     async def initialize(self) -> None:
         self._client = OpenAI(api_key=self._config.api_key)
 
-        self._sql_store = authorized_sqlstore(self._config.metadata_store, self.policy)
+        self._sql_store = await authorized_sqlstore(self._config.metadata_store, self.policy)
         await self._sql_store.create_table(
             "openai_files",
             {

--- a/src/ogx/providers/remote/files/s3/files.py
+++ b/src/ogx/providers/remote/files/s3/files.py
@@ -184,7 +184,7 @@ class S3FilesImpl(Files):
         self._client = _create_s3_client(self._config)
         await _create_bucket_if_not_exists(self._client, self._config)
 
-        self._sql_store = authorized_sqlstore(self._config.metadata_store, self.policy)
+        self._sql_store = await authorized_sqlstore(self._config.metadata_store, self.policy)
         await self._sql_store.create_table(
             "openai_files",
             {

--- a/src/ogx/providers/remote/vector_io/chroma/chroma.py
+++ b/src/ogx/providers/remote/vector_io/chroma/chroma.py
@@ -267,7 +267,7 @@ class ChromaVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         if isinstance(self.config, RemoteChromaVectorIOConfig):
             log.info(f"Connecting to Chroma server at: {self.config.url}")

--- a/src/ogx/providers/remote/vector_io/elasticsearch/elasticsearch.py
+++ b/src/ogx/providers/remote/vector_io/elasticsearch/elasticsearch.py
@@ -406,7 +406,7 @@ class ElasticsearchVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStore
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         start_key = VECTOR_DBS_PREFIX
         end_key = f"{VECTOR_DBS_PREFIX}\xff"

--- a/src/ogx/providers/remote/vector_io/infinispan/infinispan.py
+++ b/src/ogx/providers/remote/vector_io/infinispan/infinispan.py
@@ -575,7 +575,7 @@ class InfinispanVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresPr
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         # Setup HTTP client with authentication
         auth: httpx.BasicAuth | httpx.DigestAuth | None = None

--- a/src/ogx/providers/remote/vector_io/milvus/milvus.py
+++ b/src/ogx/providers/remote/vector_io/milvus/milvus.py
@@ -479,7 +479,7 @@ class MilvusVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         start_key = VECTOR_DBS_PREFIX
         end_key = f"{VECTOR_DBS_PREFIX}\xff"

--- a/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
+++ b/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
@@ -792,7 +792,7 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         await self.initialize_openai_vector_stores()
 

--- a/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
+++ b/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
@@ -354,7 +354,7 @@ class QdrantVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         start_key = VECTOR_DBS_PREFIX
         end_key = f"{VECTOR_DBS_PREFIX}\xff"

--- a/src/ogx/providers/remote/vector_io/weaviate/weaviate.py
+++ b/src/ogx/providers/remote/vector_io/weaviate/weaviate.py
@@ -340,7 +340,7 @@ class WeaviateVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
         if self.config.metadata_store:
             from ogx.core.storage.sqlstore import authorized_sqlstore
 
-            self.metadata_store = authorized_sqlstore(self.config.metadata_store, self._policy)
+            self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
         # Load existing vector DB definitions
         if self.kvstore is not None:

--- a/src/ogx/providers/utils/inference/inference_store.py
+++ b/src/ogx/providers/utils/inference/inference_store.py
@@ -114,7 +114,7 @@ class InferenceStore:
 
     async def initialize(self):
         """Create the necessary tables if they don't exist."""
-        self.sql_store = authorized_sqlstore(self.reference, self.policy)
+        self.sql_store = await authorized_sqlstore(self.reference, self.policy)
 
         # Disable write queue for SQLite since WAL mode handles concurrency
         # Keep it enabled for other backends (like Postgres) for performance

--- a/src/ogx/providers/utils/interactions/interactions_store.py
+++ b/src/ogx/providers/utils/interactions/interactions_store.py
@@ -30,7 +30,7 @@ class InteractionsStore:
 
     async def initialize(self) -> None:
         """Create the interactions table if it does not exist."""
-        self.sql_store = authorized_sqlstore(self.reference, self.policy)
+        self.sql_store = await authorized_sqlstore(self.reference, self.policy)
         await self.sql_store.create_table(
             self.reference.table_name,
             {

--- a/src/ogx/providers/utils/responses/responses_store.py
+++ b/src/ogx/providers/utils/responses/responses_store.py
@@ -126,7 +126,7 @@ class ResponsesStore:
 
     async def initialize(self):
         """Create the necessary tables if they don't exist."""
-        self.sql_store = authorized_sqlstore(self.reference, self.policy)
+        self.sql_store = await authorized_sqlstore(self.reference, self.policy)
 
         await self.sql_store.create_table(
             self.reference.table_name,

--- a/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
+++ b/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
@@ -56,7 +56,7 @@ BACKEND_CONFIGS = [
 
 
 @pytest.fixture
-def authorized_store(backend_config):
+async def authorized_store(backend_config):
     """Set up authorized store with proper cleanup."""
     config_func = backend_config
 

--- a/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
+++ b/tests/integration/providers/utils/sqlstore/test_authorized_sqlstore.py
@@ -63,7 +63,7 @@ def authorized_store(backend_config):
     config = config_func()
     backend_name = f"sql_{type(config).__name__.lower()}"
     register_sqlstore_backends({backend_name: config})
-    base_sqlstore = _sqlstore_impl(SqlStoreReference(backend=backend_name, table_name="authorized_store"))
+    base_sqlstore = await _sqlstore_impl(SqlStoreReference(backend=backend_name, table_name="authorized_store"))
     authorized_store = AuthorizedSqlStore(base_sqlstore, default_policy())
 
     yield authorized_store

--- a/tests/unit/core/test_storage_shutdown.py
+++ b/tests/unit/core/test_storage_shutdown.py
@@ -149,7 +149,7 @@ class TestSqlStoreShutdown:
             )
 
             # Create instance by calling _sqlstore_impl
-            store = _sqlstore_impl(SqlStoreReference(backend="sql_test", table_name="test"))
+            store = await _sqlstore_impl(SqlStoreReference(backend="sql_test", table_name="test"))
 
             # Verify store is working
             from ogx_api.internal.sqlstore import ColumnType

--- a/tests/unit/prompts/prompts/conftest.py
+++ b/tests/unit/prompts/prompts/conftest.py
@@ -45,7 +45,7 @@ async def temp_prompt_store(tmp_path_factory):
         ),
     )
 
-    # Backends must be registered before PromptServiceImpl constructor calls authorized_sqlstore()
+    # Backends must be registered before PromptServiceImpl.initialize() calls authorized_sqlstore()
     register_kvstore_backends({"kv_test": storage.backends["kv_test"]})
     register_sqlstore_backends({"sql_test": storage.backends["sql_test"]})
 

--- a/tests/unit/providers/batches/conftest.py
+++ b/tests/unit/providers/batches/conftest.py
@@ -29,7 +29,7 @@ async def provider():
         config = ReferenceBatchesImplConfig(sqlstore=SqlStoreReference(backend=backend_name, table_name="batches"))
 
         # Create sql_store and mock APIs
-        base_sql_store = _sqlstore_impl(config.sqlstore)
+        base_sql_store = await _sqlstore_impl(config.sqlstore)
         sql_store = AuthorizedSqlStore(base_sql_store, policy=[])
         mock_inference = AsyncMock()
         mock_files = AsyncMock()


### PR DESCRIPTION
# What does this PR do?

Fixes two async/concurrency issues in the storage layer identified by a codebase audit:

1. **Replace `threading.Lock` with `asyncio.Lock` in SQLStore singleton** — `_sqlstore_impl()` used a threading lock that blocks the event loop when contended. Switched to `asyncio.Lock` for consistency with the KV store layer. This required making `_sqlstore_impl()` and `authorized_sqlstore()` async, updating all ~22 callers, and moving three `__init__` calls (prompts, conversations, connectors) to their `initialize()` methods.

2. **Add expiration enforcement and TTL index to MongoDB KV store** — The MongoDB backend stored expiration timestamps but never filtered on them in `get()`, `values_in_range()`, or `keys_in_range()`. Expired documents accumulated forever. Added a TTL index for automatic cleanup and expiration filtering in all read operations. Also added `_strip_namespace()` to `keys_in_range()` for consistency with other backends.

## Test Plan

Ran the full storage test suite and pre-commit checks:

```bash
uv run pytest tests/unit/utils/kvstore/ tests/unit/utils/sqlstore/ \
  tests/unit/core/test_storage_shutdown.py tests/unit/prompts/ \
  tests/unit/providers/batches/ -x --tb=short -q
```

Output:
```
156 passed, 3 xfailed in 3.17s
```

```bash
uv run pre-commit run --all-files
```

Output: all 39 checks passed (including mypy).


🤖 Generated with [Claude Code](https://claude.com/claude-code)