### PR TITLE
chore: bump fallback_version to 1.0.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "0.8.1.dev0"
+fallback_version = "1.0.1.dev0"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -75,7 +75,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client>=0.8.0", # Optional for library-only usage
+    "ogx-client>=1.0.0", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -147,7 +147,7 @@ dev = [
     "ruamel.yaml",                   # needed for openapi generator
     "openapi-spec-validator>=0.7.2",
     "ollama",
-    "ogx-client>=0.8.0",
+    "ogx-client>=1.0.0",
     "chardet",
     "pypdf>=6.10.2",
     "together",
@@ -191,7 +191,7 @@ type_checking = [
     "langchain-openai",
     "langchain-core",
     "langgraph",
-    "ogx-client>=0.8.0",
+    "ogx-client>=1.0.0",
 ]
 # These are the dependencies required for running unit tests.
 unit = [

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -92,7 +92,7 @@ ogx_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "0.8.1.dev0"
+fallback_version = "1.0.1.dev0"
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -3973,7 +3973,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.8.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.0.0" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4033,7 +4033,7 @@ dev = [
     { name = "markitdown", extras = ["all"] },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = ">=0.8.0" },
+    { name = "ogx-client", specifier = ">=1.0.0" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.7.2" },
     { name = "pre-commit", specifier = ">=4.4.0" },
@@ -4110,7 +4110,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=0.8.0" },
+    { name = "ogx-client", specifier = ">=1.0.0" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4176,7 +4176,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "0.8.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4195,9 +4195,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/07/24c3dfd2441902c6c6fd3bcb8e91f93b81df8a30b7aea5fa4faece240637/ogx_client-0.8.0.tar.gz", hash = "sha256:f6bc08112a1f0fd78660771e74e783511e6108609f4c72c57541a5ccae26f1f0", size = 436487, upload-time = "2026-05-01T20:03:38.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/bbcd77921d29dc0a84a4767cc3661d027bfc5db6a0c32a4f82dadc182542/ogx_client-1.0.0.tar.gz", hash = "sha256:a13133105149b77384ba804cc1fa340c1defce9ebb4820e3c593c36b103f0010", size = 435209, upload-time = "2026-05-12T13:58:58.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/9c/2350f0aac4400dc3f556ed68b348496ec48972f5f406e6f847d4074f8e88/ogx_client-0.8.0-py3-none-any.whl", hash = "sha256:7265cd2ff23e148eb2818e7063d13b68e83cb73796b640d158525e758972a80d", size = 311475, upload-time = "2026-05-01T20:03:36.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/95/2cafdc4e3ff4a89db82862c0e0ed10fed2154ba74c7b16c2a5e371bac5d9/ogx_client-1.0.0-py3-none-any.whl", hash = "sha256:d0ef468f3a46b5bf3af9de3540902aa0d4a0c9d4370444697ca710473843c439", size = 309279, upload-time = "2026-05-12T13:58:57.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release version bump after v1.0.0.

Updates fallback_version in both pyproject.toml files to 1.0.1.dev0.

This PR was created automatically by the post-release workflow.