### PR TITLE
feat(tests): add e2e test suite for Responses API with real vLLM + PostgreSQL

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -167,7 +167,7 @@ jobs:
       # called from pull_request_target workflows.
       - name: Setup test environment
         if: ${{ matrix.config.allowed_clients == null || contains(matrix.config.allowed_clients, matrix.client) }}
-        uses: ogx-ai/ogx/.github/actions/setup-test-environment@68c0994a790e4f029007f3cce12a744d69a7d435
+        uses: ogx-ai/ogx/.github/actions/setup-test-environment@2d57aacb987e484a90441ac0a9d86439298a5820
         with:
           python-version: ${{ matrix.python-version }}
           client-version: ${{ matrix.client-version }}

--- a/scripts/generate_ci_matrix.py
+++ b/scripts/generate_ci_matrix.py
@@ -31,7 +31,7 @@ PROVIDER_PATH_TO_SETUPS: list[tuple[str, list[str]]] = [
     ("src/ogx/providers/remote/inference/openai/", ["gpt", "gpt-reasoning"]),
     ("src/ogx/providers/remote/inference/azure/", ["azure"]),
     ("src/ogx/providers/remote/inference/bedrock/", ["bedrock"]),
-    ("src/ogx/providers/remote/inference/vllm/", ["vllm"]),
+    ("src/ogx/providers/remote/inference/vllm/", ["vllm", "vllm-postgres"]),
     ("src/ogx/providers/remote/inference/watsonx/", ["watsonx"]),
     ("src/ogx/providers/remote/inference/vertexai/", ["vertexai"]),
     ("src/ogx/providers/remote/inference/gemini/", ["gemini"]),
@@ -45,6 +45,9 @@ CORE_PATHS = [
     "src/ogx/providers/inline/agents/",
     "src/ogx_api/",
     "tests/integration/conftest",
+    "tests/integration/e2e/",
+    "tests/integration/suites.py",
+    "tests/integration/ci_matrix.json",
 ]
 
 

--- a/tests/integration/ci_matrix.json
+++ b/tests/integration/ci_matrix.json
@@ -11,6 +11,7 @@
     {"suite": "responses", "setup": "vertexai"},
     {"suite": "bedrock-responses", "setup": "bedrock"},
     {"suite": "base-vllm-subset", "setup": "vllm"},
+    {"suite": "responses-e2e", "setup": "vllm-postgres", "allowed_clients": ["server"], "stack_config": "server:ci-tests::run-with-postgres-store.yaml", "inference_mode": "live"},
     {"suite": "vllm-reasoning", "setup": "vllm"},
     {"suite": "ollama-reasoning", "setup": "ollama-reasoning"},
     {"suite": "messages", "setup": "ollama"},

--- a/tests/integration/e2e/__init__.py
+++ b/tests/integration/e2e/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import os
 
 import asyncpg
@@ -20,42 +21,39 @@ def pytest_configure(config):
     os.environ["OGX_TEST_LOG_STDERR"] = "0"
 
 
-@pytest.fixture(scope="session")
-def pg_conn():
-    """Direct asyncpg connection to the test PostgreSQL database.
+class SyncDB:
+    """Synchronous wrapper around an asyncpg connection.
 
-    Returns a synchronous wrapper so non-async tests can query the DB.
+    Uses a single event loop for both the connection and all queries
+    to avoid asyncpg's "attached to a different loop" error.
     """
-    import asyncio
 
-    async def _connect():
-        return await asyncpg.connect(
-            host=os.environ.get("POSTGRES_HOST", "127.0.0.1"),
-            port=int(os.environ.get("POSTGRES_PORT", "5432")),
-            database=os.environ.get("POSTGRES_DB", "ogx"),
-            user=os.environ.get("POSTGRES_USER", "ogx"),
-            password=os.environ.get("POSTGRES_PASSWORD", "ogx"),
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+        self._conn = self._loop.run_until_complete(
+            asyncpg.connect(
+                host=os.environ.get("POSTGRES_HOST", "127.0.0.1"),
+                port=int(os.environ.get("POSTGRES_PORT", "5432")),
+                database=os.environ.get("POSTGRES_DB", "ogx"),
+                user=os.environ.get("POSTGRES_USER", "ogx"),
+                password=os.environ.get("POSTGRES_PASSWORD", "ogx"),
+            )
         )
 
-    conn = asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_connect())
-    yield conn
-    asyncio.get_event_loop_policy().new_event_loop().run_until_complete(conn.close())
+    def fetchrow(self, query, *args):
+        return self._loop.run_until_complete(self._conn.fetchrow(query, *args))
+
+    def fetch(self, query, *args):
+        return self._loop.run_until_complete(self._conn.fetch(query, *args))
+
+    def close(self):
+        self._loop.run_until_complete(self._conn.close())
+        self._loop.close()
 
 
-@pytest.fixture
-def db(pg_conn):
-    """Helper that wraps pg_conn with a sync query method."""
-    import asyncio
-
-    class SyncDB:
-        def __init__(self, conn):
-            self._conn = conn
-            self._loop = asyncio.new_event_loop()
-
-        def fetchrow(self, query, *args):
-            return self._loop.run_until_complete(self._conn.fetchrow(query, *args))
-
-        def fetch(self, query, *args):
-            return self._loop.run_until_complete(self._conn.fetch(query, *args))
-
-    return SyncDB(pg_conn)
+@pytest.fixture(scope="session")
+def db():
+    """Direct PostgreSQL connection for verifying data persistence."""
+    sync_db = SyncDB()
+    yield sync_db
+    sync_db.close()

--- a/tests/integration/e2e/conftest.py
+++ b/tests/integration/e2e/conftest.py
@@ -1,0 +1,61 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import os
+
+import asyncpg
+import pytest
+
+# Import fixtures from common module to make them available in this test directory
+from tests.integration.fixtures.common import (  # noqa: F401
+    openai_client,
+    require_server,
+)
+
+
+def pytest_configure(config):
+    os.environ["OGX_TEST_LOG_STDERR"] = "0"
+
+
+@pytest.fixture(scope="session")
+def pg_conn():
+    """Direct asyncpg connection to the test PostgreSQL database.
+
+    Returns a synchronous wrapper so non-async tests can query the DB.
+    """
+    import asyncio
+
+    async def _connect():
+        return await asyncpg.connect(
+            host=os.environ.get("POSTGRES_HOST", "127.0.0.1"),
+            port=int(os.environ.get("POSTGRES_PORT", "5432")),
+            database=os.environ.get("POSTGRES_DB", "ogx"),
+            user=os.environ.get("POSTGRES_USER", "ogx"),
+            password=os.environ.get("POSTGRES_PASSWORD", "ogx"),
+        )
+
+    conn = asyncio.get_event_loop_policy().new_event_loop().run_until_complete(_connect())
+    yield conn
+    asyncio.get_event_loop_policy().new_event_loop().run_until_complete(conn.close())
+
+
+@pytest.fixture
+def db(pg_conn):
+    """Helper that wraps pg_conn with a sync query method."""
+    import asyncio
+
+    class SyncDB:
+        def __init__(self, conn):
+            self._conn = conn
+            self._loop = asyncio.new_event_loop()
+
+        def fetchrow(self, query, *args):
+            return self._loop.run_until_complete(self._conn.fetchrow(query, *args))
+
+        def fetch(self, query, *args):
+            return self._loop.run_until_complete(self._conn.fetch(query, *args))
+
+    return SyncDB(pg_conn)

--- a/tests/integration/e2e/test_agentic_loop_e2e.py
+++ b/tests/integration/e2e/test_agentic_loop_e2e.py
@@ -1,0 +1,324 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+End-to-end tests for the agentic loop with real vLLM inference and PostgreSQL persistence.
+
+These tests validate that the full tool-calling loop works against real infrastructure:
+model emits function call → client provides output → model continues → state persisted in PostgreSQL.
+"""
+
+import json
+import time
+
+import pytest
+
+WEATHER_TOOL = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get current temperature for a given location.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "location": {
+                "type": "string",
+                "description": "City name, e.g. 'Paris'",
+            },
+        },
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+}
+
+LOOKUP_TOOL = {
+    "type": "function",
+    "name": "lookup_employee",
+    "description": "Look up an employee by name and return their department and role.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Employee name",
+            },
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _wait_for_db_row(db, table, id_value, timeout=10):
+    """Poll the database until a row appears (async writes may lag slightly)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        row = db.fetchrow(f"SELECT * FROM {table} WHERE id = $1", id_value)  # noqa: S608
+        if row is not None:
+            return row
+        time.sleep(0.5)
+    raise AssertionError(f"Row {id_value} not found in {table} within {timeout}s")
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(180, method="thread")
+class TestAgenticLoopE2E:
+    """E2E tests for the agentic tool-calling loop with real inference and persistence."""
+
+    def test_single_tool_round_trip(self, openai_client, text_model_id, db):
+        """Model calls a tool, client provides output, model responds — verify DB persistence."""
+        response1 = openai_client.responses.create(
+            model=text_model_id,
+            input="What is the weather in Tokyo? YOU MUST USE the get_weather function.",
+            tools=[WEATHER_TOOL],
+            stream=False,
+        )
+
+        function_calls = [o for o in response1.output if o.type == "function_call"]
+        assert len(function_calls) >= 1, f"Expected function_call, got types: {[o.type for o in response1.output]}"
+
+        call = function_calls[0]
+        assert call.name == "get_weather"
+        assert call.status == "completed"
+        args = json.loads(call.arguments)
+        assert "tokyo" in args.get("location", "").lower() or "Tokyo" in args.get("location", "")
+
+        response2 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": call.call_id,
+                    "output": "It is sunny and 28 degrees Celsius in Tokyo.",
+                },
+            ],
+            tools=[WEATHER_TOOL],
+            previous_response_id=response1.id,
+            stream=False,
+        )
+
+        assert response2.output[0].type == "message"
+        assert len(response2.output_text.strip()) > 0
+
+        row1 = _wait_for_db_row(db, "responses", response1.id)
+        resp_obj1 = (
+            json.loads(row1["response_object"]) if isinstance(row1["response_object"], str) else row1["response_object"]
+        )
+        assert resp_obj1["status"] == "completed"
+        output_types1 = [o["type"] for o in resp_obj1["output"]]
+        assert "function_call" in output_types1
+
+        row2 = _wait_for_db_row(db, "responses", response2.id)
+        resp_obj2 = (
+            json.loads(row2["response_object"]) if isinstance(row2["response_object"], str) else row2["response_object"]
+        )
+        assert resp_obj2["status"] == "completed"
+        assert row2["previous_response_id"] == response1.id
+
+    def test_tool_round_trip_streaming(self, openai_client, text_model_id, db):
+        """Streaming agentic loop — verify events, persistence, and DB state."""
+        with openai_client.responses.create(
+            model=text_model_id,
+            input="What is the weather in Paris? YOU MUST USE the get_weather function.",
+            tools=[WEATHER_TOOL],
+            stream=True,
+        ) as stream:
+            events = list(stream)
+
+        created_event = next((e for e in events if e.type == "response.created"), None)
+        assert created_event is not None
+        response_id = created_event.response.id
+
+        completed_event = next((e for e in events if e.type == "response.completed"), None)
+        assert completed_event is not None
+        response1 = completed_event.response
+
+        function_calls = [o for o in response1.output if o.type == "function_call"]
+        assert len(function_calls) >= 1
+        call = function_calls[0]
+
+        retrieved = openai_client.responses.retrieve(response_id=response_id)
+        retrieved_calls = [o for o in retrieved.output if o.type == "function_call"]
+        assert len(retrieved_calls) >= 1
+        assert retrieved_calls[0].call_id == call.call_id
+
+        response2 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": call.call_id,
+                    "output": "It is rainy and 15 degrees Celsius in Paris.",
+                },
+            ],
+            tools=[WEATHER_TOOL],
+            previous_response_id=response1.id,
+            stream=False,
+        )
+        assert len(response2.output_text.strip()) > 0
+
+        row = _wait_for_db_row(db, "responses", response_id)
+        resp_obj = (
+            json.loads(row["response_object"]) if isinstance(row["response_object"], str) else row["response_object"]
+        )
+        assert resp_obj["status"] == "completed"
+
+    def test_tool_state_persisted_across_turns(self, openai_client, text_model_id, db):
+        """Verify the full tool call chain is persisted in PostgreSQL."""
+        response1 = openai_client.responses.create(
+            model=text_model_id,
+            input="What is the weather in London? YOU MUST USE the get_weather function.",
+            tools=[WEATHER_TOOL],
+            stream=False,
+        )
+        function_calls = [o for o in response1.output if o.type == "function_call"]
+        assert len(function_calls) >= 1
+        call = function_calls[0]
+
+        response2 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": call.call_id,
+                    "output": "It is foggy and 12 degrees Celsius in London.",
+                },
+            ],
+            tools=[WEATHER_TOOL],
+            previous_response_id=response1.id,
+            stream=False,
+        )
+
+        row1 = _wait_for_db_row(db, "responses", response1.id)
+        row2 = _wait_for_db_row(db, "responses", response2.id)
+
+        resp_obj1 = (
+            json.loads(row1["response_object"]) if isinstance(row1["response_object"], str) else row1["response_object"]
+        )
+        resp_obj2 = (
+            json.loads(row2["response_object"]) if isinstance(row2["response_object"], str) else row2["response_object"]
+        )
+
+        call_ids = [o["call_id"] for o in resp_obj1["output"] if o["type"] == "function_call"]
+        assert call.call_id in call_ids
+
+        assert resp_obj2["status"] == "completed"
+        assert row2["previous_response_id"] == response1.id
+        output_types2 = [o["type"] for o in resp_obj2["output"]]
+        assert "message" in output_types2
+
+    def test_multi_tool_conversation_with_persistence(self, openai_client, text_model_id, db):
+        """Multi-turn agentic conversation: two tool cycles, all four responses in DB."""
+        response1 = openai_client.responses.create(
+            model=text_model_id,
+            input="What is the weather in Berlin? YOU MUST USE the get_weather function.",
+            tools=[WEATHER_TOOL],
+            stream=False,
+        )
+        calls1 = [o for o in response1.output if o.type == "function_call"]
+        assert len(calls1) >= 1
+
+        response2 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": calls1[0].call_id,
+                    "output": "It is snowing and -2 degrees Celsius in Berlin.",
+                },
+            ],
+            tools=[WEATHER_TOOL],
+            previous_response_id=response1.id,
+            stream=False,
+        )
+        assert response2.output[0].type == "message"
+
+        response3 = openai_client.responses.create(
+            model=text_model_id,
+            input="Now check Madrid. YOU MUST USE the get_weather function.",
+            tools=[WEATHER_TOOL],
+            previous_response_id=response2.id,
+            stream=False,
+        )
+        calls3 = [o for o in response3.output if o.type == "function_call"]
+        assert len(calls3) >= 1
+
+        response4 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": calls3[0].call_id,
+                    "output": "It is sunny and 22 degrees Celsius in Madrid.",
+                },
+            ],
+            tools=[WEATHER_TOOL],
+            previous_response_id=response3.id,
+            stream=False,
+        )
+        assert response4.output[0].type == "message"
+
+        for resp_id in [response1.id, response2.id, response3.id, response4.id]:
+            row = _wait_for_db_row(db, "responses", resp_id)
+            resp_obj = (
+                json.loads(row["response_object"])
+                if isinstance(row["response_object"], str)
+                else row["response_object"]
+            )
+            assert resp_obj["status"] == "completed"
+
+        row4 = db.fetchrow("SELECT previous_response_id FROM responses WHERE id = $1", response4.id)
+        assert row4["previous_response_id"] == response3.id
+
+    def test_agentic_loop_with_conversation(self, openai_client, text_model_id, db):
+        """Agentic loop inside a conversation — verify tool state in conversation items table."""
+        conversation = openai_client.conversations.create()
+
+        response1 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "role": "user",
+                    "content": "Look up the employee named Alice. YOU MUST USE the lookup_employee function.",
+                }
+            ],
+            tools=[LOOKUP_TOOL],
+            conversation=conversation.id,
+            stream=False,
+        )
+        calls = [o for o in response1.output if o.type == "function_call"]
+        assert len(calls) >= 1
+        assert calls[0].name == "lookup_employee"
+
+        response2 = openai_client.responses.create(
+            model=text_model_id,
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": calls[0].call_id,
+                    "output": "Alice works in the Engineering department as a Senior Developer.",
+                },
+            ],
+            tools=[LOOKUP_TOOL],
+            conversation=conversation.id,
+            stream=False,
+        )
+        assert response2.output[0].type == "message"
+        assert "engineering" in response2.output_text.lower() or "senior" in response2.output_text.lower()
+
+        items = openai_client.conversations.items.list(conversation.id)
+        assert len(items.data) >= 3
+
+        conv_row = db.fetchrow(
+            "SELECT id FROM openai_conversations WHERE id = $1",
+            conversation.id,
+        )
+        assert conv_row is not None, f"Conversation {conversation.id} not found in openai_conversations table"
+
+        conv_items = db.fetch(
+            "SELECT id, sort_order FROM conversation_items WHERE conversation_id = $1 ORDER BY sort_order",
+            conversation.id,
+        )
+        assert len(conv_items) >= 3, f"Expected >= 3 conversation items in DB, got {len(conv_items)}"

--- a/tests/integration/suites.py
+++ b/tests/integration/suites.py
@@ -97,6 +97,23 @@ SETUP_DEFINITIONS: dict[str, Setup] = {
             "rerank_model": "vllm/Qwen/Qwen3-Reranker-0.6B",
         },
     ),
+    "vllm-postgres": Setup(
+        name="vllm-postgres",
+        description="vLLM inference with PostgreSQL-backed persistence (full e2e)",
+        env={
+            "VLLM_URL": "http://localhost:8000/v1",
+            "POSTGRES_HOST": "127.0.0.1",
+            "POSTGRES_PORT": "5432",
+            "POSTGRES_DB": "ogx",
+            "POSTGRES_USER": "ogx",
+            "POSTGRES_PASSWORD": "ogx",
+        },
+        defaults={
+            "text_model": "vllm/Qwen/Qwen3-0.6B",
+            "embedding_model": "sentence-transformers/nomic-embed-text-v1.5",
+            "rerank_model": "vllm/Qwen/Qwen3-Reranker-0.6B",
+        },
+    ),
     "ollama-reasoning": Setup(
         name="ollama",
         description="Local Ollama provider with a reasoning-capable model (deepseek-r1)",
@@ -261,7 +278,8 @@ base_roots = [
     str(p)
     for p in this_dir.glob("*")
     if p.is_dir()
-    and p.name not in ("__pycache__", "fixtures", "test_cases", "recordings", "responses", "messages", "interactions")
+    and p.name
+    not in ("__pycache__", "fixtures", "test_cases", "recordings", "responses", "messages", "interactions", "e2e")
 ]
 
 SUITE_DEFINITIONS: dict[str, Suite] = {
@@ -274,6 +292,18 @@ SUITE_DEFINITIONS: dict[str, Suite] = {
         name="base-vllm-subset",
         roots=["tests/integration/inference"],
         default_setup="vllm",
+    ),
+    "responses-e2e": Suite(
+        name="responses-e2e",
+        roots=[
+            "tests/integration/responses/test_basic_responses.py",
+            "tests/integration/responses/test_conversation_responses.py",
+            "tests/integration/responses/test_responses_errors.py",
+            "tests/integration/responses/test_compact_responses.py",
+            "tests/integration/responses/test_prompt_templates.py",
+            "tests/integration/e2e",
+        ],
+        default_setup="vllm-postgres",
     ),
     "responses": Suite(
         name="responses",


### PR DESCRIPTION
# What does this PR do?

Adds a `responses-e2e` CI lane that exercises the full Responses API stack against real infrastructure: real OGX server, real vLLM CPU inference (Qwen3-0.6B), and real PostgreSQL persistence — running in live mode (no recording/replay). This closes a critical GA gap where no test validated that responses are actually persisted in PostgreSQL and retrievable across the agentic tool-calling loop.

The suite reuses existing response test files (basic, conversations, errors, compact, prompts) and adds focused agentic loop tests with direct PostgreSQL assertions proving data lands in the database.

## Test Plan

1. **Pre-commit checks pass** on all new/modified files
2. **Unit tests pass** (2319 passed, no regressions)
3. **Test collection verified** — all 5 new e2e tests collect correctly
4. **CI validation** — the new matrix entry should trigger the `responses-e2e` lane in the Integration Tests workflow with:

```bash
uv run --no-sync ./scripts/integration-tests.sh \
  --stack-config server:ci-tests::run-with-postgres-store.yaml \
  --setup vllm-postgres \
  --suite responses-e2e \
  --inference-mode live
```

The `setup-test-environment` action automatically starts both vLLM (`startsWith(setup, 'vllm')`) and PostgreSQL (`contains(setup, 'postgres')`) for the `vllm-postgres` setup name.