### PR TITLE
fix(conversations): add sort_order column for deterministic item ordering

### DIFF
--- a/src/ogx/core/conversations/conversations.py
+++ b/src/ogx/core/conversations/conversations.py
@@ -94,9 +94,12 @@ class ConversationServiceImpl(Conversations):
                 "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
                 "conversation_id": ColumnType.STRING,
                 "created_at": ColumnType.INTEGER,
+                "sort_order": ColumnType.INTEGER,
                 "item_data": ColumnType.JSON,
             },
         )
+        # Migration for existing databases that lack the sort_order column
+        await self.sql_store.sql_store.add_column_if_not_exists("conversation_items", "sort_order", ColumnType.INTEGER)
 
     async def create_conversation(self, request: CreateConversationRequest) -> Conversation:
         """Create a conversation."""
@@ -125,7 +128,8 @@ class ConversationServiceImpl(Conversations):
                 item_record = {
                     "id": item_id,
                     "conversation_id": conversation_id,
-                    "created_at": base_time + i,
+                    "created_at": base_time,
+                    "sort_order": i,
                     "item_data": item_dict,
                 }
 
@@ -208,24 +212,35 @@ class ConversationServiceImpl(Conversations):
         """Validate conversation ID format and return the conversation if it exists."""
         return await self.get_conversation(GetConversationRequest(conversation_id=conversation_id))
 
+    async def _next_sort_order(self, conversation_id: str) -> int:
+        result = await self.sql_store.fetch_all(
+            table="conversation_items",
+            where={"conversation_id": conversation_id},
+            order_by=[("sort_order", "desc")],
+            limit=1,
+        )
+        if result.data:
+            current_max = result.data[0].get("sort_order")
+            return (current_max + 1) if current_max is not None else 0
+        return 0
+
     async def add_items(self, conversation_id: str, request: AddItemsRequest) -> ConversationItemList:
         """Create (add) items to a conversation."""
         await self._get_validated_conversation(conversation_id)
 
         created_items = []
         base_time = int(time.time())
+        base_sort_order = await self._next_sort_order(conversation_id)
 
         for i, item in enumerate(request.items):
             item_dict = item.model_dump()
             item_id = self._get_or_generate_item_id(item, item_dict)
 
-            # make each timestamp unique to maintain order
-            created_at = base_time + i
-
             item_record = {
                 "id": item_id,
                 "conversation_id": conversation_id,
-                "created_at": created_at,
+                "created_at": base_time,
+                "sort_order": base_sort_order + i,
                 "item_data": item_dict,
             }
 
@@ -287,7 +302,7 @@ class ConversationServiceImpl(Conversations):
         result = await self.sql_store.fetch_all(
             table="conversation_items",
             where={"conversation_id": request.conversation_id},
-            order_by=[("created_at", order)],
+            order_by=[("sort_order", order)],
             cursor=("id", request.after) if request.after else None,
             limit=limit,
         )

--- a/tests/unit/conversations/test_conversations.py
+++ b/tests/unit/conversations/test_conversations.py
@@ -539,6 +539,47 @@ async def test_create_conversation_with_items_supports_pagination(service):
     assert pages == 3
 
 
+async def test_item_ordering_uses_sort_order_not_timestamp(service):
+    """sort_order column must exist and increase monotonically across add_items calls.
+
+    Regression: created_at uses second-precision timestamps, so calls within the
+    same second collide. Ordering must use a dedicated sort_order counter, not
+    created_at. We assert on the column values directly so this fails if
+    sort_order is missing or not populated, regardless of DB-specific row ordering.
+    """
+    from unittest.mock import patch
+
+    conversation = await service.create_conversation(CreateConversationRequest())
+    fixed_time = 1700000000
+
+    with patch("ogx.core.conversations.conversations.time") as mock_time:
+        mock_time.time.return_value = fixed_time
+
+        for i in range(5):
+            items = [
+                OpenAIResponseMessage(
+                    type="message",
+                    role="user",
+                    content=[OpenAIResponseInputMessageContentText(type="input_text", text=f"msg-{i}")],
+                    id=f"msg_{'0' * 44}{i:04d}",
+                    status="completed",
+                )
+            ]
+            await service.add_items(conversation.id, AddItemsRequest(items=items))
+
+    raw = await service.sql_store.fetch_all(
+        table="conversation_items",
+        where={"conversation_id": conversation.id},
+        order_by=[("sort_order", "asc")],
+    )
+
+    sort_orders = [r["sort_order"] for r in raw.data]
+    assert sort_orders == [0, 1, 2, 3, 4]
+
+    timestamps = {r["created_at"] for r in raw.data}
+    assert len(timestamps) == 1, f"All timestamps should be identical, got {timestamps}"
+
+
 async def test_list_items_empty_conversation(service):
     """Listing items on empty conversation returns valid ConversationItemList with empty strings."""
     conversation = await service.create_conversation(CreateConversationRequest())


### PR DESCRIPTION
## Summary
- Adds a `sort_order` INTEGER column to `conversation_items` as a monotonically increasing per-conversation counter
- Replaces `created_at`-based ordering in `list_items` with `sort_order`, eliminating non-deterministic results when multiple `add_items` calls land within the same second
- Includes migration via `add_column_if_not_exists` for existing databases

Closes https://github.com/ogx-ai/ogx/issues/5849

## Test plan
- [x] All 27 existing unit tests pass (`tests/unit/conversations/test_conversations.py`)
- [x] Pagination tests (cursor, has_more, asc/desc) pass with sort_order ordering
- [x] Verified fix with SQLite backend using end-to-end test script
- [x] Verified fix with PostgreSQL backend
- [ ] Run full integration test suite