### PR TITLE
fix(ci): update constraint deps script to handle missing and regular dependencies

### DIFF
--- a/.github/scripts/update_constraint_deps.py
+++ b/.github/scripts/update_constraint_deps.py
@@ -5,11 +5,16 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-"""Update constraint-dependencies in pyproject.toml for Dependabot PRs.
+"""Update dependency version floors in pyproject.toml for Dependabot PRs.
 
 Dependabot's uv ecosystem only modifies uv.lock directly. This script
-updates the >= lower bound in [tool.uv] constraint-dependencies so that
-pyproject.toml remains the source of truth.
+keeps pyproject.toml in sync by updating the >= lower bound wherever the
+dependency is declared:
+
+1. If found in a regular dependency array ([project] dependencies,
+   [project.optional-dependencies], [dependency-groups]) — update in place.
+2. Else if found in [tool.uv] constraint-dependencies — update in place.
+3. Else — add a new entry to constraint-dependencies.
 """
 
 import argparse
@@ -49,6 +54,51 @@ def find_constraint_line(lines: list[str], pkg_name: str) -> int | None:
         if pattern.match(lines[i]):
             return i
     return None
+
+
+def find_dependency_lines(lines: list[str], pkg_name: str) -> list[int]:
+    """Find all dependency lines for a package outside constraint-dependencies."""
+    constraint_section = find_constraint_section(lines)
+    exclude_start, exclude_end = constraint_section if constraint_section else (-1, -1)
+
+    pattern = re.compile(rf'^\s*"{normalize_pkg_pattern(pkg_name)}[\[>=<,"\s]', re.IGNORECASE)
+    matches = []
+    for i, line in enumerate(lines):
+        if exclude_start <= i <= exclude_end:
+            continue
+        if pattern.match(line):
+            matches.append(i)
+    return matches
+
+
+def _canonical_sort_key(line: str) -> str:
+    """Extract the package name from a constraint line for alphabetical sorting."""
+    m = re.match(r'^\s*"([^>=<\[" ]+)', line)
+    return m.group(1).lower().replace("-", "").replace("_", "").replace(".", "") if m else ""
+
+
+def insert_constraint(lines: list[str], pkg_name: str, version: str) -> tuple[list[str], bool, str]:
+    """Insert a new constraint-dependencies entry in alphabetical order.
+
+    Returns (new_lines, changed, reason).
+    """
+    section = find_constraint_section(lines)
+    if section is None:
+        return lines, False, "constraint-dependencies section not found in pyproject.toml"
+
+    start, end = section
+
+    new_entry = f'    "{pkg_name}>={version}",\n'
+    new_key = _canonical_sort_key(new_entry)
+
+    insert_at = end
+    for i in range(start + 1, end + 1):
+        if _canonical_sort_key(lines[i]) > new_key:
+            insert_at = i
+            break
+
+    lines.insert(insert_at, new_entry)
+    return lines, True, f"{pkg_name}: added to constraint-dependencies with >={version}"
 
 
 def update_constraint(line: str, pkg_name: str, new_version: str) -> tuple[str, bool, str]:
@@ -96,22 +146,53 @@ def main() -> int:
     content = pyproject_path.read_text()
     lines = content.splitlines(keepends=True)
 
-    line_idx = find_constraint_line(lines, args.dependency_name)
-    if line_idx is None:
-        print(f"SKIP: {args.dependency_name} not found in constraint-dependencies")
-        print("updated=false")
+    constraint_idx = find_constraint_line(lines, args.dependency_name)
+    dep_indices = find_dependency_lines(lines, args.dependency_name)
+
+    # 1. If in constraint-dependencies, that's the authoritative version spec — update there
+    if constraint_idx is not None:
+        new_line, changed, reason = update_constraint(
+            lines[constraint_idx], args.dependency_name, args.dependency_version
+        )
+        if not changed:
+            print(f"SKIP: {reason}")
+            print("updated=false")
+            return 0
+        lines[constraint_idx] = new_line
+        pyproject_path.write_text("".join(lines))
+        print(f"UPDATED: {reason}")
+        print("updated=true")
         return 0
 
-    new_line, changed, reason = update_constraint(lines[line_idx], args.dependency_name, args.dependency_version)
+    # 2. Try updating >= floors in regular dependency arrays
+    if dep_indices:
+        any_changed = False
+        skip_reasons = []
+        for idx in dep_indices:
+            new_line, changed, reason = update_constraint(lines[idx], args.dependency_name, args.dependency_version)
+            if changed:
+                lines[idx] = new_line
+                any_changed = True
+                print(f"UPDATED (dependencies): {reason}")
+            else:
+                skip_reasons.append(reason)
+        if any_changed:
+            pyproject_path.write_text("".join(lines))
+            print("updated=true")
+        else:
+            for r in skip_reasons:
+                print(f"SKIP (dependencies): {r}")
+            print("updated=false")
+        return 0
 
+    # 3. Not found anywhere — add to constraint-dependencies
+    lines, changed, reason = insert_constraint(lines, args.dependency_name, args.dependency_version)
     if not changed:
         print(f"SKIP: {reason}")
         print("updated=false")
         return 0
-
-    lines[line_idx] = new_line
     pyproject_path.write_text("".join(lines))
-    print(f"UPDATED: {reason}")
+    print(f"ADDED: {reason}")
     print("updated=true")
     return 0
 

--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -68,7 +68,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Parsed: $dep_name $dep_version"
 
-      - name: Update constraint-dependencies in pyproject.toml
+      - name: Update dependency version floors in pyproject.toml
         if: steps.parse.outputs.skip != 'true'
         id: update
         env:

--- a/tests/unit/test_update_constraint_deps.py
+++ b/tests/unit/test_update_constraint_deps.py
@@ -20,6 +20,8 @@ parse_version = _mod.parse_version
 normalize_pkg_pattern = _mod.normalize_pkg_pattern
 find_constraint_section = _mod.find_constraint_section
 find_constraint_line = _mod.find_constraint_line
+find_dependency_lines = _mod.find_dependency_lines
+insert_constraint = _mod.insert_constraint
 update_constraint = _mod.update_constraint
 main = _mod.main
 
@@ -43,6 +45,17 @@ SAMPLE_PYPROJECT = textwrap.dedent("""\
     dependencies = [
         "requests>=2.28.0",
         "pydantic>=2.11.9",
+    ]
+
+    [project.optional-dependencies]
+    starter = [
+        "aiohttp",
+        "google-genai>=1.69.0",
+    ]
+
+    [dependency-groups]
+    test = [
+        "google-genai>=1.69.0",
     ]
 """)
 
@@ -135,6 +148,78 @@ class TestFindConstraintLine:
         assert find_constraint_line(lines, "nonexistent-pkg") is None
 
 
+class TestFindDependencyLines:
+    def test_finds_in_project_dependencies(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        indices = find_dependency_lines(lines, "requests")
+        assert len(indices) == 1
+        assert "requests" in lines[indices[0]]
+
+    def test_finds_in_optional_and_groups(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        indices = find_dependency_lines(lines, "google-genai")
+        assert len(indices) == 2
+        for idx in indices:
+            assert "google-genai" in lines[idx]
+
+    def test_excludes_constraint_dependencies(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        indices = find_dependency_lines(lines, "urllib3")
+        assert len(indices) == 0
+
+    def test_finds_bare_dep_without_version(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        indices = find_dependency_lines(lines, "aiohttp")
+        assert len(indices) == 1
+        assert '"aiohttp"' in lines[indices[0]]
+
+    def test_returns_empty_for_unknown(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        assert find_dependency_lines(lines, "nonexistent") == []
+
+
+class TestInsertConstraint:
+    def test_inserts_alphabetically_middle(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        new_lines, changed, reason = insert_constraint(lines, "google-genai", "2.3.0")
+        assert changed is True
+        assert "added to constraint-dependencies" in reason
+        joined = "".join(new_lines)
+        assert '"google-genai>=2.3.0"' in joined
+        constraint_lines = [line.strip() for line in new_lines if "google-genai" in line or "litellm" in line]
+        assert constraint_lines.index('    "google-genai>=2.3.0",'.strip()) < constraint_lines.index(
+            '    "litellm<1.83.7",                  # upper-bound only'.strip()
+        )
+
+    def test_inserts_alphabetically_beginning(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        new_lines, changed, _ = insert_constraint(lines, "aaa-first", "1.0.0")
+        assert changed is True
+        joined = "".join(new_lines)
+        aaa_pos = joined.index('"aaa-first>=1.0.0"')
+        aiohttp_pos = joined.index('"aiohttp>=')
+        assert aaa_pos < aiohttp_pos
+
+    def test_inserts_alphabetically_end(self):
+        lines = SAMPLE_PYPROJECT.splitlines(keepends=True)
+        new_lines, changed, _ = insert_constraint(lines, "zzz-last", "1.0.0")
+        assert changed is True
+        joined = "".join(new_lines)
+        zzz_pos = joined.index('"zzz-last>=1.0.0"')
+        urllib3_pos = joined.index('"urllib3>=')
+        assert zzz_pos > urllib3_pos
+
+    def test_returns_false_when_no_constraint_section(self):
+        lines = textwrap.dedent("""\
+            [project]
+            name = "no-constraints"
+            dependencies = ["requests"]
+        """).splitlines(keepends=True)
+        _, changed, reason = insert_constraint(lines, "pkg", "1.0.0")
+        assert changed is False
+        assert "not found" in reason
+
+
 class TestUpdateConstraint:
     def test_updates_lower_bound(self):
         line = '    "aiohttp>=3.13.4",                # CVE-2026-34514\n'
@@ -221,7 +306,8 @@ class TestMainCli:
         assert "aiohttp>=3.14.0" in content
         assert "CVE-2026-34514" in content
 
-    def test_skips_unknown_package(self, tmp_path):
+    def test_updates_dependency_in_place(self, tmp_path):
+        """A dep in optional-dependencies/dependency-groups gets updated in place."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(SAMPLE_PYPROJECT)
 
@@ -230,7 +316,32 @@ class TestMainCli:
                 "python3",
                 str(_script_path),
                 "--dependency-name",
-                "nonexistent",
+                "google-genai",
+                "--dependency-version",
+                "2.3.0",
+                "--pyproject",
+                str(pyproject),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "updated=true" in result.stdout
+        assert "UPDATED (dependencies)" in result.stdout
+        content = pyproject.read_text()
+        assert content.count("google-genai>=2.3.0") == 2
+        assert "google-genai>=1.69.0" not in content
+
+    def test_adds_unknown_package(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(SAMPLE_PYPROJECT)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(_script_path),
+                "--dependency-name",
+                "some-new-pkg",
                 "--dependency-version",
                 "1.0.0",
                 "--pyproject",
@@ -240,8 +351,10 @@ class TestMainCli:
             text=True,
         )
         assert result.returncode == 0
-        assert "updated=false" in result.stdout
-        assert pyproject.read_text() == SAMPLE_PYPROJECT
+        assert "updated=true" in result.stdout
+        assert "ADDED" in result.stdout
+        content = pyproject.read_text()
+        assert '"some-new-pkg>=1.0.0"' in content
 
     def test_skips_upper_bound_conflict(self, tmp_path):
         pyproject = tmp_path / "pyproject.toml"
@@ -265,9 +378,9 @@ class TestMainCli:
         assert "updated=false" in result.stdout
         assert "pydantic>=2.11.9,<2.12.0" in pyproject.read_text()
 
-    def test_does_not_modify_project_dependencies(self, tmp_path):
-        """Updating a package that exists in [project] dependencies but not in
-        constraint-dependencies must not touch pyproject.toml."""
+    def test_updates_project_dependency_in_place(self, tmp_path):
+        """A package in [project] dependencies gets updated in place, not added
+        to constraint-dependencies."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(SAMPLE_PYPROJECT)
 
@@ -286,8 +399,61 @@ class TestMainCli:
             text=True,
         )
         assert result.returncode == 0
+        assert "updated=true" in result.stdout
+        assert "UPDATED (dependencies)" in result.stdout
+        content = pyproject.read_text()
+        assert "requests>=2.32.0" in content
+
+    def test_skips_dep_in_deps_when_version_not_newer(self, tmp_path):
+        """A dep in dependencies with a >= floor should skip when the new version
+        is not newer, and NOT fall through to add to constraint-dependencies."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(SAMPLE_PYPROJECT)
+        original = pyproject.read_text()
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(_script_path),
+                "--dependency-name",
+                "google-genai",
+                "--dependency-version",
+                "1.50.0",
+                "--pyproject",
+                str(pyproject),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
         assert "updated=false" in result.stdout
-        assert pyproject.read_text() == SAMPLE_PYPROJECT
+        assert pyproject.read_text() == original
+
+    def test_bare_dep_falls_through_to_constraint(self, tmp_path):
+        """A dep without a >= floor in dependencies falls through to
+        constraint-dependencies if present there."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(SAMPLE_PYPROJECT)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(_script_path),
+                "--dependency-name",
+                "aiohttp",
+                "--dependency-version",
+                "3.14.0",
+                "--pyproject",
+                str(pyproject),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "updated=true" in result.stdout
+        content = pyproject.read_text()
+        assert "aiohttp>=3.14.0" in content
+        assert "CVE-2026-34514" in content
 
     def test_missing_pyproject_returns_error(self, tmp_path):
         result = subprocess.run(


### PR DESCRIPTION
# What does this PR do?

The Dependabot constraint-update workflow was silently skipping dependencies not already listed in `constraint-dependencies` (e.g. `google-genai`), causing Dependabot PRs to miss version floor updates in `pyproject.toml`. See [CI run](https://github.com/ogx-ai/ogx/actions/runs/25972495462/job/76346870212) for the `SKIP: google-genai not found in constraint-dependencies` output.

This PR teaches the `update_constraint_deps.py` script a three-way lookup strategy:

1. **constraint-dependencies** (checked first, authoritative) — if found, update the `>=` floor there. Upper-bound constraints like `<2.12.0` are respected.
2. **Regular dependency arrays** (`[project] dependencies`, `[project.optional-dependencies]`, `[dependency-groups]`) — if found with a `>=` floor, update all occurrences in place.
3. **Neither** — insert a new entry into `constraint-dependencies` in alphabetical order.

Also adds `find_dependency_lines()` to search all non-constraint dependency arrays, and `insert_constraint()` for alphabetically-ordered insertion.

## Test Plan

Unit tests expanded from 31 to 42, covering all three lookup paths, alphabetical insertion edge cases, and the fall-through behavior when a bare dep (no `>=` floor) exists in regular deps but a floor exists in constraint-deps.

```bash
uv run pytest tests/unit/test_update_constraint_deps.py -x --tb=short -v
```

Output:
```
42 passed in 1.62s
```

Pre-commit:
```bash
uv run pre-commit run --all-files
# All hooks passed
```