### PR TITLE
fix(storage): reset SQL engines after temp event loop init

### DIFF
--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -120,6 +120,13 @@ class StackApp(FastAPI):
             future = executor.submit(asyncio.run, self.stack.initialize())  # type: ignore[no-untyped-call]
             future.result()
 
+        # Reset SQL engines that may have been created in the temporary event loop
+        # (e.g. by register_connectors → list_connectors → fetch_all) so they are
+        # recreated lazily in uvicorn's request-handling event loop.
+        from ogx.core.storage.sqlstore.sqlstore import reset_sqlstore_engines
+
+        reset_sqlstore_engines()
+
 
 @asynccontextmanager
 async def lifespan(app: StackApp) -> AsyncIterator[None]:

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -106,6 +106,16 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                     await self._add_column_now(table_name, col_name, col_type, nullable)
             self._pending_columns.clear()
 
+    def reset_engine(self) -> None:
+        """Reset engine state so it will be recreated in the next event loop.
+
+        Called after Stack.initialize() completes in a temporary event loop,
+        before uvicorn's request-handling loop takes over. Does not dispose
+        the old engine because the temporary loop is already closed.
+        """
+        self._engine = None
+        self.async_session = None
+
     async def shutdown(self) -> None:
         """Dispose of the async engine and close all connections."""
         if self._engine:

--- a/src/ogx/core/storage/sqlstore/sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlstore.py
@@ -98,6 +98,17 @@ def register_sqlstore_backends(backends: dict[str, StorageBackendConfig]) -> Non
         _SQLSTORE_BACKENDS[name] = cfg
 
 
+def reset_sqlstore_engines() -> None:
+    """Reset engines on all cached SqlStore instances.
+
+    Called after Stack.initialize() completes in a temporary event loop so
+    engines are recreated lazily in uvicorn's request-handling event loop.
+    """
+    for instance in _SQLSTORE_INSTANCES.values():
+        if hasattr(instance, "reset_engine"):
+            instance.reset_engine()
+
+
 async def shutdown_sqlstore_backends() -> None:
     """Shutdown all cached SQL store instances."""
     global _SQLSTORE_INSTANCES

--- a/tests/unit/core/test_inference_store_event_loop.py
+++ b/tests/unit/core/test_inference_store_event_loop.py
@@ -106,9 +106,7 @@ def test_inference_store_write_queue_after_event_loop_reset(tmp_path):
         store._worker_tasks = []
 
         for i in range(3):
-            await store.store_chat_completion(
-                _make_completion(f"cmpl-{i}", created=1000 + i), _make_messages()
-            )
+            await store.store_chat_completion(_make_completion(f"cmpl-{i}", created=1000 + i), _make_messages())
         await store.flush()
 
         result = await store.list_chat_completions()

--- a/tests/unit/core/test_inference_store_event_loop.py
+++ b/tests/unit/core/test_inference_store_event_loop.py
@@ -1,0 +1,146 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests that InferenceStore works across event loop boundaries after engine reset.
+
+Simulates the actual server startup pattern where Stack.initialize() runs in a
+temporary event loop and request handling runs in uvicorn's event loop.
+"""
+
+import asyncio
+
+from ogx.core.storage.datatypes import InferenceStoreReference, SqliteSqlStoreConfig
+from ogx.core.storage.sqlstore.sqlstore import register_sqlstore_backends, reset_sqlstore_engines
+from ogx.providers.utils.inference.inference_store import InferenceStore
+from ogx_api import (
+    OpenAIChatCompletion,
+    OpenAIChatCompletionResponseMessage,
+    OpenAIChoice,
+    OpenAIUserMessageParam,
+)
+
+
+def _make_completion(completion_id: str) -> OpenAIChatCompletion:
+    return OpenAIChatCompletion(
+        id=completion_id,
+        created=1000,
+        model="test-model",
+        object="chat.completion",
+        choices=[
+            OpenAIChoice(
+                index=0,
+                message=OpenAIChatCompletionResponseMessage(role="assistant", content="hello"),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+
+def _make_messages():
+    return [OpenAIUserMessageParam(role="user", content="hi")]
+
+
+def test_inference_store_data_persisted_after_event_loop_reset(tmp_path):
+    """Data written via store_chat_completion is retrievable after engine reset.
+
+    Uses direct writes (SQLite disables the write queue) to verify that the
+    SQL engine is properly recreated and data reaches the database.
+    """
+    db_path = str(tmp_path / "inference.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    reference = InferenceStoreReference(backend="sql_default", table_name="inference_store")
+
+    async def init_phase():
+        store = InferenceStore(reference, policy=[])
+        await store.initialize()
+        return store
+
+    store = asyncio.run(init_phase())
+
+    reset_sqlstore_engines()
+
+    async def request_phase():
+        await store.store_chat_completion(_make_completion("cmpl-1"), _make_messages())
+        await store.flush()
+        result = await store.list_chat_completions()
+        return result
+
+    result = asyncio.run(request_phase())
+    assert len(result.data) == 1
+    assert result.data[0].id == "cmpl-1"
+    assert result.data[0].choices[0].message.content == "hello"
+    assert len(result.data[0].input_messages) == 1
+
+
+def test_inference_store_write_queue_after_event_loop_reset(tmp_path):
+    """Write queue workers function correctly after engine reset.
+
+    Forces enable_write_queue=True (normally disabled for SQLite) to exercise
+    the background worker path that fails with 'Future attached to a different
+    loop' when the engine is bound to the wrong event loop.
+    """
+    db_path = str(tmp_path / "inference.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    reference = InferenceStoreReference(backend="sql_default", table_name="inference_store")
+
+    async def init_phase():
+        store = InferenceStore(reference, policy=[])
+        await store.initialize()
+        return store
+
+    store = asyncio.run(init_phase())
+
+    reset_sqlstore_engines()
+
+    async def request_phase():
+        # Force write queue on to simulate PostgreSQL behavior
+        store.enable_write_queue = True
+        store._queue = None
+        store._worker_tasks = []
+
+        for i in range(3):
+            await store.store_chat_completion(_make_completion(f"cmpl-{i}"), _make_messages())
+        await store.flush()
+
+        result = await store.list_chat_completions()
+        await store.shutdown()
+        return result
+
+    result = asyncio.run(request_phase())
+    assert len(result.data) == 3
+    ids = {r.id for r in result.data}
+    assert ids == {"cmpl-0", "cmpl-1", "cmpl-2"}
+
+
+def test_inference_store_retrieve_after_event_loop_reset(tmp_path):
+    """Individual completion retrieval works after engine reset."""
+    db_path = str(tmp_path / "inference.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    reference = InferenceStoreReference(backend="sql_default", table_name="inference_store")
+
+    async def init_phase():
+        store = InferenceStore(reference, policy=[])
+        await store.initialize()
+        return store
+
+    store = asyncio.run(init_phase())
+
+    reset_sqlstore_engines()
+
+    async def request_phase():
+        await store.store_chat_completion(_make_completion("cmpl-42"), _make_messages())
+        await store.flush()
+
+        completion = await store.get_chat_completion("cmpl-42")
+        return completion
+
+    completion = asyncio.run(request_phase())
+    assert completion.id == "cmpl-42"
+    assert completion.choices[0].message.content == "hello"
+    assert completion.input_messages[0].content == "hi"

--- a/tests/unit/core/test_inference_store_event_loop.py
+++ b/tests/unit/core/test_inference_store_event_loop.py
@@ -23,10 +23,10 @@ from ogx_api import (
 )
 
 
-def _make_completion(completion_id: str) -> OpenAIChatCompletion:
+def _make_completion(completion_id: str, created: int = 1000) -> OpenAIChatCompletion:
     return OpenAIChatCompletion(
         id=completion_id,
-        created=1000,
+        created=created,
         model="test-model",
         object="chat.completion",
         choices=[
@@ -98,13 +98,17 @@ def test_inference_store_write_queue_after_event_loop_reset(tmp_path):
     reset_sqlstore_engines()
 
     async def request_phase():
-        # Force write queue on to simulate PostgreSQL behavior
+        # Force write queue on with a single writer to simulate PostgreSQL
+        # behavior. Multiple writers race on SQLite, so use one worker.
         store.enable_write_queue = True
+        store._num_writers = 1
         store._queue = None
         store._worker_tasks = []
 
         for i in range(3):
-            await store.store_chat_completion(_make_completion(f"cmpl-{i}"), _make_messages())
+            await store.store_chat_completion(
+                _make_completion(f"cmpl-{i}", created=1000 + i), _make_messages()
+            )
         await store.flush()
 
         result = await store.list_chat_completions()

--- a/tests/unit/core/test_sqlstore_event_loop.py
+++ b/tests/unit/core/test_sqlstore_event_loop.py
@@ -1,0 +1,109 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests that SqlAlchemySqlStoreImpl works correctly across event loop boundaries."""
+
+import asyncio
+
+import pytest
+
+from ogx.core.storage.datatypes import SqliteSqlStoreConfig
+from ogx.core.storage.sqlstore.sqlalchemy_sqlstore import SqlAlchemySqlStoreImpl
+from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_loop.db")
+
+
+def test_reset_engine_clears_state(db_path):
+    """reset_engine() sets engine and session to None."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def init():
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+        await store.insert("t", {"id": "1"})
+
+    asyncio.run(init())
+    assert store._engine is not None
+    assert store.async_session is not None
+
+    store.reset_engine()
+    assert store._engine is None
+    assert store.async_session is None
+
+
+def test_reset_engine_preserves_metadata(db_path):
+    """reset_engine() preserves table metadata so _ensure_engine recreates tables."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def init():
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+
+    asyncio.run(init())
+    assert "t" in store.metadata.tables
+
+    store.reset_engine()
+    assert "t" in store.metadata.tables
+
+
+def test_data_survives_engine_reset(db_path):
+    """Data written before reset_engine() is accessible after engine recreation."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def phase1():
+        await store.create_table(
+            "items",
+            {
+                "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
+                "value": ColumnType.STRING,
+            },
+        )
+        await store.insert("items", {"id": "row1", "value": "before_reset"})
+
+    asyncio.run(phase1())
+    store.reset_engine()
+
+    async def phase2():
+        await store.insert("items", {"id": "row2", "value": "after_reset"})
+        result = await store.fetch_all("items")
+        return result
+
+    result = asyncio.run(phase2())
+    ids = {row["id"] for row in result.data}
+    assert ids == {"row1", "row2"}
+
+
+def test_engine_reset_across_event_loops(db_path):
+    """Simulates the server init pattern: init in one loop, use in another."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def init_in_temp_loop():
+        await store.create_table(
+            "items",
+            {
+                "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
+                "value": ColumnType.STRING,
+            },
+        )
+        await store.insert("items", {"id": "init_row", "value": "from_init"})
+        result = await store.fetch_all("items")
+        assert len(result.data) == 1
+
+    asyncio.run(init_in_temp_loop())
+
+    store.reset_engine()
+
+    async def use_in_request_loop():
+        await store.insert("items", {"id": "request_row", "value": "from_request"})
+        result = await store.fetch_all("items")
+        return result
+
+    result = asyncio.run(use_in_request_loop())
+    assert len(result.data) == 2
+    ids = {row["id"] for row in result.data}
+    assert ids == {"init_row", "request_row"}


### PR DESCRIPTION
# What does this PR do?

Fixes `inference_store` table not being populated after the KV-to-SQL migration of connectors (PR #5757). `Stack.initialize()` runs in a temporary event loop via `ThreadPoolExecutor`. After the migration, `register_connectors()` → `list_connectors()` triggers `_ensure_engine()` during init, binding the asyncpg engine to the temp loop. When uvicorn's request loop takes over, `InferenceStore` write queue workers fail silently with `"got Future attached to a different loop"`, dropping all chat completion records.

The fix adds `reset_engine()` to `SqlAlchemySqlStoreImpl` and calls `reset_sqlstore_engines()` after `Stack.initialize()` returns, so engines are recreated lazily in the correct event loop. Table metadata is preserved across the reset, so `_ensure_engine()` re-creates all tables via `metadata.create_all(checkfirst=True)` on first use.

## Test Plan

New unit tests covering the event loop reset behavior:

```bash
uv run pytest tests/unit/core/test_sqlstore_event_loop.py tests/unit/core/test_inference_store_event_loop.py -x --tb=short -v
```

Output:
```
tests/unit/core/test_sqlstore_event_loop.py::test_reset_engine_clears_state PASSED
tests/unit/core/test_sqlstore_event_loop.py::test_reset_engine_preserves_metadata PASSED
tests/unit/core/test_sqlstore_event_loop.py::test_data_survives_engine_reset PASSED
tests/unit/core/test_sqlstore_event_loop.py::test_engine_reset_across_event_loops PASSED
tests/unit/core/test_inference_store_event_loop.py::test_inference_store_data_persisted_after_event_loop_reset PASSED
tests/unit/core/test_inference_store_event_loop.py::test_inference_store_write_queue_after_event_loop_reset PASSED
tests/unit/core/test_inference_store_event_loop.py::test_inference_store_retrieve_after_event_loop_reset PASSED
7 passed
```

Key test: `test_inference_store_write_queue_after_event_loop_reset` forces `enable_write_queue=True` to simulate the PostgreSQL background worker path that fails without this fix.

Existing tests unaffected:
```bash
uv run pytest tests/unit/core/test_sqlstore_add_column.py tests/unit/utils/inference/test_inference_store.py tests/unit/core/connectors/ -x --tb=short
# 44 passed
```