### PR TITLE
chore: update ogx-client to ^1.0.1 in UI lockfile

### DIFF
--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -27,7 +27,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.0.0",
+        "ogx-client": "^1.0.1",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11209,9 +11209,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.0.tgz",
-      "integrity": "sha512-mzPsh9ZLRElCDnddOmnuEuL5OMfd5+LNaV8PN0NrnU9H8ibOEx8NCUSQR3s2ipLTBPNtDopCDyC9VaGQTz9+MQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.1.tgz",
+      "integrity": "sha512-1d5ieUe/ss/DvTpBXYT2Ty+j5JwPmGAsEo+jKkS0FFPKy/jphstfhl+cJGzmWQXONvgBy2wrHGkXbOZkE5y6bw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -51,7 +51,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.0.0",
+    "ogx-client": "^1.0.1",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3973,7 +3973,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.0.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.0.1" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4033,7 +4033,7 @@ dev = [
     { name = "markitdown", extras = ["all"] },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = "==1.0.0" },
+    { name = "ogx-client", specifier = "==1.0.1" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.7.2" },
     { name = "pre-commit", specifier = ">=4.4.0" },
@@ -4110,7 +4110,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = "==1.0.0" },
+    { name = "ogx-client", specifier = "==1.0.1" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4176,7 +4176,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4195,9 +4195,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ed/bbcd77921d29dc0a84a4767cc3661d027bfc5db6a0c32a4f82dadc182542/ogx_client-1.0.0.tar.gz", hash = "sha256:a13133105149b77384ba804cc1fa340c1defce9ebb4820e3c593c36b103f0010", size = 435209, upload-time = "2026-05-12T13:58:58.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/ef/8a9d62c755855bd0a62f4d06d6811d693cb334db4e8bbb36e8fcc20c3506/ogx_client-1.0.1.tar.gz", hash = "sha256:ffdffb21896cfe0ebe43753384dc3faddf5c32f704ef7a497416b2078e7170f8", size = 435213, upload-time = "2026-05-13T18:05:25.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/95/2cafdc4e3ff4a89db82862c0e0ed10fed2154ba74c7b16c2a5e371bac5d9/ogx_client-1.0.0-py3-none-any.whl", hash = "sha256:d0ef468f3a46b5bf3af9de3540902aa0d4a0c9d4370444697ca710473843c439", size = 309279, upload-time = "2026-05-12T13:58:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/44/5a10ff00f03f11ba2a9127286e4db28754e4d1617a7e8c93ef8d77b76ea6/ogx_client-1.0.1-py3-none-any.whl", hash = "sha256:2b3dc108a0c244fd4d9e3908968c42ecdc97f8d60b9d1ae45165439b5032dee9", size = 309282, upload-time = "2026-05-13T18:05:23.683Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release npm lockfile update after v1.0.1.

Updates ogx-client to ^1.0.1 in the UI package lockfile.

This PR was created automatically by the post-release workflow.