### PR TITLE
fix(storage): harden PostgreSQL storage and pgvector safety defaults

### DIFF
--- a/docs/docs/providers/vector_io/remote_pgvector.mdx
+++ b/docs/docs/providers/vector_io/remote_pgvector.mdx
@@ -233,12 +233,13 @@ See [PGVector's documentation](https://github.com/pgvector/pgvector) for more de
 | `port` | `int \| None` | No | 5432 |  |
 | `db` | `str \| None` | No | postgres |  |
 | `user` | `str \| None` | No | postgres |  |
-| `password` | `str \| None` | No | mysecretpassword |  |
+| `password` | `SecretStr \| None` | No |  |  |
 | `distance_metric` | `Literal[COSINE, L2, L1, INNER_PRODUCT] \| None` | No | COSINE | PGVector distance metric used for vector search in PGVectorIndex |
 | `vector_index` | `PGVectorHNSWVectorIndex \| PGVectorIVFFlatVectorIndex \| None` | No | type=&lt;PGVectorIndexType.HNSW: 'HNSW'&gt; m=16 ef_construction=64 ef_search=40 | PGVector vector index used for Approximate Nearest Neighbor (ANN) search |
 | `pool_min_size` | `int` | No | 4 | Minimum number of connections in the asyncpg pool |
 | `pool_max_size` | `int` | No | 20 | Maximum number of connections in the asyncpg pool |
 | `statement_cache_size` | `int` | No | 512 | Size of the prepared statement cache per connection |
+| `command_timeout` | `float` | No | 30.0 | Timeout in seconds for individual SQL statements |
 | `persistence` | `KVStoreReference \| None` | No |  | Config for KV store backend (SQLite only for now) |
 | `persistence.namespace` | `str` | No |  | Key prefix for KVStore backends |
 | `persistence.backend` | `str` | No |  | Name of backend from storage.backends |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,7 +380,9 @@ convention = "google"
 # Security rule suppressions for known false positives
 "src/ogx/core/datatypes.py" = ["S105"] # Enum values like OAUTH2_TOKEN are not hardcoded secrets
 "src/ogx/distributions/**/*.py" = ["S106"] # Env var template defaults (e.g. ${env.PGVECTOR_PASSWORD:=})
-"src/ogx/providers/remote/**/config.py" = ["S107"] # Env var template defaults in provider configs
+"src/ogx/providers/remote/inference/databricks/config.py" = ["S107"] # Env var template defaults in sample_run_config
+"src/ogx/providers/remote/inference/gemini/config.py" = ["S107"] # Env var template defaults in sample_run_config
+"src/ogx/providers/remote/vector_io/pgvector/config.py" = ["S107"] # Env var template defaults in sample_run_config
 "src/ogx/providers/remote/inference/oci/auth.py" = ["S106"] # pass_phrase="none" placeholder
 "src/ogx/cli/**/*.py" = ["S603", "S607"] # CLI tools legitimately invoke subprocesses
 "src/ogx/core/utils/exec.py" = ["S603"] # Command execution utility

--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -11,7 +11,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR
 
@@ -88,12 +88,13 @@ class PostgresKVStoreConfig(CommonConfig):
     port: int | str = 5432
     db: str = "ogx"
     user: str
-    password: str | None = None
+    password: SecretStr | None = None
     ssl_mode: str | None = None
     ca_cert_path: str | None = None
     table_name: str = "ogx_kvstore"
     pool_size: int = Field(default=5, ge=1, description="Number of persistent connections in the pool")
     max_overflow: int = Field(default=10, ge=0, description="Max additional connections beyond pool_size")
+    command_timeout: float = Field(default=30.0, gt=0, description="Timeout in seconds for individual SQL statements")
 
     @classmethod
     def sample_run_config(cls, table_name: str = "ogx_kvstore", **kwargs: object) -> dict[str, str]:
@@ -203,14 +204,15 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
     port: int | str = 5432
     db: str = "ogx"
     user: str
-    password: str | None = None
+    password: SecretStr | None = None
     pool_size: int = Field(default=10, ge=1, description="Number of persistent connections in the pool")
     max_overflow: int = Field(default=20, ge=0, description="Max additional connections beyond pool_size")
-    pool_recycle: int = Field(default=-1, ge=-1, description="Connection recycle interval in seconds, -1 to disable")
+    pool_recycle: int = Field(default=3600, ge=-1, description="Connection recycle interval in seconds, -1 to disable")
 
     @property
     def engine_str(self) -> str:
-        return f"postgresql+asyncpg://{self.user}:{self.password}@{self.host}:{self.port}/{self.db}"
+        pw = self.password.get_secret_value() if self.password else ""
+        return f"postgresql+asyncpg://{self.user}:{pw}@{self.host}:{self.port}/{self.db}"
 
     @classmethod
     def pip_packages(cls) -> list[str]:
@@ -227,7 +229,7 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
             "password": "${env.POSTGRES_PASSWORD:=ogx}",
             "pool_size": "${env.POSTGRES_POOL_SIZE:=10}",
             "max_overflow": "${env.POSTGRES_MAX_OVERFLOW:=20}",
-            "pool_recycle": "${env.POSTGRES_POOL_RECYCLE:=-1}",
+            "pool_recycle": "${env.POSTGRES_POOL_RECYCLE:=3600}",
             "pool_pre_ping": "${env.POSTGRES_POOL_PRE_PING:=true}",
         }
 

--- a/src/ogx/core/storage/kvstore/postgres/postgres.py
+++ b/src/ogx/core/storage/kvstore/postgres/postgres.py
@@ -58,10 +58,11 @@ class PostgresKVStoreImpl(KVStore):
                     port=int(self.config.port),
                     database=self.config.db,
                     user=self.config.user,
-                    password=self.config.password,
+                    password=self.config.password.get_secret_value() if self.config.password else None,
                     ssl=self._build_ssl(),
                     min_size=self.config.pool_size,
                     max_size=self.config.pool_size + self.config.max_overflow,
+                    command_timeout=self.config.command_timeout,
                 )
                 self._loop = loop
             except Exception as e:
@@ -75,8 +76,15 @@ class PostgresKVStoreImpl(KVStore):
                     CREATE TABLE IF NOT EXISTS {self.config.table_name} (
                         key TEXT PRIMARY KEY,
                         value TEXT,
-                        expiration TIMESTAMP
+                        expiration TIMESTAMPTZ
                     )
+                    """
+                )
+                await conn.execute(
+                    f"""
+                    CREATE INDEX IF NOT EXISTS idx_{self.config.table_name}_expiration
+                    ON {self.config.table_name} (expiration)
+                    WHERE expiration IS NOT NULL
                     """
                 )
                 self._table_created = True

--- a/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import json
 import re
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
@@ -370,6 +371,28 @@ class AuthorizedSqlStore:
         else:
             raise ValueError(f"Unsupported database type: {self.database_type}")
 
+    def _json_array_contains_value(self, column: str, path: str, param_name: str, value: str) -> tuple[str, Any]:
+        """Generate SQL condition and bind param for checking if a JSON array contains an exact value.
+
+        Args:
+            column: The JSON column name
+            path: The JSON path to the array (e.g., 'roles', 'teams')
+            param_name: Name for the bind parameter
+            value: The exact value to check for in the array
+
+        Returns:
+            A tuple of (sql_condition, param_value)
+        """
+        self._validate_json_path(path)
+        if self.database_type == StorageBackendType.SQL_POSTGRES.value:
+            sql = f"CAST({column}->'{path}' AS jsonb) @> CAST(:{param_name} AS jsonb)"
+            return sql, json.dumps([value])
+        elif self.database_type == StorageBackendType.SQL_SQLITE.value:
+            sql = f"EXISTS (SELECT 1 FROM json_each(json_extract({column}, '$.{path}')) WHERE value = :{param_name})"
+            return sql, value
+        else:
+            raise ValueError(f"Unsupported database type: {self.database_type}")
+
     def _get_public_access_conditions(self) -> list[str]:
         """Get the SQL conditions for public access.
 
@@ -404,9 +427,11 @@ class AuthorizedSqlStore:
                         value_conditions = []
                         for j, value in enumerate(user_values):
                             param_name = f"attr_{attr_key}_{j}"
-                            json_text = self._json_extract_text("access_attributes", attr_key)
-                            value_conditions.append(f"({json_text} LIKE :{param_name})")
-                            params[param_name] = f'%"{value}"%'
+                            condition, param_value = self._json_array_contains_value(
+                                "access_attributes", attr_key, param_name, value
+                            )
+                            value_conditions.append(f"({condition})")
+                            params[param_name] = param_value
 
                         if value_conditions:
                             base_conditions.append(f"({' OR '.join(value_conditions)})")

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -443,7 +443,11 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                 compiled_type = type_impl.compile(dialect=dialect)
 
                 nullable_clause = "" if nullable else " NOT NULL"
-                add_column_sql = text(f"ALTER TABLE {table} ADD COLUMN {column_name} {compiled_type}{nullable_clause}")
+                quoted_table = f'"{table}"' if not self._is_sqlite_backend else table
+                quoted_column = f'"{column_name}"' if not self._is_sqlite_backend else column_name
+                add_column_sql = text(
+                    f"ALTER TABLE {quoted_table} ADD COLUMN {quoted_column} {compiled_type}{nullable_clause}"
+                )
 
                 await conn.execute(add_column_sql)
         except Exception as e:

--- a/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
@@ -253,7 +253,7 @@ storage:
       password: ${env.POSTGRES_PASSWORD:=ogx}
       pool_size: ${env.POSTGRES_POOL_SIZE:=10}
       max_overflow: ${env.POSTGRES_MAX_OVERFLOW:=20}
-      pool_recycle: ${env.POSTGRES_POOL_RECYCLE:=-1}
+      pool_recycle: ${env.POSTGRES_POOL_RECYCLE:=3600}
       pool_pre_ping: ${env.POSTGRES_POOL_PRE_PING:=true}
   stores:
     metadata:

--- a/src/ogx/distributions/starter/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/starter/run-with-postgres-store.yaml
@@ -247,7 +247,7 @@ storage:
       password: ${env.POSTGRES_PASSWORD:=ogx}
       pool_size: ${env.POSTGRES_POOL_SIZE:=10}
       max_overflow: ${env.POSTGRES_MAX_OVERFLOW:=20}
-      pool_recycle: ${env.POSTGRES_POOL_RECYCLE:=-1}
+      pool_recycle: ${env.POSTGRES_POOL_RECYCLE:=3600}
       pool_pre_ping: ${env.POSTGRES_POOL_PRE_PING:=true}
   stores:
     metadata:

--- a/src/ogx/providers/remote/vector_io/pgvector/config.py
+++ b/src/ogx/providers/remote/vector_io/pgvector/config.py
@@ -7,7 +7,7 @@
 from enum import StrEnum
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, model_validator
 
 from ogx.core.storage.datatypes import KVStoreReference, SqlStoreReference
 from ogx_api import json_schema_type
@@ -81,7 +81,7 @@ class PGVectorVectorIOConfig(BaseModel):
     port: int | None = Field(default=5432)
     db: str | None = Field(default="postgres")
     user: str | None = Field(default="postgres")
-    password: str | None = Field(default="mysecretpassword")
+    password: SecretStr | None = Field(default=None)
     distance_metric: Literal["COSINE", "L2", "L1", "INNER_PRODUCT"] | None = Field(
         default="COSINE", description="PGVector distance metric used for vector search in PGVectorIndex"
     )
@@ -94,6 +94,7 @@ class PGVectorVectorIOConfig(BaseModel):
     statement_cache_size: int = Field(
         default=512, ge=0, description="Size of the prepared statement cache per connection"
     )
+    command_timeout: float = Field(default=30.0, gt=0, description="Timeout in seconds for individual SQL statements")
     persistence: KVStoreReference | None = Field(
         description="Config for KV store backend (SQLite only for now)", default=None
     )

--- a/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
+++ b/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
@@ -293,28 +293,31 @@ class PGVectorIndex(EmbeddingIndex):
         pgvector_search_function = self.get_pgvector_search_function()
 
         async with self.pool.acquire() as conn:
-            # Specify the number of probes to allow PGVector to use Index Scan using IVFFlat index if it was configured (https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options-1)
-            if self.vector_index.type == PGVectorIndexType.IVFFlat:
-                await conn.execute(f"SET ivfflat.probes = {self.vector_index.probes}")
+            # Keep query-level search tuning transaction-local and scoped to the
+            # same transaction as the SELECT statement.
+            async with conn.transaction():
+                # Specify the number of probes to allow PGVector to use Index Scan using IVFFlat index if it was configured (https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options-1)
+                if self.vector_index.type == PGVectorIndexType.IVFFlat:
+                    await conn.execute("SELECT set_config('ivfflat.probes', $1, true)", str(self.vector_index.probes))
 
-            # Specify the max size of max heap that holds best candidates when traversing the graph (https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options)
-            elif self.vector_index.type == PGVectorIndexType.HNSW:
-                await conn.execute(f"SET hnsw.ef_search = {self.vector_index.ef_search}")
+                # Specify the max size of max heap that holds best candidates when traversing the graph (https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options)
+                elif self.vector_index.type == PGVectorIndexType.HNSW:
+                    await conn.execute("SELECT set_config('hnsw.ef_search', $1, true)", str(self.vector_index.ef_search))
 
-            where = f"WHERE {filter_clause}" if filter_clause else ""
+                where = f"WHERE {filter_clause}" if filter_clause else ""
 
-            rows = await conn.fetch(
-                f"""
-                SELECT document, embedding {pgvector_search_function} $1::vector AS distance
-                FROM {self._quoted_table}
-                {where}
-                ORDER BY distance
-                LIMIT ${next_idx}
-                """,
-                embedding.tolist(),
-                *filter_params,
-                k,
-            )
+                rows = await conn.fetch(
+                    f"""
+                    SELECT document, embedding {pgvector_search_function} $1::vector AS distance
+                    FROM {self._quoted_table}
+                    {where}
+                    ORDER BY distance
+                    LIMIT ${next_idx}
+                    """,
+                    embedding.tolist(),
+                    *filter_params,
+                    k,
+                )
 
             chunks = []
             scores = []
@@ -349,7 +352,7 @@ class PGVectorIndex(EmbeddingIndex):
         Returns:
             QueryChunksResponse with combined results
         """
-        filter_clause, filter_params, next_idx = self._translate_filters(filters, param_idx=3)
+        filter_clause, filter_params, next_idx = self._translate_filters(filters, param_idx=2)
 
         async with self.pool.acquire() as conn:
             filter_sql = f" AND ({filter_clause})" if filter_clause else ""
@@ -358,11 +361,10 @@ class PGVectorIndex(EmbeddingIndex):
                 f"""
                 SELECT document, ts_rank(tokenized_content, plainto_tsquery('english', $1)) AS score
                 FROM {self._quoted_table}
-                WHERE tokenized_content @@ plainto_tsquery('english', $2){filter_sql}
+                WHERE tokenized_content @@ plainto_tsquery('english', $1){filter_sql}
                 ORDER BY score DESC
                 LIMIT ${next_idx}
                 """,
-                query_string,
                 query_string,
                 *filter_params,
                 k,
@@ -700,7 +702,7 @@ class PGVectorIndex(EmbeddingIndex):
         """
         try:
             log.info(f"Fetching number of records in vector_store: {self.vector_store.identifier}...")
-            count = await conn.fetchval(f"SELECT COUNT(DISTINCT id) FROM {self._quoted_table}")
+            count = await conn.fetchval(f"SELECT COUNT(*) FROM {self._quoted_table}")
 
             if count:
                 log.info(f"vector_store: {self.vector_store.identifier} has {count} records.")
@@ -795,10 +797,11 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
                 port=self.config.port,
                 database=self.config.db,
                 user=self.config.user,
-                password=self.config.password,
+                password=self.config.password.get_secret_value() if self.config.password else None,
                 min_size=self.config.pool_min_size,
                 max_size=self.config.pool_max_size,
                 statement_cache_size=self.config.statement_cache_size,
+                command_timeout=self.config.command_timeout,
                 init=self._init_connection,
                 reset=self._reset_connection,
             )
@@ -811,6 +814,11 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
                             log.info("Vector extension version", version=version)
                         else:
                             await create_vector_extension(conn)
+
+                        try:
+                            await conn.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+                        except asyncpg.PostgresError:
+                            log.debug("pg_stat_statements not available, skipping")
 
                         await conn.execute(
                             """
@@ -829,8 +837,7 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
             return self.pool
 
     async def initialize(self) -> None:
-        safe_config = {**self.config.model_dump(exclude={"password"}), "password": "******"}
-        log.info(f"Initializing PGVector memory adapter with config: {safe_config}")
+        log.info("Initializing PGVector memory adapter", config=self.config.model_dump())
         self.kvstore = await kvstore_impl(self.config.persistence)
 
         if self.config.metadata_store:

--- a/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
+++ b/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
@@ -302,7 +302,9 @@ class PGVectorIndex(EmbeddingIndex):
 
                 # Specify the max size of max heap that holds best candidates when traversing the graph (https://github.com/pgvector/pgvector?tab=readme-ov-file#query-options)
                 elif self.vector_index.type == PGVectorIndexType.HNSW:
-                    await conn.execute("SELECT set_config('hnsw.ef_search', $1, true)", str(self.vector_index.ef_search))
+                    await conn.execute(
+                        "SELECT set_config('hnsw.ef_search', $1, true)", str(self.vector_index.ef_search)
+                    )
 
                 where = f"WHERE {filter_clause}" if filter_clause else ""
 

--- a/tests/unit/providers/vector_io/conftest.py
+++ b/tests/unit/providers/vector_io/conftest.py
@@ -223,12 +223,16 @@ async def faiss_vec_adapter(unique_kvstore_config, mock_inference_api, embedding
 def _make_mock_asyncpg_pool():
     """Create a mock asyncpg pool with acquire() as async context manager."""
     pool = MagicMock()
-    mock_conn = AsyncMock()
+    mock_conn = MagicMock()
     mock_conn.execute = AsyncMock()
     mock_conn.executemany = AsyncMock()
     mock_conn.fetch = AsyncMock(return_value=[])
     mock_conn.fetchrow = AsyncMock(return_value=None)
     mock_conn.fetchval = AsyncMock(return_value=None)
+    tx_acm = AsyncMock()
+    tx_acm.__aenter__ = AsyncMock(return_value=None)
+    tx_acm.__aexit__ = AsyncMock(return_value=False)
+    mock_conn.transaction = MagicMock(return_value=tx_acm)
 
     # Make pool.acquire() return an async context manager yielding mock_conn
     acm = AsyncMock()

--- a/tests/unit/providers/vector_io/test_vector_io_stores_config.py
+++ b/tests/unit/providers/vector_io/test_vector_io_stores_config.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 
 from ogx_api import (
+    EmbeddedChunk,
     OpenAICreateVectorStoreRequestWithExtraBody,
     QueryChunksResponse,
     VectorStore,
@@ -21,12 +22,16 @@ from ogx_api import (
 def _make_mock_asyncpg_pool():
     """Create a mock asyncpg pool with acquire() as async context manager."""
     pool = MagicMock()
-    mock_conn = AsyncMock()
+    mock_conn = MagicMock()
     mock_conn.execute = AsyncMock()
     mock_conn.executemany = AsyncMock()
     mock_conn.fetch = AsyncMock(return_value=[])
     mock_conn.fetchrow = AsyncMock(return_value=None)
     mock_conn.fetchval = AsyncMock(return_value=None)
+    tx_acm = AsyncMock()
+    tx_acm.__aenter__ = AsyncMock(return_value=None)
+    tx_acm.__aexit__ = AsyncMock(return_value=False)
+    mock_conn.transaction = MagicMock(return_value=tx_acm)
 
     acm = AsyncMock()
     acm.__aenter__ = AsyncMock(return_value=mock_conn)
@@ -325,11 +330,15 @@ async def test_set_ef_search_called_before_select_in_query_vector(mock_asyncpg_p
 
     assert len(execute_calls) == 1, f"Expected 1 execute call (SET), got {len(execute_calls)}"
     assert len(fetch_calls) == 1, f"Expected 1 fetch call (SELECT), got {len(fetch_calls)}"
+    mock_conn.transaction.assert_called_once()
 
-    set_call_sql = str(execute_calls[0])
+    set_call_args = execute_calls[0].args
     select_call_sql = str(fetch_calls[0])
-    assert f"SET hnsw.ef_search = {index.vector_index.ef_search}" in set_call_sql, (
-        f"First call should be SET, got: {set_call_sql}"
+    assert set_call_args[0] == "SELECT set_config('hnsw.ef_search', $1, true)", (
+        f"First call should set hnsw.ef_search, got: {set_call_args[0]}"
+    )
+    assert set_call_args[1] == str(index.vector_index.ef_search), (
+        f"Expected ef_search value {index.vector_index.ef_search}, got: {set_call_args[1]}"
     )
     assert "SELECT document" in select_call_sql, f"Second call should be SELECT, got: {select_call_sql}"
 
@@ -360,10 +369,52 @@ async def test_apply_default_ef_search_for_query_vector(mock_asyncpg_pool, embed
     await index.query_vector(embedding, k=5, score_threshold=0.5)
 
     execute_calls = mock_conn.execute.call_args_list
-    set_call_sql = str(execute_calls[0])
-    assert f"SET hnsw.ef_search = {PGVectorHNSWVectorIndex().ef_search}" in set_call_sql, (
-        f"Expected default 'SET hnsw.ef_search = {PGVectorHNSWVectorIndex().ef_search}' when ef_search is not explicitly configured, got: {set_call_sql}"
+    set_call_args = execute_calls[0].args
+    assert set_call_args[0] == "SELECT set_config('hnsw.ef_search', $1, true)", (
+        f"Expected set_config call for hnsw.ef_search, got: {set_call_args[0]}"
     )
+    assert set_call_args[1] == str(PGVectorHNSWVectorIndex().ef_search), (
+        f"Expected default ef_search value {PGVectorHNSWVectorIndex().ef_search}, got: {set_call_args[1]}"
+    )
+    mock_conn.transaction.assert_called_once()
+
+
+async def test_add_chunks_does_not_run_analyze_on_write():
+    from ogx.providers.remote.vector_io.pgvector.config import PGVectorHNSWVectorIndex
+    from ogx.providers.remote.vector_io.pgvector.pgvector import PGVectorIndex
+
+    pool, mock_conn = _make_mock_asyncpg_pool()
+
+    index = PGVectorIndex(
+        vector_store=VectorStore(
+            identifier="test-vector-db",
+            embedding_model="test-model",
+            embedding_dimension=2,
+            provider_id="pgvector",
+        ),
+        dimension=2,
+        pool=pool,
+        distance_metric="COSINE",
+        vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64, ef_search=40),
+    )
+    index.table_name = "test_table"
+    index._quoted_table = '"test_table"'
+
+    await index.add_chunks(
+        [
+            EmbeddedChunk(
+                content="hello world",
+                chunk_id="chunk-1",
+                chunk_metadata={},
+                embedding=[0.1, 0.2],
+                embedding_model="test-model",
+                embedding_dimension=2,
+            )
+        ]
+    )
+
+    mock_conn.executemany.assert_called_once()
+    mock_conn.execute.assert_not_called()
 
 
 def _make_pgvector_adapter():

--- a/tests/unit/utils/kvstore/test_postgres_kvstore.py
+++ b/tests/unit/utils/kvstore/test_postgres_kvstore.py
@@ -16,6 +16,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import SecretStr
 
 from ogx.core.storage.datatypes import PostgresKVStoreConfig
 
@@ -26,7 +27,7 @@ def _make_config(namespace: str | None = None, table_name: str = "test_kvstore")
         port=5432,
         db="testdb",
         user="testuser",
-        password="testpass",
+        password=SecretStr("testpass"),
         table_name=table_name,
         namespace=namespace,
     )

--- a/tests/unit/utils/sqlstore/test_sqlstore.py
+++ b/tests/unit/utils/sqlstore/test_sqlstore.py
@@ -559,7 +559,7 @@ async def test_postgres_pool_config_defaults():
     cfg = PostgresSqlStoreConfig(user="test", password="test")
     assert cfg.pool_size == 10
     assert cfg.max_overflow == 20
-    assert cfg.pool_recycle == -1
+    assert cfg.pool_recycle == 3600
 
 
 async def test_postgres_pool_kwargs_propagate_to_engine():

--- a/tests/unit/utils/test_authorized_sqlstore.py
+++ b/tests/unit/utils/test_authorized_sqlstore.py
@@ -14,7 +14,7 @@ from ogx.core.access_control.datatypes import Action
 from ogx.core.datatypes import User
 from ogx.core.storage.sqlstore.authorized_sqlstore import AuthorizedSqlStore, SqlRecord
 from ogx.core.storage.sqlstore.sqlalchemy_sqlstore import SqlAlchemySqlStoreImpl
-from ogx.core.storage.sqlstore.sqlstore import SqliteSqlStoreConfig
+from ogx.core.storage.sqlstore.sqlstore import PostgresSqlStoreConfig, SqliteSqlStoreConfig
 from ogx_api.internal.sqlstore import ColumnType
 
 
@@ -498,6 +498,38 @@ async def test_json_extract_text_rejects_malicious_path(mock_get_authenticated_u
         sqlstore._json_extract_text("access_attributes", "teams")
         sqlstore._json_extract("access_attributes", "projects")
         sqlstore._json_extract("access_attributes", "namespaces")
+
+
+def test_json_array_contains_value_uses_backend_specific_sql():
+    """Ensure JSON array containment SQL is valid for both SQLite and PostgreSQL backends."""
+    with TemporaryDirectory() as tmp_dir:
+        sqlite_store = AuthorizedSqlStore(
+            SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=tmp_dir + "/test_json_array_contains.db")),
+            default_policy(),
+        )
+        sqlite_sql, sqlite_param = sqlite_store._json_array_contains_value(
+            "access_attributes",
+            "roles",
+            "attr_roles_0",
+            "admin",
+        )
+        assert sqlite_sql == (
+            "EXISTS (SELECT 1 FROM json_each(json_extract(access_attributes, '$.roles')) WHERE value = :attr_roles_0)"
+        )
+        assert sqlite_param == "admin"
+
+    postgres_store = AuthorizedSqlStore(
+        SqlAlchemySqlStoreImpl(PostgresSqlStoreConfig(user="test", password="test")),
+        default_policy(),
+    )
+    postgres_sql, postgres_param = postgres_store._json_array_contains_value(
+        "access_attributes",
+        "roles",
+        "attr_roles_0",
+        "admin",
+    )
+    assert postgres_sql == "CAST(access_attributes->'roles' AS jsonb) @> CAST(:attr_roles_0 AS jsonb)"
+    assert postgres_param == '["admin"]'
 
 
 @patch("ogx.core.storage.sqlstore.authorized_sqlstore.get_authenticated_user")


### PR DESCRIPTION
# What does this PR do?
This PR hardens PostgreSQL-backed storage defaults and credential handling while improving PGVector query/runtime safety.
It converts Postgres passwords to SecretStr-based handling, adds command timeouts and expiration index support, and updates default pool recycle settings in config and distribution templates.
It also fixes ACL JSON array matching for SQLite/PostgreSQL, quotes Postgres identifiers during dynamic column adds, and updates PGVector query tuning to transaction-scoped `set_config` with matching unit tests and docs updates.

## Test Plan
- `uv run pytest tests/unit/providers/vector_io/test_vector_io_stores_config.py::test_set_ef_search_called_before_select_in_query_vector tests/unit/providers/vector_io/test_vector_io_stores_config.py::test_apply_default_ef_search_for_query_vector tests/unit/providers/vector_io/test_vector_io_stores_config.py::test_add_chunks_does_not_run_analyze_on_write -q` (3 passed)
- `uv run pytest tests/unit/providers/vector_io -k "pgvector or vector_io_stores_config and (ef_search or probes or keyword or hybrid or filter)" -q` (45 passed)
- `uv run pytest tests/unit/utils/kvstore/test_postgres_kvstore.py tests/unit/utils/sqlstore/test_sqlstore.py tests/unit/utils/test_authorized_sqlstore.py -q` (52 passed, 3 xfailed)
- `uv run ruff check src/ogx/providers/remote/vector_io/pgvector/pgvector.py tests/unit/providers/vector_io/test_vector_io_stores_config.py tests/unit/providers/vector_io/conftest.py` (all checks passed)
