### PR TITLE
fix(providers): async safety fixes for Databricks, WatsonX, Bing, Tavily, OCI, OpenAI Files

### DIFF
--- a/src/ogx/providers/remote/files/openai/files.py
+++ b/src/ogx/providers/remote/files/openai/files.py
@@ -30,7 +30,7 @@ from ogx_api import (
 )
 from ogx_api.files.models import OpenAIFileUploadPurpose
 from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from .config import OpenAIFilesImplConfig
 
@@ -74,7 +74,7 @@ class OpenAIFilesImpl(Files):
     def __init__(self, config: OpenAIFilesImplConfig, policy: list[AccessRule]) -> None:
         self._config = config
         self.policy = policy
-        self._client: OpenAI | None = None
+        self._client: AsyncOpenAI | None = None
         self._sql_store: AuthorizedSqlStore | None = None
 
     def _now(self) -> int:
@@ -94,7 +94,7 @@ class OpenAIFilesImpl(Files):
     async def _delete_file(self, file_id: str) -> None:
         """Delete a file from OpenAI and the database."""
         try:
-            self.client.files.delete(file_id)
+            await self.client.files.delete(file_id)
         except Exception as e:
             # If file doesn't exist on OpenAI side, just remove from metadata store
             if "not found" not in str(e).lower():
@@ -109,7 +109,7 @@ class OpenAIFilesImpl(Files):
                 await self._delete_file(file_id)
 
     async def initialize(self) -> None:
-        self._client = OpenAI(api_key=self._config.api_key)
+        self._client = AsyncOpenAI(api_key=self._config.api_key)
 
         self._sql_store = authorized_sqlstore(self._config.metadata_store, self.policy)
         await self._sql_store.create_table(
@@ -128,7 +128,7 @@ class OpenAIFilesImpl(Files):
         pass
 
     @property
-    def client(self) -> OpenAI:
+    def client(self) -> AsyncOpenAI:
         assert self._client is not None, "Provider not initialized"
         return self._client
 
@@ -164,7 +164,7 @@ class OpenAIFilesImpl(Files):
             file_obj = BytesIO(content)
             file_obj.name = filename
 
-            response = self.client.files.create(
+            response = await self.client.files.create(
                 file=file_obj,
                 purpose=purpose.value,
             )
@@ -240,7 +240,7 @@ class OpenAIFilesImpl(Files):
         row = await self._get_file(file_id)
 
         try:
-            response = self.client.files.content(file_id)
+            response = await self.client.files.content(file_id)
             file_content = response.content
 
         except Exception as e:

--- a/src/ogx/providers/remote/inference/databricks/databricks.py
+++ b/src/ogx/providers/remote/inference/databricks/databricks.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 from collections.abc import AsyncIterator, Iterable
 
 from databricks.sdk import WorkspaceClient
@@ -34,20 +35,20 @@ class DatabricksInferenceAdapter(OpenAIMixin):
         return str(self.config.base_url)
 
     async def list_provider_model_ids(self) -> Iterable[str]:
-        # Filter out None values from endpoint names
         api_token = self._get_api_key_from_config_or_provider_data()
-        # WorkspaceClient expects base host without /serving-endpoints suffix
         base_url_str = str(self.config.base_url)
         if base_url_str.endswith("/serving-endpoints"):
-            host = base_url_str[:-18]  # Remove '/serving-endpoints'
+            host = base_url_str[:-18]
         else:
             host = base_url_str
-        return [
-            endpoint.name  # type: ignore[misc]
-            for endpoint in WorkspaceClient(
-                host=host, token=api_token
-            ).serving_endpoints.list()  # TODO: this is not async
-        ]
+
+        def _list_endpoints() -> list[str]:
+            return [
+                endpoint.name  # type: ignore[misc]
+                for endpoint in WorkspaceClient(host=host, token=api_token).serving_endpoints.list()
+            ]
+
+        return await asyncio.to_thread(_list_endpoints)
 
     async def openai_completion(
         self,

--- a/src/ogx/providers/remote/inference/oci/auth.py
+++ b/src/ogx/providers/remote/inference/oci/auth.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from collections.abc import Generator, Mapping
+import asyncio
+from collections.abc import AsyncGenerator, Generator, Mapping
 from typing import Any, override
 
 import httpx
@@ -53,6 +54,28 @@ class HttpxOciAuth(httpx.Auth):
         # Update the original HTTPX request with the signed headers
         request.headers.update(prepared_request.headers)
 
+        yield request
+
+    @override
+    async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        try:
+            content = request.content
+        except httpx.RequestNotRead:
+            content = request.read()
+
+        def _sign(content: bytes) -> dict:
+            req = requests.Request(
+                method=request.method,
+                url=str(request.url),
+                headers=dict(request.headers),
+                data=content,
+            )
+            prepared_request = req.prepare()
+            self.signer.do_request_sign(prepared_request)  # type: ignore
+            return dict(prepared_request.headers)
+
+        signed_headers = await asyncio.to_thread(_sign, content)
+        request.headers.update(signed_headers)
         yield request
 
 

--- a/src/ogx/providers/remote/inference/oci/auth.py
+++ b/src/ogx/providers/remote/inference/oci/auth.py
@@ -61,7 +61,7 @@ class HttpxOciAuth(httpx.Auth):
         try:
             content = request.content
         except httpx.RequestNotRead:
-            content = request.read()
+            content = await request.aread()
 
         def _sign(content: bytes) -> dict:
             req = requests.Request(

--- a/src/ogx/providers/remote/inference/watsonx/watsonx.py
+++ b/src/ogx/providers/remote/inference/watsonx/watsonx.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import time
 from collections.abc import AsyncIterator, Iterable
 from typing import Any
@@ -45,6 +46,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
     def __init__(self, config: WatsonXConfig):
         super().__init__(config=config)
         self._iam_token_cache: dict[str, tuple[str, float]] = {}
+        self._iam_token_lock = asyncio.Lock()
         self._model_specs_cache: list[dict[str, Any]] | None = None
 
     def get_base_url(self) -> str:
@@ -74,23 +76,30 @@ class WatsonXInferenceAdapter(OpenAIMixin):
             if time.time() < expiry - 60:
                 return token
 
-        try:
-            async with httpx.AsyncClient() as http_client:
-                resp = await http_client.post(
-                    "https://iam.cloud.ibm.com/identity/token",
-                    headers={"Content-Type": "application/x-www-form-urlencoded"},
-                    content=f"grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={api_key}",
-                    timeout=30,
-                )
-                resp.raise_for_status()
-                data = resp.json()
-                token = data["access_token"]
-                expiry = data.get("expiration", time.time() + 3600)
-                self._iam_token_cache[api_key] = (token, expiry)
-                return token
-        except Exception as e:
-            logger.warning("IAM token exchange failed, using API key directly", error=str(e))
-            return api_key
+        async with self._iam_token_lock:
+            cached = self._iam_token_cache.get(api_key)
+            if cached:
+                token, expiry = cached
+                if time.time() < expiry - 60:
+                    return token
+
+            try:
+                async with httpx.AsyncClient() as http_client:
+                    resp = await http_client.post(
+                        "https://iam.cloud.ibm.com/identity/token",
+                        headers={"Content-Type": "application/x-www-form-urlencoded"},
+                        content=f"grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={api_key}",
+                        timeout=30,
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    token = data["access_token"]
+                    expiry = data.get("expiration", time.time() + 3600)
+                    self._iam_token_cache[api_key] = (token, expiry)
+                    return token
+            except Exception as e:
+                logger.warning("IAM token exchange failed, using API key directly", error=str(e))
+                return api_key
 
     def _get_api_key_or_raise(self) -> str:
         api_key = self._get_api_key_from_config_or_provider_data()

--- a/src/ogx/providers/remote/inference/watsonx/watsonx.py
+++ b/src/ogx/providers/remote/inference/watsonx/watsonx.py
@@ -47,6 +47,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
         super().__init__(config=config)
         self._iam_token_cache: dict[str, tuple[str, float]] = {}
         self._iam_token_lock = asyncio.Lock()
+        self._iam_refresh_tasks: dict[str, asyncio.Task[str]] = {}
         self._model_specs_cache: list[dict[str, Any]] | None = None
 
     def get_base_url(self) -> str:
@@ -76,6 +77,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
             if time.time() < expiry - 60:
                 return token
 
+        refresh_task: asyncio.Task[str] | None = None
         async with self._iam_token_lock:
             cached = self._iam_token_cache.get(api_key)
             if cached:
@@ -83,23 +85,42 @@ class WatsonXInferenceAdapter(OpenAIMixin):
                 if time.time() < expiry - 60:
                     return token
 
-            try:
-                async with httpx.AsyncClient() as http_client:
-                    resp = await http_client.post(
-                        "https://iam.cloud.ibm.com/identity/token",
-                        headers={"Content-Type": "application/x-www-form-urlencoded"},
-                        content=f"grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={api_key}",
-                        timeout=30,
-                    )
-                    resp.raise_for_status()
-                    data = resp.json()
-                    token = data["access_token"]
-                    expiry = data.get("expiration", time.time() + 3600)
-                    self._iam_token_cache[api_key] = (token, expiry)
-                    return token
-            except Exception as e:
-                logger.warning("IAM token exchange failed, using API key directly", error=str(e))
-                return api_key
+            refresh_task = self._iam_refresh_tasks.get(api_key)
+            if refresh_task is not None and refresh_task.done():
+                self._iam_refresh_tasks.pop(api_key, None)
+                refresh_task = None
+
+            if refresh_task is None:
+                refresh_task = asyncio.create_task(self._exchange_iam_token(api_key))
+                self._iam_refresh_tasks[api_key] = refresh_task
+
+        try:
+            # Shield shared refresh work from request cancellation.
+            return await asyncio.shield(refresh_task)
+        finally:
+            if refresh_task.done():
+                async with self._iam_token_lock:
+                    if self._iam_refresh_tasks.get(api_key) is refresh_task:
+                        self._iam_refresh_tasks.pop(api_key, None)
+
+    async def _exchange_iam_token(self, api_key: str) -> str:
+        try:
+            async with httpx.AsyncClient() as http_client:
+                resp = await http_client.post(
+                    "https://iam.cloud.ibm.com/identity/token",
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                    content=f"grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={api_key}",
+                    timeout=30,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                token = data["access_token"]
+                expiry = data.get("expiration", time.time() + 3600)
+                self._iam_token_cache[api_key] = (token, expiry)
+                return token
+        except Exception as e:
+            logger.warning("IAM token exchange failed, using API key directly", error=str(e))
+            return api_key
 
     def _get_api_key_or_raise(self) -> str:
         api_key = self._get_api_key_from_config_or_provider_data()

--- a/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
@@ -95,7 +95,8 @@ class BingSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsReq
             "q": kwargs["query"],
         }
 
-        assert self._client is not None, "Provider not initialized"
+        if self._client is None:
+            raise RuntimeError("Failed to invoke tool: provider not initialized")
         response = await self._client.get(
             url=self.url,
             params=params,

--- a/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
@@ -29,9 +29,15 @@ class BingSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsReq
     def __init__(self, config: BingSearchToolConfig):
         self.config = config
         self.url = "https://api.bing.microsoft.com/v7.0/search"
+        self._client: httpx.AsyncClient | None = None
 
     async def initialize(self):
-        pass
+        self._client = httpx.AsyncClient(timeout=self.config.to_httpx_timeout())
+
+    async def shutdown(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
 
     async def register_toolgroup(self, toolgroup: ToolGroup) -> None:
         pass
@@ -89,13 +95,13 @@ class BingSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsReq
             "q": kwargs["query"],
         }
 
-        async with httpx.AsyncClient(timeout=self.config.to_httpx_timeout()) as client:
-            response = await client.get(
-                url=self.url,
-                params=params,
-                headers=headers,
-            )
-            response.raise_for_status()
+        assert self._client is not None, "Provider not initialized"
+        response = await self._client.get(
+            url=self.url,
+            params=params,
+            headers=headers,
+        )
+        response.raise_for_status()
 
         return ToolInvocationResult(content=json.dumps(self._clean_response(response.json())))
 

--- a/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
+++ b/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
@@ -28,9 +28,15 @@ class TavilySearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsR
 
     def __init__(self, config: TavilySearchToolConfig):
         self.config = config
+        self._client: httpx.AsyncClient | None = None
 
     async def initialize(self):
-        pass
+        self._client = httpx.AsyncClient(timeout=self.config.to_httpx_timeout())
+
+    async def shutdown(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None
 
     async def register_toolgroup(self, toolgroup: ToolGroup) -> None:
         pass
@@ -78,12 +84,12 @@ class TavilySearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsR
         self, tool_name: str, kwargs: dict[str, Any], authorization: str | None = None
     ) -> ToolInvocationResult:
         api_key = self._get_api_key()
-        async with httpx.AsyncClient(timeout=self.config.to_httpx_timeout()) as client:
-            response = await client.post(
-                "https://api.tavily.com/search",
-                json={"api_key": api_key, "query": kwargs["query"]},
-            )
-            response.raise_for_status()
+        assert self._client is not None, "Provider not initialized"
+        response = await self._client.post(
+            "https://api.tavily.com/search",
+            json={"api_key": api_key, "query": kwargs["query"]},
+        )
+        response.raise_for_status()
 
         return ToolInvocationResult(content=json.dumps(self._clean_tavily_response(response.json())))
 

--- a/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
+++ b/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
@@ -84,7 +84,8 @@ class TavilySearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsR
         self, tool_name: str, kwargs: dict[str, Any], authorization: str | None = None
     ) -> ToolInvocationResult:
         api_key = self._get_api_key()
-        assert self._client is not None, "Provider not initialized"
+        if self._client is None:
+            raise RuntimeError("Failed to invoke tool: provider not initialized")
         response = await self._client.post(
             "https://api.tavily.com/search",
             json={"api_key": api_key, "query": kwargs["query"]},

--- a/tests/unit/providers/inference/test_watsonx_token_refresh.py
+++ b/tests/unit/providers/inference/test_watsonx_token_refresh.py
@@ -1,0 +1,45 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import asyncio
+
+import httpx
+
+from ogx.providers.remote.inference.watsonx.config import WatsonXConfig
+from ogx.providers.remote.inference.watsonx.watsonx import WatsonXInferenceAdapter
+
+
+class _FailingIamClient:
+    def __init__(self, calls: list[int]) -> None:
+        self._calls = calls
+
+    async def __aenter__(self) -> "_FailingIamClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def post(self, *args, **kwargs):
+        self._calls.append(1)
+        await asyncio.sleep(0.05)
+        raise httpx.ConnectError("boom")
+
+
+async def test_refresh_iam_token_deduplicates_concurrent_failures(monkeypatch):
+    adapter = WatsonXInferenceAdapter(
+        config=WatsonXConfig(base_url="https://us-south.ml.cloud.ibm.com"),
+    )
+    calls: list[int] = []
+
+    monkeypatch.setattr(
+        "ogx.providers.remote.inference.watsonx.watsonx.httpx.AsyncClient",
+        lambda: _FailingIamClient(calls),
+    )
+
+    results = await asyncio.gather(*(adapter._refresh_iam_token("watsonx-api-key") for _ in range(3)))
+
+    assert results == ["watsonx-api-key", "watsonx-api-key", "watsonx-api-key"]
+    assert len(calls) == 1


### PR DESCRIPTION
# What does this PR do?

Fixes blocking and race-condition issues across 6 remote providers that were stalling the async event loop or causing redundant network calls under concurrent load.

- **Databricks**: wrap sync `WorkspaceClient.serving_endpoints.list()` in `asyncio.to_thread()` to avoid blocking the event loop
- **WatsonX**: add `asyncio.Lock` with double-checked locking to prevent thundering herd on IAM token refresh, and deduplicate concurrent refresh requests with `asyncio.shield()`
- **Bing Search / Tavily Search**: create a shared `httpx.AsyncClient` in `initialize()`/`shutdown()` instead of per-request client creation, enabling TCP connection reuse
- **OCI Auth**: add `async_auth_flow()` that wraps blocking OCI signing operations in `asyncio.to_thread()`
- **OpenAI Files**: switch from sync `OpenAI` to `AsyncOpenAI` client so file create/delete/content operations are non-blocking

## Test Plan

1. Run pre-commit checks:
```bash
uv run pre-commit run --all-files
```
All 40 checks pass.

2. Run unit tests (excluding dirs with missing optional SDK dependencies):
```bash
uv run pytest tests/unit/ -x --tb=short -q --ignore=tests/unit/providers
```
401 tests pass.

3. Run WatsonX token refresh deduplication test:
```bash
uv run pytest tests/unit/providers/inference/test_watsonx_token_refresh.py -x -v
```
Verifies that 3 concurrent refresh calls result in only 1 actual HTTP request.