### PR TITLE
docs: update stale /v1/tools references to /v1/admin/tools

### DIFF
--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -20,7 +20,7 @@ OGX implements the OpenAI API and organizes endpoints by stability level. Use an
         { title: 'Files', endpoint: '/v1/files', href: '/docs/api/files', blurb: 'File upload and management' },
         { title: 'Vector IO', endpoint: '/v1/vector_stores', href: '/docs/api/vector-io', blurb: 'Document storage and semantic search' },
         { title: 'Batches', endpoint: '/v1/batches', href: '/docs/api/batches', blurb: 'Offline batch processing' },
-        { title: 'Tools', endpoint: '/v1/tools', href: '/docs/api/tools', blurb: 'Tool listing and management' },
+        { title: 'Tools', endpoint: '/v1/admin/tools', href: '/docs/api/tools', blurb: 'Tool listing and management' },
         { title: 'Conversations', endpoint: '/v1/conversations', href: '/docs/api/conversations', blurb: 'Conversation state management' },
         { title: 'Prompts', endpoint: '/v1/prompts', href: '/docs/api/prompts', blurb: 'Prompt templates and versioning' },
       ],

--- a/docs/docs/building_applications/tools.mdx
+++ b/docs/docs/building_applications/tools.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 # Tools
 
 :::note[Tool Configuration Simplified]
-Built-in tools (web search, RAG, WolframAlpha) are now auto-registered based on your provider configuration. The `/v1/tools` and `/v1/toolgroups` endpoints are available for tool discovery and management. For MCP servers, use the [Connectors API](/docs/concepts/apis/).
+Built-in tools (web search, RAG, WolframAlpha) are now auto-registered based on your provider configuration. The `/v1/admin/tools` and `/v1/toolgroups` endpoints are available for tool discovery and management. For MCP servers, use the [Connectors API](/docs/concepts/apis/).
 :::
 
 Tools are functions that can be invoked by an agent to perform tasks. They are organized into tool groups and registered with specific providers. Each tool group represents a collection of related tools from a single provider. They are organized into groups so that state can be externalized: the collection operates on the same state typically.

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -155,7 +155,7 @@ const API_SURFACE = [
   ]},
   { category: 'Moderation & Tools', endpoints: [
     { label: 'Moderations', path: '/v1/moderations' },
-    { label: 'Tools', path: '/v1/tools' },
+    { label: 'Tools', path: '/v1/admin/tools' },
     { label: 'Connectors', path: '/v1/connectors' },
   ]},
 ];


### PR DESCRIPTION
# What does this PR do?

Updates three documentation pages that still referenced the old `/v1/tools` endpoint path after #5787 moved it to `/v1/admin/tools`.

Files updated:
- `docs/src/pages/index.js` — landing page API grid
- `docs/docs/api-overview.mdx` — API reference overview
- `docs/docs/building_applications/tools.mdx` — tools guide prose

## Test Plan

1. Run the docs dev server: `cd docs && npm install && npx docusaurus gen-api-docs all && npx docusaurus start`
2. Verify the landing page API grid shows `/v1/admin/tools`
3. Verify `/docs/api-overview` shows `/v1/admin/tools` in the stable section
4. Verify `/docs/building_applications/tools` prose references `/v1/admin/tools`