### PR TITLE
Update agent event logger docs examples

### DIFF
--- a/docs/docs/building_applications/agent.mdx
+++ b/docs/docs/building_applications/agent.mdx
@@ -66,7 +66,7 @@ turn_response = agent.create_turn(
     messages=[{"role": "user", "content": "Tell me about Llama models"}],
 )
 for log in AgentEventLogger().log(turn_response):
-    log.print()
+    print(log, end="", flush=True)
 ```
 
 </TabItem>

--- a/docs/docs/building_applications/agent_execution_loop.mdx
+++ b/docs/docs/building_applications/agent_execution_loop.mdx
@@ -132,7 +132,7 @@ response = agent.create_turn(
 
 # Monitor each step of execution
 for log in AgentEventLogger().log(response):
-    log.print()
+    print(log, end="", flush=True)
 ```
 
 </TabItem>

--- a/docs/docs/building_applications/evals.mdx
+++ b/docs/docs/building_applications/evals.mdx
@@ -65,7 +65,7 @@ for prompt in user_prompts:
     )
 
     for log in AgentEventLogger().log(response):
-        log.print()
+        print(log, end="", flush=True)
 ```
 
 ### 2. Query Agent Execution Steps

--- a/docs/docs/building_applications/tools.mdx
+++ b/docs/docs/building_applications/tools.mdx
@@ -234,7 +234,7 @@ response = agent.create_turn(
     session_id=session_id,
 )
 for log in EventLogger().log(response):
-    log.print()
+    print(log, end="", flush=True)
 ```
 
 </TabItem>

--- a/docs/docs/getting_started/demo_script.py
+++ b/docs/docs/getting_started/demo_script.py
@@ -93,11 +93,7 @@ response = agent.create_turn(
 # Only call `AgentEventLogger().log(response)` for streaming responses.
 if use_stream:
     for log in AgentEventLogger().log(response):
-        if hasattr(log, 'print'):
-            log.print()
-        else:
-            # Print text chunks inline without newlines
-            print(log, end='', flush=True)
+        print(log, end="", flush=True)
     print()  # Final newline at the end
 else:
     print(response)


### PR DESCRIPTION
## Summary
- Update agent docs examples to print `AgentEventLogger().log(...)` string fragments directly
- Remove the stale `log.print()` pattern from related building-application docs and demo script

## Verification
- `npm ci`
- `npm run gen-api-docs all`
- `npm run build` (passes; reports pre-existing broken-link warnings such as `/versions.html`)

References meta-llama/llama-stack-client-python#138