### PR TITLE
feat(docs): add Anthropic and Google SDK examples to API docs

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -61,7 +61,7 @@ paths:
           title: Limit
         description: Maximum number of batches to return. Defaults to 20.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -105,7 +105,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateBatchRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -154,7 +154,7 @@ paths:
           title: Batch Id
         description: The ID of the batch to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -199,7 +199,7 @@ paths:
           title: Batch Id
         description: The ID of the batch to cancel.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -278,7 +278,7 @@ paths:
           title: Order
         description: 'The order to sort the chat completions by: "asc" or "desc". Defaults to "desc".'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -322,7 +322,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIChatCompletionRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -372,7 +372,7 @@ paths:
           title: Completion Id
         description: ID of the chat completion.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -417,7 +417,7 @@ paths:
               $ref: '#/components/schemas/OpenAICompletionRequestWithExtraBody'
         required: true
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -836,7 +836,7 @@ paths:
               $ref: '#/components/schemas/OpenAIEmbeddingsRequestWithExtraBody'
         required: true
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -918,7 +918,7 @@ paths:
           title: Purpose
         description: Filter files by purpose.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -960,7 +960,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Body_upload_file_v1_files_post'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1008,7 +1008,7 @@ paths:
           title: File Id
         description: The ID of the file to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1052,7 +1052,7 @@ paths:
           title: File Id
         description: The ID of the file to delete.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1097,7 +1097,7 @@ paths:
           title: File Id
         description: The ID of the file to retrieve content from.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1273,7 +1273,7 @@ paths:
           - type: 'null'
           title: X-Goog-Api-Client
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1283,6 +1283,34 @@ paths:
           models = client.models.list()
           for model in models:
               print(model.id)
+      - lang: Anthropic
+        label: Anthropic
+        source: |-
+          from anthropic import Anthropic
+
+          client = Anthropic(
+              base_url="http://localhost:8321/v1",
+              api_key="fake",
+          )
+
+          models = client.models.list()
+          for model in models:
+              print(model.id)
+      - lang: Google
+        label: Google
+        source: |-
+          from google import genai
+          from google.genai import types
+
+          client = genai.Client(
+              api_key="fake",
+              http_options=types.HttpOptions(
+                  base_url="http://localhost:8321",
+                  api_version="v1",
+              ),
+          )
+          for model in client.models.list():
+              print(model.name)
   /v1/models/{model_id}:
     get:
       responses:
@@ -1357,7 +1385,7 @@ paths:
           - type: 'null'
           title: X-Goog-Api-Client
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1366,6 +1394,33 @@ paths:
 
           model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
           print(model)
+      - lang: Anthropic
+        label: Anthropic
+        source: |-
+          from anthropic import Anthropic
+
+          client = Anthropic(
+              base_url="http://localhost:8321/v1",
+              api_key="fake",
+          )
+
+          model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+          print(model.id)
+      - lang: Google
+        label: Google
+        source: |-
+          from google import genai
+          from google.genai import types
+
+          client = genai.Client(
+              api_key="fake",
+              http_options=types.HttpOptions(
+                  base_url="http://localhost:8321",
+                  api_version="v1",
+              ),
+          )
+          model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+          print(model.name)
   /v1/prompts:
     get:
       responses:
@@ -1745,7 +1800,7 @@ paths:
           title: Order
         description: The order to sort responses by when sorted by created_at ('asc' or 'desc').
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1798,7 +1853,7 @@ paths:
             title: Guardrails
             description: Enable content moderation via the configured moderation_endpoint.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1846,7 +1901,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1890,7 +1945,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to delete.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1989,7 +2044,7 @@ paths:
           title: Order
         description: The order to return the input items in.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2168,7 +2223,7 @@ paths:
           title: Before
         description: Pagination cursor (before).
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2210,7 +2265,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAICreateVectorStoreRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2257,7 +2312,7 @@ paths:
           title: Vector Store Id
         description: The vector store identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2307,7 +2362,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIUpdateVectorStoreRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2354,7 +2409,7 @@ paths:
           title: Vector Store Id
         description: The vector store identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2405,7 +2460,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAICreateVectorStoreFileBatchRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2461,7 +2516,7 @@ paths:
           title: Batch Id
         description: The file batch identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2517,7 +2572,7 @@ paths:
           title: Batch Id
         description: The file batch identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2627,7 +2682,7 @@ paths:
           title: Order
         description: 'Sort order by created_at: asc or desc.'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2735,7 +2790,7 @@ paths:
           title: Filter
         description: Filter by file status.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2786,7 +2841,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIAttachFileRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2842,7 +2897,7 @@ paths:
           title: File Id
         description: The file identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2945,7 +3000,7 @@ paths:
           title: File Id
         description: The file identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3023,7 +3078,7 @@ paths:
           title: Include Metadata
         description: Include chunk metadata.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3077,7 +3132,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAISearchVectorStoreRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3552,7 +3607,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to cancel.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3629,7 +3684,7 @@ paths:
           title: Order
         description: Sort order for messages by timestamp. Use "asc" or "desc". Defaults to "asc".
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3703,8 +3758,8 @@ paths:
               $ref: '#/components/schemas/AnthropicCreateMessageRequest'
         required: true
       x-codeSamples:
-      - lang: Python
-        label: Anthropic SDK
+      - lang: Anthropic
+        label: Anthropic
         source: |-
           from anthropic import Anthropic
 
@@ -3722,23 +3777,6 @@ paths:
           )
 
           print(message.content[0].text)
-      - lang: TypeScript
-        label: Anthropic SDK
-        source: |-
-          import Anthropic from "@anthropic-ai/sdk";
-
-          const client = new Anthropic({
-            baseURL: "http://localhost:8321/v1",
-            apiKey: "fake",
-          });
-
-          const message = await client.messages.create({
-            model: "llama-3.3-70b",
-            max_tokens: 1024,
-            messages: [{ role: "user", content: "What is OGX?" }],
-          });
-
-          console.log(message.content[0].text);
   /v1/messages/count_tokens:
     post:
       responses:
@@ -3805,8 +3843,8 @@ paths:
               $ref: '#/components/schemas/GoogleCreateInteractionRequest'
         required: true
       x-codeSamples:
-      - lang: Python
-        label: Google GenAI
+      - lang: Google
+        label: Google
         source: |-
           from google import genai
           from google.genai import types

--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -1404,7 +1404,7 @@ paths:
               api_key="fake",
           )
 
-          model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+          model = client.models.retrieve("llama-3.3-70b")
           print(model.id)
       - lang: Google
         label: Google
@@ -1419,7 +1419,7 @@ paths:
                   api_version="v1",
               ),
           )
-          model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+          model = client.models.get(model="llama-3.3-70b")
           print(model.name)
   /v1/prompts:
     get:

--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -1404,7 +1404,7 @@ paths:
               api_key="fake",
           )
 
-          model = client.models.retrieve("llama-3.3-70b")
+          model = client.models.retrieve("openai/gpt-4o")
           print(model.id)
       - lang: Google
         label: Google
@@ -1419,7 +1419,7 @@ paths:
                   api_version="v1",
               ),
           )
-          model = client.models.get(model="llama-3.3-70b")
+          model = client.models.get(model="openai/gpt-4o")
           print(model.name)
   /v1/prompts:
     get:

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -277,8 +277,21 @@ const config: Config = {
     languageTabs: [
       {
         highlight: "python",
-        language: "python",
+        language: "OpenAI",
         logoClass: "python",
+        codeSampleLanguage: "OpenAI",
+      },
+      {
+        highlight: "python",
+        language: "Anthropic",
+        logoClass: "python",
+        codeSampleLanguage: "Anthropic",
+      },
+      {
+        highlight: "python",
+        language: "Google",
+        logoClass: "python",
+        codeSampleLanguage: "Google",
       },
       {
         highlight: "bash",

--- a/docs/scripts/patch-openapi-theme.sh
+++ b/docs/scripts/patch-openapi-theme.sh
@@ -5,23 +5,150 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Patch docusaurus-theme-openapi-docs to hide auto-generated code variants
-# (http.client, requests) when x-codeSamples are provided in the OpenAPI spec.
-# Only the OpenAI SDK examples will show for endpoints that have x-codeSamples.
-FILE="node_modules/docusaurus-theme-openapi-docs/lib/theme/ApiExplorer/CodeSnippets/index.js"
-[ ! -f "$FILE" ] && exit 0
+# Patches for docusaurus-theme-openapi-docs to support multiple SDK code
+# samples (OpenAI, Anthropic, Google) as separate language tabs.
 
+SNIPPETS="node_modules/docusaurus-theme-openapi-docs/lib/theme/ApiExplorer/CodeSnippets/index.js"
+TABS="node_modules/docusaurus-theme-openapi-docs/lib/theme/ApiExplorer/CodeTabs/index.js"
+[ ! -f "$SNIPPETS" ] && exit 0
+
+# 1. Guard the variants section: skip when x-codeSamples exist OR when
+#    the language has no postman variants (custom SDK tabs).
 python3 -c "
-with open('$FILE') as f:
+with open('$SNIPPETS') as f:
     c = f.read()
-# Skip variants tab when x-codeSamples (samples) exist for this language
 old = '          react_1.default.createElement(\n            CodeTabs_1.default,\n            {\n              className: \"openapi-tabs__code-container-inner\",\n              action: {\n                setLanguage: setLanguage,\n                setSelectedVariant: setSelectedVariant,\n              },\n              includeVariant: true,'
-new = '          !lang.samples && react_1.default.createElement(\n            CodeTabs_1.default,\n            {\n              className: \"openapi-tabs__code-container-inner\",\n              action: {\n                setLanguage: setLanguage,\n                setSelectedVariant: setSelectedVariant,\n              },\n              includeVariant: true,'
-if '!lang.samples &&' not in c:
+new = '          !lang.samples && lang.variants && react_1.default.createElement(\n            CodeTabs_1.default,\n            {\n              className: \"openapi-tabs__code-container-inner\",\n              action: {\n                setLanguage: setLanguage,\n                setSelectedVariant: setSelectedVariant,\n              },\n              includeVariant: true,'
+if 'lang.variants &&' not in c:
     c = c.replace(old, new)
-    with open('$FILE', 'w') as f:
+    with open('$SNIPPETS', 'w') as f:
         f.write(c)
-    print('Patched: x-codeSamples now replace auto-generated variants')
+    print('Patched: guard variants rendering')
 else:
-    print('Already patched')
+    print('Already patched (variants guard)')
+"
+
+# 2. Hide language tabs that have no content (no x-codeSamples and no
+#    postman variants). Custom SDK tabs only appear on endpoints that
+#    include their code samples.
+python3 -c "
+with open('$SNIPPETS') as f:
+    c = f.read()
+old = '      mergedLangs.map((lang) => {'
+new = '      mergedLangs.filter((lang) => lang.samples || (lang.variants && lang.variants.length > 0)).map((lang) => {'
+if '.filter((lang) => lang.samples' not in c:
+    c = c.replace(old, new)
+    with open('$SNIPPETS', 'w') as f:
+        f.write(c)
+    print('Patched: hide empty language tabs')
+else:
+    print('Already patched (empty tab filter)')
+"
+
+# 3. Fix CodeTabs crash when clicking a language tab without postman
+#    variants (custom SDK tabs). The click handler assumes all languages
+#    have a variants array, which is not true for custom entries.
+python3 -c "
+with open('$TABS') as f:
+    c = f.read()
+old = '''        newLanguage = languageSet.filter(
+          (lang) => lang.language === newTabValue
+        )[0];
+        action.setSelectedVariant(newLanguage.variants[0].toLowerCase());
+        action.setSelectedSample(newLanguage.sample);'''
+new = '''        newLanguage = languageSet.filter(
+          (lang) => lang.language === newTabValue
+        )[0];
+        if (newLanguage.variants) { action.setSelectedVariant(newLanguage.variants[0].toLowerCase()); }
+        action.setSelectedSample(newLanguage.sample);'''
+if 'if (newLanguage.variants)' not in c:
+    c = c.replace(old, new)
+    with open('$TABS', 'w') as f:
+        f.write(c)
+    print('Patched: guard variants access in tab click handler')
+else:
+    print('Already patched (tab click guard)')
+"
+
+# 4. When a language tab has exactly one code sample, render the code
+#    block directly instead of wrapping it in a redundant inner tab.
+python3 -c "
+with open('$SNIPPETS') as f:
+    c = f.read()
+old = '''          lang.samples &&
+            react_1.default.createElement(
+              CodeTabs_1.default,
+              {
+                className: \"openapi-tabs__code-container-inner\",'''
+new = '''          lang.samples && lang.samples.length === 1 &&
+            react_1.default.createElement(
+              ApiCodeBlock_1.default,
+              {
+                language: lang.highlight,
+                className: \"openapi-explorer__code-block\",
+                showLineNumbers: true,
+              },
+              codeSampleCodeText
+            ),
+          lang.samples && lang.samples.length > 1 &&
+            react_1.default.createElement(
+              CodeTabs_1.default,
+              {
+                className: \"openapi-tabs__code-container-inner\",'''
+if 'lang.samples.length === 1' not in c:
+    c = c.replace(old, new)
+    with open('$SNIPPETS', 'w') as f:
+        f.write(c)
+    print('Patched: skip inner tab for single code sample')
+else:
+    print('Already patched (single sample shortcut)')
+"
+
+# 5. Fix defaultValue crash on endpoints without SDK code samples.
+#    The default picks the first entry in mergedLangs (e.g. "OpenAI"),
+#    but after filtering only "curl" may remain, causing a mismatch.
+python3 -c "
+with open('$SNIPPETS') as f:
+    c = f.read()
+old = 'defaultValue: defaultLang[0]?.language ?? mergedLangs[0].language,'
+new = 'defaultValue: defaultLang[0]?.language ?? (mergedLangs.find((l) => l.samples || (l.variants && l.variants.length > 0)) || mergedLangs[0])?.language,'
+if 'mergedLangs.find' not in c:
+    c = c.replace(old, new)
+    with open('$SNIPPETS', 'w') as f:
+        f.write(c)
+    print('Patched: defaultValue picks first visible tab')
+else:
+    print('Already patched (defaultValue)')
+"
+
+# 6. Fix initial language state on endpoints without SDK code samples.
+#    The language state defaults to mergedLangs[0] (e.g. "OpenAI") but
+#    only "curl" may be visible, so curl code never gets generated.
+python3 -c "
+with open('$SNIPPETS') as f:
+    c = f.read()
+old = '''  const [language, setLanguage] = (0, react_1.useState)(() => {
+    // Return first index if only 1 user-defined language exists
+    if (mergedLangs.length === 1) {
+      return mergedLangs[0];
+    }
+    // Fall back to language in localStorage or first user-defined language
+    return defaultLang[0] ?? mergedLangs[0];
+  });'''
+new = '''  const _firstVisible = mergedLangs.find((l) => l.samples || (l.variants && l.variants.length > 0)) || mergedLangs[0];
+  const [language, setLanguage] = (0, react_1.useState)(() => {
+    // Return first index if only 1 user-defined language exists
+    if (mergedLangs.length === 1) {
+      return mergedLangs[0];
+    }
+    // Fall back to language in localStorage or first visible language
+    return defaultLang[0] ?? _firstVisible;
+  });'''
+if '_firstVisible' not in c:
+    c = c.replace(old, new)
+    with open('$SNIPPETS', 'w') as f:
+        f.write(c)
+    print('Patched: initial language picks first visible tab')
+else:
+    print('Already patched (initial language)')
 "

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -440,8 +440,8 @@ paths:
               $ref: '#/components/schemas/GoogleCreateInteractionRequest'
         required: true
       x-codeSamples:
-      - lang: Python
-        label: Google GenAI
+      - lang: Google
+        label: Google
         source: |-
           from google import genai
           from google.genai import types

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -1402,7 +1402,7 @@ paths:
               api_key="fake",
           )
 
-          model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+          model = client.models.retrieve("llama-3.3-70b")
           print(model.id)
       - lang: Google
         label: Google
@@ -1417,7 +1417,7 @@ paths:
                   api_version="v1",
               ),
           )
-          model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+          model = client.models.get(model="llama-3.3-70b")
           print(model.name)
   /v1/prompts:
     get:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -1402,7 +1402,7 @@ paths:
               api_key="fake",
           )
 
-          model = client.models.retrieve("llama-3.3-70b")
+          model = client.models.retrieve("openai/gpt-4o")
           print(model.id)
       - lang: Google
         label: Google
@@ -1417,7 +1417,7 @@ paths:
                   api_version="v1",
               ),
           )
-          model = client.models.get(model="llama-3.3-70b")
+          model = client.models.get(model="openai/gpt-4o")
           print(model.name)
   /v1/prompts:
     get:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -59,7 +59,7 @@ paths:
           title: Limit
         description: Maximum number of batches to return. Defaults to 20.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -103,7 +103,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateBatchRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -152,7 +152,7 @@ paths:
           title: Batch Id
         description: The ID of the batch to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -197,7 +197,7 @@ paths:
           title: Batch Id
         description: The ID of the batch to cancel.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -276,7 +276,7 @@ paths:
           title: Order
         description: 'The order to sort the chat completions by: "asc" or "desc". Defaults to "desc".'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -320,7 +320,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIChatCompletionRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -370,7 +370,7 @@ paths:
           title: Completion Id
         description: ID of the chat completion.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -415,7 +415,7 @@ paths:
               $ref: '#/components/schemas/OpenAICompletionRequestWithExtraBody'
         required: true
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -834,7 +834,7 @@ paths:
               $ref: '#/components/schemas/OpenAIEmbeddingsRequestWithExtraBody'
         required: true
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -916,7 +916,7 @@ paths:
           title: Purpose
         description: Filter files by purpose.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -958,7 +958,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Body_upload_file_v1_files_post'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1006,7 +1006,7 @@ paths:
           title: File Id
         description: The ID of the file to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1050,7 +1050,7 @@ paths:
           title: File Id
         description: The ID of the file to delete.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1095,7 +1095,7 @@ paths:
           title: File Id
         description: The ID of the file to retrieve content from.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1271,7 +1271,7 @@ paths:
           - type: 'null'
           title: X-Goog-Api-Client
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1281,6 +1281,34 @@ paths:
           models = client.models.list()
           for model in models:
               print(model.id)
+      - lang: Anthropic
+        label: Anthropic
+        source: |-
+          from anthropic import Anthropic
+
+          client = Anthropic(
+              base_url="http://localhost:8321/v1",
+              api_key="fake",
+          )
+
+          models = client.models.list()
+          for model in models:
+              print(model.id)
+      - lang: Google
+        label: Google
+        source: |-
+          from google import genai
+          from google.genai import types
+
+          client = genai.Client(
+              api_key="fake",
+              http_options=types.HttpOptions(
+                  base_url="http://localhost:8321",
+                  api_version="v1",
+              ),
+          )
+          for model in client.models.list():
+              print(model.name)
   /v1/models/{model_id}:
     get:
       responses:
@@ -1355,7 +1383,7 @@ paths:
           - type: 'null'
           title: X-Goog-Api-Client
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1364,6 +1392,33 @@ paths:
 
           model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
           print(model)
+      - lang: Anthropic
+        label: Anthropic
+        source: |-
+          from anthropic import Anthropic
+
+          client = Anthropic(
+              base_url="http://localhost:8321/v1",
+              api_key="fake",
+          )
+
+          model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+          print(model.id)
+      - lang: Google
+        label: Google
+        source: |-
+          from google import genai
+          from google.genai import types
+
+          client = genai.Client(
+              api_key="fake",
+              http_options=types.HttpOptions(
+                  base_url="http://localhost:8321",
+                  api_version="v1",
+              ),
+          )
+          model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+          print(model.name)
   /v1/prompts:
     get:
       responses:
@@ -1743,7 +1798,7 @@ paths:
           title: Order
         description: The order to sort responses by when sorted by created_at ('asc' or 'desc').
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1796,7 +1851,7 @@ paths:
             title: Guardrails
             description: Enable content moderation via the configured moderation_endpoint.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1844,7 +1899,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1888,7 +1943,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to delete.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1987,7 +2042,7 @@ paths:
           title: Order
         description: The order to return the input items in.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2166,7 +2221,7 @@ paths:
           title: Before
         description: Pagination cursor (before).
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2208,7 +2263,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAICreateVectorStoreRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2255,7 +2310,7 @@ paths:
           title: Vector Store Id
         description: The vector store identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2305,7 +2360,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIUpdateVectorStoreRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2352,7 +2407,7 @@ paths:
           title: Vector Store Id
         description: The vector store identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2403,7 +2458,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAICreateVectorStoreFileBatchRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2459,7 +2514,7 @@ paths:
           title: Batch Id
         description: The file batch identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2515,7 +2570,7 @@ paths:
           title: Batch Id
         description: The file batch identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2625,7 +2680,7 @@ paths:
           title: Order
         description: 'Sort order by created_at: asc or desc.'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2733,7 +2788,7 @@ paths:
           title: Filter
         description: Filter by file status.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2784,7 +2839,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIAttachFileRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2840,7 +2895,7 @@ paths:
           title: File Id
         description: The file identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2943,7 +2998,7 @@ paths:
           title: File Id
         description: The file identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3021,7 +3076,7 @@ paths:
           title: Include Metadata
         description: Include chunk metadata.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3075,7 +3130,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAISearchVectorStoreRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3188,7 +3243,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to cancel.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3265,7 +3320,7 @@ paths:
           title: Order
         description: Sort order for messages by timestamp. Use "asc" or "desc". Defaults to "asc".
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3308,8 +3363,8 @@ paths:
               $ref: '#/components/schemas/AnthropicCreateMessageRequest'
         required: true
       x-codeSamples:
-      - lang: Python
-        label: Anthropic SDK
+      - lang: Anthropic
+        label: Anthropic
         source: |-
           from anthropic import Anthropic
 
@@ -3327,23 +3382,6 @@ paths:
           )
 
           print(message.content[0].text)
-      - lang: TypeScript
-        label: Anthropic SDK
-        source: |-
-          import Anthropic from "@anthropic-ai/sdk";
-
-          const client = new Anthropic({
-            baseURL: "http://localhost:8321/v1",
-            apiKey: "fake",
-          });
-
-          const message = await client.messages.create({
-            model: "llama-3.3-70b",
-            max_tokens: 1024,
-            messages: [{ role: "user", content: "What is OGX?" }],
-          });
-
-          console.log(message.content[0].text);
   /v1/messages/count_tokens:
     post:
       responses:

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -61,7 +61,7 @@ paths:
           title: Limit
         description: Maximum number of batches to return. Defaults to 20.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -105,7 +105,7 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateBatchRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -154,7 +154,7 @@ paths:
           title: Batch Id
         description: The ID of the batch to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -199,7 +199,7 @@ paths:
           title: Batch Id
         description: The ID of the batch to cancel.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -278,7 +278,7 @@ paths:
           title: Order
         description: 'The order to sort the chat completions by: "asc" or "desc". Defaults to "desc".'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -322,7 +322,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIChatCompletionRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -372,7 +372,7 @@ paths:
           title: Completion Id
         description: ID of the chat completion.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -417,7 +417,7 @@ paths:
               $ref: '#/components/schemas/OpenAICompletionRequestWithExtraBody'
         required: true
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -836,7 +836,7 @@ paths:
               $ref: '#/components/schemas/OpenAIEmbeddingsRequestWithExtraBody'
         required: true
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -918,7 +918,7 @@ paths:
           title: Purpose
         description: Filter files by purpose.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -960,7 +960,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Body_upload_file_v1_files_post'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1008,7 +1008,7 @@ paths:
           title: File Id
         description: The ID of the file to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1052,7 +1052,7 @@ paths:
           title: File Id
         description: The ID of the file to delete.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1097,7 +1097,7 @@ paths:
           title: File Id
         description: The ID of the file to retrieve content from.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1273,7 +1273,7 @@ paths:
           - type: 'null'
           title: X-Goog-Api-Client
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1283,6 +1283,34 @@ paths:
           models = client.models.list()
           for model in models:
               print(model.id)
+      - lang: Anthropic
+        label: Anthropic
+        source: |-
+          from anthropic import Anthropic
+
+          client = Anthropic(
+              base_url="http://localhost:8321/v1",
+              api_key="fake",
+          )
+
+          models = client.models.list()
+          for model in models:
+              print(model.id)
+      - lang: Google
+        label: Google
+        source: |-
+          from google import genai
+          from google.genai import types
+
+          client = genai.Client(
+              api_key="fake",
+              http_options=types.HttpOptions(
+                  base_url="http://localhost:8321",
+                  api_version="v1",
+              ),
+          )
+          for model in client.models.list():
+              print(model.name)
   /v1/models/{model_id}:
     get:
       responses:
@@ -1357,7 +1385,7 @@ paths:
           - type: 'null'
           title: X-Goog-Api-Client
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1366,6 +1394,33 @@ paths:
 
           model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
           print(model)
+      - lang: Anthropic
+        label: Anthropic
+        source: |-
+          from anthropic import Anthropic
+
+          client = Anthropic(
+              base_url="http://localhost:8321/v1",
+              api_key="fake",
+          )
+
+          model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+          print(model.id)
+      - lang: Google
+        label: Google
+        source: |-
+          from google import genai
+          from google.genai import types
+
+          client = genai.Client(
+              api_key="fake",
+              http_options=types.HttpOptions(
+                  base_url="http://localhost:8321",
+                  api_version="v1",
+              ),
+          )
+          model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+          print(model.name)
   /v1/prompts:
     get:
       responses:
@@ -1745,7 +1800,7 @@ paths:
           title: Order
         description: The order to sort responses by when sorted by created_at ('asc' or 'desc').
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1798,7 +1853,7 @@ paths:
             title: Guardrails
             description: Enable content moderation via the configured moderation_endpoint.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1846,7 +1901,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to retrieve.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1890,7 +1945,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to delete.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -1989,7 +2044,7 @@ paths:
           title: Order
         description: The order to return the input items in.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2168,7 +2223,7 @@ paths:
           title: Before
         description: Pagination cursor (before).
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2210,7 +2265,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAICreateVectorStoreRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2257,7 +2312,7 @@ paths:
           title: Vector Store Id
         description: The vector store identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2307,7 +2362,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIUpdateVectorStoreRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2354,7 +2409,7 @@ paths:
           title: Vector Store Id
         description: The vector store identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2405,7 +2460,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAICreateVectorStoreFileBatchRequestWithExtraBody'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2461,7 +2516,7 @@ paths:
           title: Batch Id
         description: The file batch identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2517,7 +2572,7 @@ paths:
           title: Batch Id
         description: The file batch identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2627,7 +2682,7 @@ paths:
           title: Order
         description: 'Sort order by created_at: asc or desc.'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2735,7 +2790,7 @@ paths:
           title: Filter
         description: Filter by file status.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2786,7 +2841,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAIAttachFileRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2842,7 +2897,7 @@ paths:
           title: File Id
         description: The file identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -2945,7 +3000,7 @@ paths:
           title: File Id
         description: The file identifier.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3023,7 +3078,7 @@ paths:
           title: Include Metadata
         description: Include chunk metadata.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3077,7 +3132,7 @@ paths:
             schema:
               $ref: '#/components/schemas/OpenAISearchVectorStoreRequest'
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3552,7 +3607,7 @@ paths:
           title: Response Id
         description: The ID of the OpenAI response to cancel.
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3629,7 +3684,7 @@ paths:
           title: Order
         description: Sort order for messages by timestamp. Use "asc" or "desc". Defaults to "asc".
       x-codeSamples:
-      - lang: Python
+      - lang: OpenAI
         label: OpenAI
         source: |-
           from openai import OpenAI
@@ -3703,8 +3758,8 @@ paths:
               $ref: '#/components/schemas/AnthropicCreateMessageRequest'
         required: true
       x-codeSamples:
-      - lang: Python
-        label: Anthropic SDK
+      - lang: Anthropic
+        label: Anthropic
         source: |-
           from anthropic import Anthropic
 
@@ -3722,23 +3777,6 @@ paths:
           )
 
           print(message.content[0].text)
-      - lang: TypeScript
-        label: Anthropic SDK
-        source: |-
-          import Anthropic from "@anthropic-ai/sdk";
-
-          const client = new Anthropic({
-            baseURL: "http://localhost:8321/v1",
-            apiKey: "fake",
-          });
-
-          const message = await client.messages.create({
-            model: "llama-3.3-70b",
-            max_tokens: 1024,
-            messages: [{ role: "user", content: "What is OGX?" }],
-          });
-
-          console.log(message.content[0].text);
   /v1/messages/count_tokens:
     post:
       responses:
@@ -3805,8 +3843,8 @@ paths:
               $ref: '#/components/schemas/GoogleCreateInteractionRequest'
         required: true
       x-codeSamples:
-      - lang: Python
-        label: Google GenAI
+      - lang: Google
+        label: Google
         source: |-
           from google import genai
           from google.genai import types

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -1404,7 +1404,7 @@ paths:
               api_key="fake",
           )
 
-          model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+          model = client.models.retrieve("llama-3.3-70b")
           print(model.id)
       - lang: Google
         label: Google
@@ -1419,7 +1419,7 @@ paths:
                   api_version="v1",
               ),
           )
-          model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+          model = client.models.get(model="llama-3.3-70b")
           print(model.name)
   /v1/prompts:
     get:

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -1404,7 +1404,7 @@ paths:
               api_key="fake",
           )
 
-          model = client.models.retrieve("llama-3.3-70b")
+          model = client.models.retrieve("openai/gpt-4o")
           print(model.id)
       - lang: Google
         label: Google
@@ -1419,7 +1419,7 @@ paths:
                   api_version="v1",
               ),
           )
-          model = client.models.get(model="llama-3.3-70b")
+          model = client.models.get(model="openai/gpt-4o")
           print(model.name)
   /v1/prompts:
     get:

--- a/scripts/openapi_generator/code_samples.py
+++ b/scripts/openapi_generator/code_samples.py
@@ -435,7 +435,7 @@ client = genai.Client(
         api_version="v1",
     ),
 )
-model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+model = client.models.get(model="llama-3.3-70b")
 print(model.name)
 """,
     ("/v1alpha/interactions", "post"): """\
@@ -489,7 +489,7 @@ client = Anthropic(
     api_key="fake",
 )
 
-model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+model = client.models.retrieve("llama-3.3-70b")
 print(model.id)""",
         },
     ],

--- a/scripts/openapi_generator/code_samples.py
+++ b/scripts/openapi_generator/code_samples.py
@@ -435,7 +435,7 @@ client = genai.Client(
         api_version="v1",
     ),
 )
-model = client.models.get(model="llama-3.3-70b")
+model = client.models.get(model="openai/gpt-4o")
 print(model.name)
 """,
     ("/v1alpha/interactions", "post"): """\
@@ -489,7 +489,7 @@ client = Anthropic(
     api_key="fake",
 )
 
-model = client.models.retrieve("llama-3.3-70b")
+model = client.models.retrieve("openai/gpt-4o")
 print(model.id)""",
         },
     ],

--- a/scripts/openapi_generator/code_samples.py
+++ b/scripts/openapi_generator/code_samples.py
@@ -410,6 +410,34 @@ for result in results:
 
 # Google GenAI SDK code samples for Interactions API endpoints.
 _GOOGLE_CODE_SAMPLES: dict[tuple[str, str], str] = {
+    ("/v1/models", "get"): """\
+from google import genai
+from google.genai import types
+
+client = genai.Client(
+    api_key="fake",
+    http_options=types.HttpOptions(
+        base_url="http://localhost:8321",
+        api_version="v1",
+    ),
+)
+for model in client.models.list():
+    print(model.name)
+""",
+    ("/v1/models/{model_id}", "get"): """\
+from google import genai
+from google.genai import types
+
+client = genai.Client(
+    api_key="fake",
+    http_options=types.HttpOptions(
+        base_url="http://localhost:8321",
+        api_version="v1",
+    ),
+)
+model = client.models.get(model="meta-llama/Llama-3.1-8B-Instruct")
+print(model.name)
+""",
     ("/v1alpha/interactions", "post"): """\
 from google import genai
 from google.genai import types
@@ -432,10 +460,43 @@ print(interaction.outputs[0].text)
 
 # Anthropic SDK code samples for the Messages API endpoints.
 _ANTHROPIC_CODE_SAMPLES: dict[tuple[str, str], list[dict[str, str]]] = {
+    ("/v1/models", "get"): [
+        {
+            "lang": "Anthropic",
+            "label": "Anthropic",
+            "source": """\
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="http://localhost:8321/v1",
+    api_key="fake",
+)
+
+models = client.models.list()
+for model in models:
+    print(model.id)""",
+        },
+    ],
+    ("/v1/models/{model_id}", "get"): [
+        {
+            "lang": "Anthropic",
+            "label": "Anthropic",
+            "source": """\
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="http://localhost:8321/v1",
+    api_key="fake",
+)
+
+model = client.models.retrieve("meta-llama/Llama-3.1-8B-Instruct")
+print(model.id)""",
+        },
+    ],
     ("/v1/messages", "post"): [
         {
-            "lang": "Python",
-            "label": "Anthropic SDK",
+            "lang": "Anthropic",
+            "label": "Anthropic",
             "source": """\
 from anthropic import Anthropic
 
@@ -453,25 +514,6 @@ message = client.messages.create(
 )
 
 print(message.content[0].text)""",
-        },
-        {
-            "lang": "TypeScript",
-            "label": "Anthropic SDK",
-            "source": """\
-import Anthropic from "@anthropic-ai/sdk";
-
-const client = new Anthropic({
-  baseURL: "http://localhost:8321/v1",
-  apiKey: "fake",
-});
-
-const message = await client.messages.create({
-  model: "llama-3.3-70b",
-  max_tokens: 1024,
-  messages: [{ role: "user", content: "What is OGX?" }],
-});
-
-console.log(message.content[0].text);""",
         },
     ],
 }
@@ -510,7 +552,7 @@ def _add_openai_code_samples(openapi_schema: dict[str, Any]) -> dict[str, Any]:
             continue
 
         code_sample = {
-            "lang": "Python",
+            "lang": "OpenAI",
             "label": "OpenAI",
             "source": source_code.rstrip("\n"),
         }
@@ -537,8 +579,8 @@ def _add_google_code_samples(openapi_schema: dict[str, Any]) -> dict[str, Any]:
             continue
 
         code_sample = {
-            "lang": "Python",
-            "label": "Google GenAI",
+            "lang": "Google",
+            "label": "Google",
             "source": source_code.rstrip("\n"),
         }
 


### PR DESCRIPTION
# What does this PR do?

Adds Python SDK code samples for Anthropic and Google GenAI to the API documentation, alongside the existing OpenAI examples. Currently covers the List Models, Get Model, and Messages endpoints. Each SDK renders as its own language tab (OpenAI, Anthropic, Google, curl) and tabs only appear on endpoints that have matching samples.

Includes six patches to `docusaurus-theme-openapi-docs` (applied via the existing `postinstall` hook) to support custom language tabs that don't have postman-code-generators backends: guarding variant rendering, filtering empty tabs, fixing click handlers, removing redundant inner sub-tabs for single samples, and ensuring correct default tab selection on endpoints without SDK examples.

## Test Plan

1. Run `uv run ./scripts/run_openapi_generator.sh` and verify specs regenerate without errors
2. Run `cd docs && npm install && npm run gen-api-docs && npm start`
3. Verify http://localhost:3000/docs/api/list-models-v-1-models-get shows OpenAI, Anthropic, Google, and curl tabs with correct code
4. Verify http://localhost:3000/docs/api/health-v-1-health-get loads without crash (curl-only endpoint)
5. Verify http://localhost:3000/docs/api/delete-conversation-v-1-conversations-conversation-id-delete shows curl code immediately without requiring a click