### PR TITLE
perf(routers): parallelize health and vector store fan-out

### DIFF
--- a/src/ogx/core/library_client.py
+++ b/src/ogx/core/library_client.py
@@ -15,7 +15,7 @@ import queue
 import sys
 import threading
 import typing
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator, Mapping
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
@@ -495,26 +495,61 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
             raise ValueError("Client not initialized. Please call initialize() first.")
 
         # Create headers with provider data if available
-        headers = options.headers or {}
+        request_headers = self._sanitize_headers(options.headers)
         if self.provider_data:
             keys = ["X-OGX-Provider-Data", "x-ogx-provider-data"]
-            if all(key not in headers for key in keys):
-                headers["X-OGX-Provider-Data"] = json.dumps(self.provider_data)
+            if all(key not in request_headers for key in keys):
+                request_headers["X-OGX-Provider-Data"] = json.dumps(self.provider_data)
 
         # Use context manager for provider data
-        with request_provider_data_context(headers):
+        with request_provider_data_context(request_headers):
             if stream:
                 response = await self._call_streaming(
                     cast_to=cast_to,
                     options=options,
+                    request_headers=request_headers,
                     stream_cls=stream_cls,
                 )
             else:
                 response = await self._call_non_streaming(
                     cast_to=cast_to,
                     options=options,
+                    request_headers=request_headers,
                 )
             return response
+
+    @staticmethod
+    def _coerce_header_component(value: Any) -> str | None:
+        if value is None or value is NOT_GIVEN:
+            return None
+        if value.__class__.__name__ == "Omit":
+            return None
+        if isinstance(value, bytes):
+            try:
+                return value.decode("utf-8")
+            except UnicodeDecodeError:
+                return value.decode("latin-1")
+        if isinstance(value, str):
+            return value
+        if isinstance(value, int | float | bool):
+            return str(value)
+        return None
+
+    @classmethod
+    def _sanitize_headers(cls, headers: Any) -> dict[str, str]:
+        if headers is None or headers is NOT_GIVEN or headers.__class__.__name__ == "Omit":
+            return {}
+        if not isinstance(headers, Mapping):
+            return {}
+
+        sanitized_headers: dict[str, str] = {}
+        for key, value in headers.items():
+            normalized_key = cls._coerce_header_component(key)
+            normalized_value = cls._coerce_header_component(value)
+            if normalized_key is None or normalized_value is None:
+                continue
+            sanitized_headers[normalized_key] = normalized_value
+        return sanitized_headers
 
     def _handle_file_uploads(self, options: Any, body: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
         """Handle file uploads from OpenAI client and add them to the request body."""
@@ -546,6 +581,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
         *,
         cast_to: Any,
         options: Any,
+        request_headers: dict[str, str],
     ) -> Any:
         assert self.route_impls is not None  # Should be guaranteed by request() method, assertion for mypy
         path = options.url
@@ -597,7 +633,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
                 method=options.method,
                 url=options.url,
                 params=options.params,
-                headers=options.headers or {},
+                headers=request_headers,
                 json=convert_pydantic_to_json_value(filtered_body),
             ),
         )
@@ -616,6 +652,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
         *,
         cast_to: Any,
         options: Any,
+        request_headers: dict[str, str],
         stream_cls: Any,
     ) -> Any:
         assert self.route_impls is not None  # Should be guaranteed by request() method, assertion for mypy
@@ -668,7 +705,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
                 method=options.method,
                 url=options.url,
                 params=options.params,
-                headers=options.headers or {},
+                headers=request_headers,
                 json=convert_pydantic_to_json_value(body),
             ),
         )

--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -351,27 +351,27 @@ class InferenceRouter(Inference):
         return response
 
     async def health(self) -> dict[str, HealthResponse]:
-        health_statuses = {}
-        timeout = 1  # increasing the timeout to 1 second for health checks
-        for provider_id, impl in self.routing_table.impls_by_provider_id.items():
+        timeout = 1
+        impls_snapshot = dict(self.routing_table.impls_by_provider_id)
+
+        async def _check_one(provider_id: str, impl: object) -> tuple[str, HealthResponse]:
             try:
-                # check if the provider has a health method
                 if not hasattr(impl, "health"):
-                    continue
-                health = await asyncio.wait_for(impl.health(), timeout=timeout)
-                health_statuses[provider_id] = health
+                    return provider_id, HealthResponse(status=HealthStatus.NOT_IMPLEMENTED)
+                result = await asyncio.wait_for(impl.health(), timeout=timeout)
+                return provider_id, result
             except TimeoutError:
-                health_statuses[provider_id] = HealthResponse(
+                return provider_id, HealthResponse(
                     status=HealthStatus.ERROR,
                     message=f"Health check timed out after {timeout} seconds",
                 )
             except NotImplementedError:
-                health_statuses[provider_id] = HealthResponse(status=HealthStatus.NOT_IMPLEMENTED)
+                return provider_id, HealthResponse(status=HealthStatus.NOT_IMPLEMENTED)
             except Exception as e:
-                health_statuses[provider_id] = HealthResponse(
-                    status=HealthStatus.ERROR, message=f"Health check failed: {str(e)}"
-                )
-        return health_statuses
+                return provider_id, HealthResponse(status=HealthStatus.ERROR, message=f"Health check failed: {str(e)}")
+
+        results = await asyncio.gather(*[_check_one(pid, impl) for pid, impl in impls_snapshot.items()])
+        return dict(results)
 
     async def stream_tokens_and_compute_metrics_openai_chat(
         self,

--- a/src/ogx/core/routers/vector_io.py
+++ b/src/ogx/core/routers/vector_io.py
@@ -377,14 +377,16 @@ class VectorIORouter(VectorIO):
         # Route to default provider for now - could aggregate from all providers in the future
         # call retrieve on each vector dbs to get list of vector stores
         vector_stores = await self.routing_table.get_all_with_type("vector_store")
-        all_stores = []
-        for vector_store in vector_stores:
+
+        async def _retrieve_safe(identifier: str) -> VectorStoreObject | None:
             try:
-                vector_store_obj = await self.routing_table.openai_retrieve_vector_store(vector_store.identifier)
-                all_stores.append(vector_store_obj)
+                return await self.routing_table.openai_retrieve_vector_store(identifier)
             except Exception as e:
-                logger.error("Error retrieving vector store", identifier=vector_store.identifier, error=str(e))
-                continue
+                logger.error("Error retrieving vector store", identifier=identifier, error=str(e))
+                return None
+
+        results = await asyncio.gather(*[_retrieve_safe(vs.identifier) for vs in vector_stores])
+        all_stores = [r for r in results if r is not None]
 
         # Sort by created_at
         reverse_order = order == "desc"
@@ -667,27 +669,27 @@ class VectorIORouter(VectorIO):
             raise
 
     async def health(self) -> dict[str, HealthResponse]:
-        health_statuses = {}
-        timeout = 1  # increasing the timeout to 1 second for health checks
-        for provider_id, impl in self.routing_table.impls_by_provider_id.items():
+        timeout = 1
+        impls_snapshot = dict(self.routing_table.impls_by_provider_id)
+
+        async def _check_one(provider_id: str, impl: object) -> tuple[str, HealthResponse]:
             try:
-                # check if the provider has a health method
                 if not hasattr(impl, "health"):
-                    continue
-                health = await asyncio.wait_for(impl.health(), timeout=timeout)
-                health_statuses[provider_id] = health
+                    return provider_id, HealthResponse(status=HealthStatus.NOT_IMPLEMENTED)
+                result = await asyncio.wait_for(impl.health(), timeout=timeout)
+                return provider_id, result
             except TimeoutError:
-                health_statuses[provider_id] = HealthResponse(
+                return provider_id, HealthResponse(
                     status=HealthStatus.ERROR,
                     message=f"Health check timed out after {timeout} seconds",
                 )
             except NotImplementedError:
-                health_statuses[provider_id] = HealthResponse(status=HealthStatus.NOT_IMPLEMENTED)
+                return provider_id, HealthResponse(status=HealthStatus.NOT_IMPLEMENTED)
             except Exception as e:
-                health_statuses[provider_id] = HealthResponse(
-                    status=HealthStatus.ERROR, message=f"Health check failed: {str(e)}"
-                )
-        return health_statuses
+                return provider_id, HealthResponse(status=HealthStatus.ERROR, message=f"Health check failed: {str(e)}")
+
+        results = await asyncio.gather(*[_check_one(pid, impl) for pid, impl in impls_snapshot.items()])
+        return dict(results)
 
     async def openai_create_vector_store_file_batch(
         self,

--- a/tests/unit/distribution/test_library_client_initialization.py
+++ b/tests/unit/distribution/test_library_client_initialization.py
@@ -15,6 +15,7 @@ import threading
 import time
 
 import pytest
+from ogx_client import NOT_GIVEN, Omit
 
 from ogx.core.library_client import (
     AsyncOGXAsLibraryClient,
@@ -597,3 +598,27 @@ class TestOGXAsLibraryClientSyncOnAsync:
             time.sleep(0.01)
         else:
             pytest.fail("Background event loop thread was not cleaned up after init failure")
+
+
+class TestAsyncOGXAsLibraryClientHeaderSanitization:
+    def test_sanitize_headers_filters_omit_and_not_given(self):
+        headers = {
+            "Authorization": Omit(),
+            "X-Not-Given": NOT_GIVEN,
+            "X-Trace-Id": "trace-123",
+        }
+
+        assert AsyncOGXAsLibraryClient._sanitize_headers(headers) == {"X-Trace-Id": "trace-123"}
+
+    def test_sanitize_headers_normalizes_supported_types(self):
+        headers = {
+            b"X-Bytes-Key": b"bytes-value",
+            "X-Int": 7,
+            "X-Bool": False,
+        }
+
+        assert AsyncOGXAsLibraryClient._sanitize_headers(headers) == {
+            "X-Bytes-Key": "bytes-value",
+            "X-Int": "7",
+            "X-Bool": "False",
+        }


### PR DESCRIPTION
## What does this PR do?
This PR parallelizes router fan-out work to reduce latency when many providers or vector stores are registered.
`InferenceRouter.health` and `VectorIORouter.health` now snapshot provider implementations and run per-provider health checks concurrently with `asyncio.gather`, while preserving timeout and error mapping to `HealthResponse`.
`VectorIORouter.openai_list_vector_stores` now retrieves registered vector stores concurrently and preserves existing sorting and pagination behavior by filtering failed retrievals.

Also adds header sanitization in the library client to handle `Omit` and `NOT_GIVEN` sentinel values from the OpenAI SDK, preventing `TypeError` crashes when these sentinels are passed through as header values.

## Test Plan
```bash
uv run pytest tests/unit/core/routers/test_vector_io.py tests/unit/core/routers/test_inference_router.py tests/unit/distribution/test_library_client_initialization.py::TestAsyncOGXAsLibraryClientHeaderSanitization -q
```

Output:
```
..............                                                           [100%]
============================= slowest 10 durations =============================

(10 durations < 0.005s hidden.  Use -vv to show these durations.)
14 passed in 2.36s
```

Based on https://github.com/ogx-ai/ogx/pull/5802

🤖 Generated with [Claude Code](https://claude.com/claude-code)