### PR TITLE
chore: bump fallback_version to 1.0.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "1.0.1.dev0"
+fallback_version = "1.0.2.dev0"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -75,7 +75,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client>=1.0.0", # Optional for library-only usage
+    "ogx-client>=1.0.1", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -139,7 +139,7 @@ dev = [
     "pre-commit>=4.4.0",
     "ruamel.yaml",                   # needed for openapi generator
     "openapi-spec-validator>=0.7.2",
-    "ogx-client>=1.0.0",
+    "ogx-client>=1.0.1",
     "boto3",
     "torch>=2.6.0",
 ]
@@ -178,7 +178,7 @@ type_checking = [
     "langchain-openai",
     "langchain-core",
     "langgraph",
-    "ogx-client>=1.0.0",
+    "ogx-client>=1.0.1",
 ]
 test-common = [
     "aiohttp",

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -92,7 +92,7 @@ ogx_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "1.0.1.dev0"
+fallback_version = "1.0.2.dev0"
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -4302,7 +4302,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.0.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.0.1" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4368,7 +4368,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = ">=1.0.0" },
+    { name = "ogx-client", specifier = ">=1.0.1" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.7.2" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4461,7 +4461,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=1.0.0" },
+    { name = "ogx-client", specifier = ">=1.0.1" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4527,7 +4527,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4546,9 +4546,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/bbcd77921d29dc0a84a4767cc3661d027bfc5db6a0c32a4f82dadc182542/ogx_client-1.0.0.tar.gz", hash = "sha256:a13133105149b77384ba804cc1fa340c1defce9ebb4820e3c593c36b103f0010", size = 435209, upload-time = "2026-05-12T13:58:58.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/ef/8a9d62c755855bd0a62f4d06d6811d693cb334db4e8bbb36e8fcc20c3506/ogx_client-1.0.1.tar.gz", hash = "sha256:ffdffb21896cfe0ebe43753384dc3faddf5c32f704ef7a497416b2078e7170f8", size = 435213, upload-time = "2026-05-13T18:05:25.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/95/2cafdc4e3ff4a89db82862c0e0ed10fed2154ba74c7b16c2a5e371bac5d9/ogx_client-1.0.0-py3-none-any.whl", hash = "sha256:d0ef468f3a46b5bf3af9de3540902aa0d4a0c9d4370444697ca710473843c439", size = 309279, upload-time = "2026-05-12T13:58:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/44/5a10ff00f03f11ba2a9127286e4db28754e4d1617a7e8c93ef8d77b76ea6/ogx_client-1.0.1-py3-none-any.whl", hash = "sha256:2b3dc108a0c244fd4d9e3908968c42ecdc97f8d60b9d1ae45165439b5032dee9", size = 309282, upload-time = "2026-05-13T18:05:23.683Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release version bump after v1.0.1.

Updates fallback_version in both pyproject.toml files to 1.0.2.dev0.

This PR was created automatically by the post-release workflow.