### PR TITLE
docs: fix links to external providers, and base url for edits

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # OGX Documentation
 
-Here's a collection of comprehensive guides, examples, and resources for building AI applications with OGX. For the complete documentation, visit our [Github page](https://ogx-ai.github.io/getting_started/quickstart).
+Here's a collection of comprehensive guides, examples, and resources for building AI applications with OGX. For the complete documentation, visit our [Github page](https://ogx-ai.github.io/docs/getting_started/quickstart).
 
 ## Render locally
 

--- a/docs/docs/providers/external/external-providers-list.mdx
+++ b/docs/docs/providers/external/external-providers-list.mdx
@@ -4,8 +4,8 @@ Here's a list of known external providers that you can use with OGX:
 
 | Name | Description | API | Type | Repository |
 |------|-------------|-----|------|------------|
-| KubeFlow Training | Train models with KubeFlow | Post Training | Remote | [ogx-provider-kft](https://github.com/opendatahub-io/ogx-provider-kft) |
-| KubeFlow Pipelines | Train models with KubeFlow Pipelines | Post Training | Inline **and** Remote | [ogx-provider-kfp-trainer](https://github.com/opendatahub-io/ogx-provider-kfp-trainer) |
+| KubeFlow Training | Train models with KubeFlow | Post Training | Remote | [llama-stack-provider-kft](https://github.com/opendatahub-io/llama-stack-provider-kft) |
+| KubeFlow Pipelines | Train models with KubeFlow Pipelines | Post Training | Inline **and** Remote | [llama-stack-provider-kfp-trainer](https://github.com/opendatahub-io/llama-stack-provider-kfp-trainer) |
 | RamaLama | Inference models with RamaLama | Inference | Remote | [ramalama-stack](https://github.com/containers/ramalama-stack) |
-| TrustyAI LM-Eval | Evaluate models with TrustyAI LM-Eval | Eval | Remote | [ogx-provider-lmeval](https://github.com/trustyai-explainability/ogx-provider-lmeval) |
-| MongoDB | VectorIO with MongoDB | Vector_IO | Remote | [mongodb-ogx](https://github.com/mongodb-partners/mongodb-ogx) |
+| TrustyAI LM-Eval | Evaluate models with TrustyAI LM-Eval | Eval | Remote | [llama-stack-provider-lmeval](https://github.com/trustyai-explainability/llama-stack-provider-lmeval) |
+| MongoDB | VectorIO with MongoDB | Vector_IO | Remote | [mongodb-llama-stack](https://github.com/mongodb-partners/mongodb-llama-stack) |

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -71,7 +71,7 @@ const config: Config = {
           sidebarPath: require.resolve("./sidebars.ts"),
           // disableVersioning: true,
           docItemComponent: "@theme/ApiItem", // Derived from docusaurus-theme-openapi
-          editUrl: 'https://github.com/ogx-ai/ogx/edit/main/',
+          editUrl: 'https://github.com/ogx-ai/ogx/edit/main/docs/',
           showLastUpdateTime: true,
           showLastUpdateAuthor: false,
           remarkPlugins: [


### PR DESCRIPTION
# What does this PR do?

This PR fixes the incorrect repo names and broken links on the [Known External Providers](https://ogx-ai.github.io/docs/providers/external/external-providers-list) page. In addition, the base URL for editing docs is corrected so clicking on "Edit this page" on the docs site will lead to the corresponding file edit view in github.

Resolves #5821 

## Test Plan

Link changes verified. No code change.
