### PR TITLE
chore: remove leftover Meta copyright headers

### DIFF
--- a/scripts/openapi_generator/multi_sdk.py
+++ b/scripts/openapi_generator/multi_sdk.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """
 Multi-SDK response schema transforms for OpenAPI generation.
 

--- a/tests/evals/multitenant/bench_e2e_latency.py
+++ b/tests/evals/multitenant/bench_e2e_latency.py
@@ -5,12 +5,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """
 End-to-end latency benchmark for OGX on OpenShift.
 

--- a/tests/evals/multitenant/bench_predicate_pushdown.py
+++ b/tests/evals/multitenant/bench_predicate_pushdown.py
@@ -5,12 +5,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """
 Predicate pushdown vs post-retrieval filtering benchmark.
 

--- a/tests/evals/multitenant/conftest.py
+++ b/tests/evals/multitenant/conftest.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """
 Shared fixtures for multitenant security and retrieval evaluations.
 

--- a/tests/integration/messages/test_message_batches.py
+++ b/tests/integration/messages/test_message_batches.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """Integration tests for the Anthropic Message Batches API.
 
 Covers POST/GET/cancel/results under /v1/messages/batches. Each batch request

--- a/tests/unit/providers/inference/test_openai_mixin_streaming_usage.py
+++ b/tests/unit/providers/inference/test_openai_mixin_streaming_usage.py
@@ -4,12 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the terms described in the LICENSE file in
-# the root directory of this source tree.
-
 """Tests for OpenAIMixin.coalesce_streaming_usage behavior.
 
 Some OpenAI-compatible providers (notably Gemini's endpoint) violate the OpenAI


### PR DESCRIPTION
# What does this PR do?

Removes duplicate "Copyright (c) Meta Platforms, Inc. and affiliates" blocks from six files that already carry the correct OGX Contributors copyright header. No functional changes.

## Test Plan

Pre-commit checks pass (`uv run pre-commit run --all-files`). Verified with grep that no `Meta Platforms` references remain in the codebase.