### PR TITLE
fix(core): library client streaming request without aclose()

### DIFF
--- a/src/ogx/core/library_client.py
+++ b/src/ogx/core/library_client.py
@@ -323,7 +323,12 @@ class OGXAsLibraryClient(OgxClient):
                         await asyncio.sleep(0.01)
             finally:
                 if async_gen is not None:
-                    await async_gen.aclose()
+                    if hasattr(async_gen, "aclose"):
+                        await async_gen.aclose()
+                    elif hasattr(async_gen, "close"):
+                        close = async_gen.close()
+                        if asyncio.iscoroutine(close):
+                            await close
 
         future = asyncio.run_coroutine_threadsafe(_consume(), self.loop)
 


### PR DESCRIPTION
# What does this PR do?
Fix yet another concurrency issue in the `OGXAsLibraryClient` - discovered by overnight integration tests: [link](https://github.com/ogx-ai/ogx/actions/runs/25834318640/job/75905919243).

I was under the impression that an object that can be iterated over with `async for` has to expose `.aclose()` method. I am proven wrong the first time today, and it's only 5:45 AM at the time of writing :wink: 
It looks like OpenAI's SDK AsyncStream doesn't expose `aclose()`

Modified the existing code to handle graceful shutdown.

## Test Plan
No unit test added — mocking `AsyncStream` without `aclose()` would require importing and faking OpenAI SDK internals. The fix is covered by the overnight integration run that caught the bug.