### PR TITLE
chore: update ogx-client to ^1.0.0 in UI lockfile

### DIFF
--- a/src/ogx/core/library_client.py
+++ b/src/ogx/core/library_client.py
@@ -15,7 +15,7 @@ import queue
 import sys
 import threading
 import typing
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator, Mapping
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
@@ -495,26 +495,61 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
             raise ValueError("Client not initialized. Please call initialize() first.")
 
         # Create headers with provider data if available
-        headers = options.headers or {}
+        request_headers = self._sanitize_headers(options.headers)
         if self.provider_data:
             keys = ["X-OGX-Provider-Data", "x-ogx-provider-data"]
-            if all(key not in headers for key in keys):
-                headers["X-OGX-Provider-Data"] = json.dumps(self.provider_data)
+            if all(key not in request_headers for key in keys):
+                request_headers["X-OGX-Provider-Data"] = json.dumps(self.provider_data)
 
         # Use context manager for provider data
-        with request_provider_data_context(headers):
+        with request_provider_data_context(request_headers):
             if stream:
                 response = await self._call_streaming(
                     cast_to=cast_to,
                     options=options,
+                    request_headers=request_headers,
                     stream_cls=stream_cls,
                 )
             else:
                 response = await self._call_non_streaming(
                     cast_to=cast_to,
                     options=options,
+                    request_headers=request_headers,
                 )
             return response
+
+    @staticmethod
+    def _coerce_header_component(value: Any) -> str | None:
+        if value is None or value is NOT_GIVEN:
+            return None
+        if value.__class__.__name__ == "Omit":
+            return None
+        if isinstance(value, bytes):
+            try:
+                return value.decode("utf-8")
+            except UnicodeDecodeError:
+                return value.decode("latin-1")
+        if isinstance(value, str):
+            return value
+        if isinstance(value, int | float | bool):
+            return str(value)
+        return None
+
+    @classmethod
+    def _sanitize_headers(cls, headers: Any) -> dict[str, str]:
+        if headers is None or headers is NOT_GIVEN or headers.__class__.__name__ == "Omit":
+            return {}
+        if not isinstance(headers, Mapping):
+            return {}
+
+        sanitized_headers: dict[str, str] = {}
+        for key, value in headers.items():
+            normalized_key = cls._coerce_header_component(key)
+            normalized_value = cls._coerce_header_component(value)
+            if normalized_key is None or normalized_value is None:
+                continue
+            sanitized_headers[normalized_key] = normalized_value
+        return sanitized_headers
 
     def _handle_file_uploads(self, options: Any, body: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
         """Handle file uploads from OpenAI client and add them to the request body."""
@@ -546,6 +581,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
         *,
         cast_to: Any,
         options: Any,
+        request_headers: dict[str, str],
     ) -> Any:
         assert self.route_impls is not None  # Should be guaranteed by request() method, assertion for mypy
         path = options.url
@@ -597,7 +633,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
                 method=options.method,
                 url=options.url,
                 params=options.params,
-                headers=options.headers or {},
+                headers=request_headers,
                 json=convert_pydantic_to_json_value(filtered_body),
             ),
         )
@@ -616,6 +652,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
         *,
         cast_to: Any,
         options: Any,
+        request_headers: dict[str, str],
         stream_cls: Any,
     ) -> Any:
         assert self.route_impls is not None  # Should be guaranteed by request() method, assertion for mypy
@@ -668,7 +705,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
                 method=options.method,
                 url=options.url,
                 params=options.params,
-                headers=options.headers or {},
+                headers=request_headers,
                 json=convert_pydantic_to_json_value(body),
             ),
         )

--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -27,6 +27,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
+        "ogx-client": "^1.0.0",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11206,6 +11207,36 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ogx-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.0.tgz",
+      "integrity": "sha512-mzPsh9ZLRElCDnddOmnuEuL5OMfd5+LNaV8PN0NrnU9H8ibOEx8NCUSQR3s2ipLTBPNtDopCDyC9VaGQTz9+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/ogx-client/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/ogx-client/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/oidc-token-hash": {
       "version": "5.1.0",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -51,6 +51,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
+    "ogx-client": "^1.0.0",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/tests/unit/distribution/test_library_client_initialization.py
+++ b/tests/unit/distribution/test_library_client_initialization.py
@@ -15,6 +15,7 @@ import threading
 import time
 
 import pytest
+from ogx_client import NOT_GIVEN, Omit
 
 from ogx.core.library_client import (
     AsyncOGXAsLibraryClient,
@@ -597,3 +598,27 @@ class TestOGXAsLibraryClientSyncOnAsync:
             time.sleep(0.01)
         else:
             pytest.fail("Background event loop thread was not cleaned up after init failure")
+
+
+class TestAsyncOGXAsLibraryClientHeaderSanitization:
+    def test_sanitize_headers_filters_omit_and_not_given(self):
+        headers = {
+            "Authorization": Omit(),
+            "X-Not-Given": NOT_GIVEN,
+            "X-Trace-Id": "trace-123",
+        }
+
+        assert AsyncOGXAsLibraryClient._sanitize_headers(headers) == {"X-Trace-Id": "trace-123"}
+
+    def test_sanitize_headers_normalizes_supported_types(self):
+        headers = {
+            b"X-Bytes-Key": b"bytes-value",
+            "X-Int": 7,
+            "X-Bool": False,
+        }
+
+        assert AsyncOGXAsLibraryClient._sanitize_headers(headers) == {
+            "X-Bytes-Key": "bytes-value",
+            "X-Int": "7",
+            "X-Bool": "False",
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -3973,7 +3973,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.8.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.0.0" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4033,7 +4033,7 @@ dev = [
     { name = "markitdown", extras = ["all"] },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = ">=0.8.0" },
+    { name = "ogx-client", specifier = "==1.0.0" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.7.2" },
     { name = "pre-commit", specifier = ">=4.4.0" },
@@ -4110,7 +4110,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=0.8.0" },
+    { name = "ogx-client", specifier = "==1.0.0" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4176,7 +4176,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "0.8.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4195,9 +4195,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/07/24c3dfd2441902c6c6fd3bcb8e91f93b81df8a30b7aea5fa4faece240637/ogx_client-0.8.0.tar.gz", hash = "sha256:f6bc08112a1f0fd78660771e74e783511e6108609f4c72c57541a5ccae26f1f0", size = 436487, upload-time = "2026-05-01T20:03:38.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/bbcd77921d29dc0a84a4767cc3661d027bfc5db6a0c32a4f82dadc182542/ogx_client-1.0.0.tar.gz", hash = "sha256:a13133105149b77384ba804cc1fa340c1defce9ebb4820e3c593c36b103f0010", size = 435209, upload-time = "2026-05-12T13:58:58.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/9c/2350f0aac4400dc3f556ed68b348496ec48972f5f406e6f847d4074f8e88/ogx_client-0.8.0-py3-none-any.whl", hash = "sha256:7265cd2ff23e148eb2818e7063d13b68e83cb73796b640d158525e758972a80d", size = 311475, upload-time = "2026-05-01T20:03:36.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/95/2cafdc4e3ff4a89db82862c0e0ed10fed2154ba74c7b16c2a5e371bac5d9/ogx_client-1.0.0-py3-none-any.whl", hash = "sha256:d0ef468f3a46b5bf3af9de3540902aa0d4a0c9d4370444697ca710473843c439", size = 309279, upload-time = "2026-05-12T13:58:57.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release npm lockfile update after v1.0.0.

Updates ogx-client to ^1.0.0 in the UI package lockfile.

This PR was created automatically by the post-release workflow.