### PR TITLE
feat: add release automation script with RC/prerelease support

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -71,6 +71,18 @@ jobs:
           # Strip 'v' prefix
           VERSION="${TAG#v}"
 
+          # Skip post-release housekeeping for prerelease tags (e.g., rc1)
+          if [[ "$VERSION" =~ [a-zA-Z-] ]]; then
+            {
+              echo "version=${VERSION}"
+              echo "is_prerelease=true"
+            } >> "$GITHUB_OUTPUT"
+            echo "Prerelease detected (${VERSION}); skipping post-release housekeeping."
+            exit 0
+          fi
+
+          echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+
           # Split into components
           MAJOR="${VERSION%%.*}"
           REST="${VERSION#*.}"
@@ -100,10 +112,15 @@ jobs:
           echo "Next fallback: ${NEXT_FALLBACK}"
           echo "Release branch: ${RELEASE_BRANCH}"
 
+      - name: Skip prerelease housekeeping
+        if: steps.parse.outputs.is_prerelease == 'true'
+        run: echo "Skipping post-release automation for prerelease ${{ steps.parse.outputs.version }}"
+
       # -----------------------------------------------------------------------
       # Step A: Tag main with the next dev tag
       # -----------------------------------------------------------------------
       - name: Push dev tag to main
+        if: steps.parse.outputs.is_prerelease != 'true'
         run: |
           DEV_TAG="${{ steps.parse.outputs.next_dev_tag }}"
 
@@ -120,12 +137,14 @@ jobs:
           echo "Pushed tag $DEV_TAG to main ($MAIN_SHA)"
 
       - name: Set up uv
+        if: steps.parse.outputs.is_prerelease != 'true'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       # -----------------------------------------------------------------------
       # Step B: Bump fallback_version on main and open PR
       # -----------------------------------------------------------------------
       - name: Create fallback_version bump PR
+        if: steps.parse.outputs.is_prerelease != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
@@ -184,12 +203,14 @@ jobs:
       # Step C: Update npm lockfile on release branch via PR
       # -----------------------------------------------------------------------
       - name: Set up Node.js
+        if: steps.parse.outputs.is_prerelease != 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Create npm lockfile update PR for release branch
+        if: steps.parse.outputs.is_prerelease != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., "0.5.1")'
+        description: 'Release version (e.g., "0.5.1" or "0.5.1rc1")'
         required: true
         type: string
       release_branch:
@@ -45,9 +45,9 @@ jobs:
           VERSION="${{ inputs.version }}"
           BRANCH="${{ inputs.release_branch }}"
 
-          # Validate version format (X.Y.Z)
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid version format: ${VERSION}. Expected X.Y.Z (e.g., 0.5.1)"
+          # Validate version format (X.Y.Z or X.Y.ZrcN)
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(rc[1-9][0-9]*)?$'; then
+            echo "::error::Invalid version format: ${VERSION}. Expected X.Y.Z or X.Y.ZrcN (e.g., 0.5.1 or 0.5.1rc1)"
             exit 1
           fi
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -46,7 +46,9 @@
 # dry_run:
 #   - test-pypi: Publish to test.pypi.org, npm pack only (default)
 #   - build-only: Build and validate only, no publishing
-#   - off: Production publish to pypi.org and npmjs.org
+#   - off: Publish using channel inferred from version:
+#     stable -> pypi.org + npm latest + Docker latest
+#     prerelease (rc*) -> test.pypi.org + npm rc + prerelease Docker tags
 #
 # version: Optional version override (e.g., "0.2.0rc1")
 #
@@ -89,13 +91,13 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run mode'
+        description: 'Dry run mode (off respects rc prerelease channel routing)'
         required: false
         type: choice
         options:
           - 'test-pypi'      # Publish to test.pypi.org (default for testing)
           - 'build-only'     # Build and validate only, no publishing anywhere
-          - 'off'            # Production publish (use with caution!)
+          - 'off'            # Publish using stable/rc channel rules (use with caution!)
         default: 'test-pypi'
       version:
         description: 'Version override (e.g., "0.2.0rc1"). Leave empty for auto-detection.'
@@ -346,11 +348,18 @@ jobs:
             PACKAGE="$MATRIX_PACKAGE"
           fi
 
+          PYPI_API_BASE="https://pypi.org/pypi"
+          PYPI_REGISTRY="PyPI"
+          if [[ "$BASE_VERSION" =~ rc[0-9]+$ ]]; then
+            PYPI_API_BASE="https://test.pypi.org/pypi"
+            PYPI_REGISTRY="TestPyPI"
+          fi
+
           # Function to check if version exists on PyPI
           check_version_exists() {
             local pkg=$1
             local ver=$2
-            if curl -sf "https://pypi.org/pypi/${pkg}/${ver}/json" -o /dev/null 2>&1; then
+            if curl -sf "${PYPI_API_BASE}/${pkg}/${ver}/json" -o /dev/null 2>&1; then
               return 0  # exists
             else
               return 1  # does not exist
@@ -360,9 +369,12 @@ jobs:
           # Start with the base version and increment patch if needed
           VERSION="$BASE_VERSION"
 
-          # Only check/bump for non-dev versions (production releases)
-          if [[ ! "$VERSION" =~ \.dev ]]; then
-            echo "Checking if ${PACKAGE} ${VERSION} exists on PyPI..."
+          # Keep release-candidate versions stable across retries.
+          if [[ "$VERSION" =~ rc[0-9]+$ ]]; then
+            echo "RC version detected (${VERSION}), keeping exact version (no patch bump)"
+          # Only check/bump for non-dev stable versions.
+          elif [[ ! "$VERSION" =~ \.dev ]]; then
+            echo "Checking if ${PACKAGE} ${VERSION} exists on ${PYPI_REGISTRY}..."
 
             # Parse version components
             if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
@@ -381,16 +393,16 @@ jobs:
                   exit 1
                 fi
 
-                echo "Version ${VERSION} already exists on PyPI, trying next patch version..."
+                echo "Version ${VERSION} already exists on ${PYPI_REGISTRY}, trying next patch version..."
                 PATCH=$((PATCH + 1))
                 VERSION="${MAJOR}.${MINOR}.${PATCH}${SUFFIX}"
                 echo "Checking ${VERSION}..."
               done
 
               if [ "$VERSION" != "$BASE_VERSION" ]; then
-                echo "::notice::Bumped ${MATRIX_PACKAGE} (PyPI: ${PACKAGE}) version from ${BASE_VERSION} to ${VERSION} (already existed on PyPI)"
+                echo "::notice::Bumped ${MATRIX_PACKAGE} (${PYPI_REGISTRY}: ${PACKAGE}) version from ${BASE_VERSION} to ${VERSION} (already existed on ${PYPI_REGISTRY})"
               else
-                echo "Version ${VERSION} is available on PyPI for ${PACKAGE}"
+                echo "Version ${VERSION} is available on ${PYPI_REGISTRY} for ${PACKAGE}"
               fi
             else
               echo "::warning::Could not parse version ${VERSION}, using as-is"
@@ -436,6 +448,11 @@ jobs:
           # Convert PEP 440 dev version to valid semver for npm
           # e.g. 0.4.5.dev20260202 -> 0.4.5-dev.20260202
           VERSION="${BASE_VERSION/.dev/-dev.}"
+          # Convert PEP 440 RC to npm prerelease semver
+          # e.g. 1.1.0rc1 -> 1.1.0-rc1
+          if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}-rc${BASH_REMATCH[2]}"
+          fi
 
           # Function to check if version exists on npm using registry API
           check_npm_version_exists() {
@@ -448,8 +465,11 @@ jobs:
             fi
           }
 
-          # Only check/bump for non-dev versions (production releases)
-          if [[ ! "$VERSION" =~ -dev\. ]]; then
+          # Keep release-candidate versions stable across retries.
+          if [[ "$VERSION" =~ -rc[0-9]+$ ]]; then
+            echo "RC version detected (${VERSION}), keeping exact version (no patch bump)"
+          # Only check/bump for non-dev stable versions.
+          elif [[ ! "$VERSION" =~ -dev\. ]]; then
             echo "Checking if ${PACKAGE} ${VERSION} exists on npm..."
 
             # Parse version components (semver format)
@@ -764,9 +784,16 @@ jobs:
         run: |
           DRY_RUN="${{ inputs.dry_run }}"
           EVENT="${{ github.event_name }}"
+          IS_PRERELEASE="${{ (github.event_name == 'release' && contains(github.event.release.tag_name, 'rc')) || (github.event_name == 'workflow_dispatch' && contains(inputs.version, 'rc')) }}"
 
           # Determine target registry
-          if [ "$EVENT" == "release" ]; then
+          if [ "$IS_PRERELEASE" == "true" ] && { [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; }; then
+            {
+              echo "url=https://test.pypi.org/legacy/"
+              echo "target=test.pypi.org"
+              echo "is_production=false"
+            } >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT" == "release" ]; then
             {
               echo "url=https://upload.pypi.org/legacy/"
               echo "target=pypi.org"
@@ -841,12 +868,17 @@ jobs:
         run: |
           DRY_RUN="${{ inputs.dry_run }}"
           EVENT="${{ github.event_name }}"
+          IS_PRERELEASE="${{ (github.event_name == 'release' && contains(github.event.release.tag_name, 'rc')) || (github.event_name == 'workflow_dispatch' && contains(inputs.version, 'rc')) }}"
+          NPM_TAG="latest"
 
           echo "Event: $EVENT"
           echo "Dry run: $DRY_RUN"
 
           # Check if we should do production publish
-          if [ "$EVENT" == "release" ]; then
+          if [ "$IS_PRERELEASE" == "true" ] && { [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; }; then
+            IS_PRODUCTION=true
+            NPM_TAG="rc"
+          elif [ "$EVENT" == "release" ]; then
             IS_PRODUCTION=true
           elif [ "$DRY_RUN" == "off" ]; then
             IS_PRODUCTION=true
@@ -855,14 +887,14 @@ jobs:
           fi
 
           if [ "$IS_PRODUCTION" == "true" ]; then
-            echo "PRODUCTION: Publishing to npm"
+            echo "PRODUCTION: Publishing to npm with dist-tag '$NPM_TAG'"
             if [ -z "$NODE_AUTH_TOKEN" ]; then
               echo "::error::NPM_TOKEN secret not configured. Cannot publish to npm."
               exit 1
             fi
             # Extract and publish from the tarball
             TARBALL=$(find ./dist -name '*.tgz' | head -1)
-            npm publish "$TARBALL" --access public
+            npm publish "$TARBALL" --access public --tag "$NPM_TAG"
           else
             echo "DRY RUN: Verifying npm package (not publishing)"
             echo "Package tarball:"
@@ -881,7 +913,8 @@ jobs:
   # linux/arm64. GPU distros are built for linux/amd64 only.
   #
   # Images are pushed to: ogx/distribution-<distro>:<tag>
-  #   - Production (release or dry_run=off): tagged with VERSION and "latest"
+  #   - Stable production (release or dry_run=off): tagged with VERSION and "latest"
+  #   - Prerelease (rc*): tagged with VERSION only, installed from test-pypi
   #   - Test (test-pypi or schedule): tagged with "test-VERSION"
   publish-docker-images:
     name: Publish Docker ${{ matrix.distro }}
@@ -948,8 +981,16 @@ jobs:
 
           DRY_RUN="${{ inputs.dry_run }}"
           EVENT="${{ github.event_name }}"
+          IS_PRERELEASE="${{ (github.event_name == 'release' && contains(github.event.release.tag_name, 'rc')) || (github.event_name == 'workflow_dispatch' && contains(inputs.version, 'rc')) }}"
 
-          if [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; then
+          if [ "$IS_PRERELEASE" == "true" ] && { [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; }; then
+            {
+              echo "install_mode=test-pypi"
+              echo "tags=${IMAGE}:${VERSION}"
+              echo "version_arg=TEST_PYPI_VERSION=${VERSION}"
+            } >> "$GITHUB_OUTPUT"
+            echo "Publishing prerelease image: ${IMAGE}:${VERSION}"
+          elif [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; then
             {
               echo "install_mode=pypi"
               echo "tags=${IMAGE}:${VERSION},${IMAGE}:latest"

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -106,40 +106,103 @@ For each release, the Release Owner should complete:
 
 ### Technical Release Steps
 
-#### Patch release (e.g., 0.4.5 on existing `release-0.4.x`)
+The [`scripts/release.sh`](./scripts/release.sh) script automates the entire technical release
+process — version preparation, GitHub release creation, build monitoring, and package
+verification — in a single command.
 
-**Pre-release on `release-0.4.x`:**
+#### Prerequisites
 
-Backports are handled automatically by Mergify — patch releases ship whatever has already been backported to the release branch. No manual cherry-picking needed.
+- **`gh` CLI** installed and authenticated with write access to `ogx-ai/ogx`
+- **`git` CLI** with access to the remote
+- Verify access: `gh repo view ogx-ai/ogx --json name`
 
-- [ ] Run the [**Prepare release**](https://github.com/ogx-ai/ogx/actions/workflows/prepare-release.yml) workflow:
-  - Input `version`: `0.4.5`
-  - Input `release_branch`: `release-0.4.x`
-  - This commits `fallback_version` and `ogx-client` pin updates directly to the release branch
+#### Using the release script
 
-**Release:**
+##### Patch release (e.g., 1.0.3 on existing `release-1.0.x`)
 
-- [ ] Create GitHub release: tag `v0.4.5`, target `release-0.4.x`
-- [ ] Verify all 4 packages published:
-  - [ogx on PyPI](https://pypi.org/project/ogx/)
-  - [ogx-api on PyPI](https://pypi.org/project/ogx-api/)
-  - [ogx-client on PyPI](https://pypi.org/project/ogx-client/)
-  - [ogx-client on npm](https://www.npmjs.com/package/ogx-client)
+Backports are handled automatically by Mergify — patch releases ship whatever has
+already been backported to the release branch. No manual cherry-picking needed.
 
-**Post-release (automated):**
+```bash
+./scripts/release.sh 1.0.3
+```
 
-The following steps are handled automatically by the [**Post-release automation**](https://github.com/ogx-ai/ogx/actions/workflows/post-release.yml) workflow, which triggers on `release: published`:
+The script will:
 
-- Tags `main` with `v0.4.6-dev` (next dev tag)
-- Commits `fallback_version` bump to `"0.4.6.dev0"` directly to `main`
-- Commits the npm lockfile update directly to `release-0.4.x`
+1. Validate the version and confirm that `release-1.0.x` exists
+2. Trigger the [**Prepare release**](https://github.com/ogx-ai/ogx/actions/workflows/prepare-release.yml)
+   workflow to update `fallback_version` and `ogx-client` pins on the release branch
+3. Wait for the prepare workflow to complete
+4. Create a GitHub release (`v1.0.3` targeting `release-1.0.x`) with auto-generated notes
+5. Monitor the [build and publish workflow](https://github.com/ogx-ai/ogx/actions/workflows/pypi.yml)
+6. Verify all 4 packages are available:
+   - [ogx on PyPI](https://pypi.org/project/ogx/)
+   - [ogx-api on PyPI](https://pypi.org/project/ogx-api/)
+   - [ogx-client on PyPI](https://pypi.org/project/ogx-client/)
+   - [ogx-client on npm](https://www.npmjs.com/package/ogx-client)
 
-#### Minor release (e.g., 0.5.0 — new release branch)
+##### Minor release (e.g., 1.1.0 — new release branches)
 
-**All of the above, plus:**
+```bash
+./scripts/release.sh 1.1.0 --minor
+```
 
-- [ ] Create `release-0.5.x` branch off `main`
-- [ ] Ensure the release branch has the setuptools-scm config in both `pyproject.toml` files (`dynamic = ["version"]`, `[tool.setuptools_scm]`, etc.)
+The `--minor` flag creates the `release-1.1.x` branch from `main` in:
+
+- `ogx-ai/ogx`
+- `ogx-ai/ogx-client-python`
+- `ogx-ai/ogx-client-typescript`
+
+Then it runs the standard release flow. Use this only for the first release on a new minor version.
+
+##### Release candidate
+
+```bash
+./scripts/release.sh 1.1.0 --rc 1
+```
+
+This creates a prerelease tagged `v1.1.0rc1`. Issue additional RCs by incrementing
+the number (`--rc 2`, `--rc 3`, etc.) until the release is stable.
+
+RC publish behavior:
+
+- Python packages publish to test.pypi.org
+- npm publishes with the `rc` dist-tag (not `latest`)
+- Docker publishes versioned prerelease tags only (not `latest`)
+
+Post-release housekeeping (dev tag and bump PRs) is skipped automatically for prereleases.
+
+Minor releases and RCs can be combined:
+
+```bash
+./scripts/release.sh 1.1.0 --minor --rc 1
+```
+
+##### Dry run
+
+Preview what the script would do without executing anything:
+
+```bash
+./scripts/release.sh 1.0.3 --dry-run
+```
+
+#### Post-release (automated)
+
+The following steps are handled automatically by the [**Post-release automation**](https://github.com/ogx-ai/ogx/actions/workflows/post-release.yml) workflow for stable releases:
+
+- Tags `main` with the next dev tag (e.g., `v1.0.4-dev`)
+- Opens a PR to bump `fallback_version` to the next `.dev0` on `main`
+- Opens a PR to update the npm lockfile on the release branch
+
+#### Manual fallback
+
+If the script is unavailable or you need to run the steps individually:
+
+1. **Prepare release**: Go to [Actions > Prepare release](https://github.com/ogx-ai/ogx/actions/workflows/prepare-release.yml)
+   and run the workflow with inputs `version` and `release_branch`
+2. **Create release**: Go to [Releases > New release](https://github.com/ogx-ai/ogx/releases/new),
+   set the tag (`vX.Y.Z`), target the release branch, and publish
+3. **Verify packages**: Check PyPI and npm for all 4 packages listed above
 
 ## Release Artifacts
 
@@ -194,10 +257,11 @@ The unified workflow (`.github/workflows/pypi.yml`) builds and publishes all pac
 
 | Trigger | Version | Target |
 |---|---|---|
-| `release: published` | From tag (`v0.4.5` → `0.4.5`) | pypi.org + npm |
+| `release: published` (stable) | From tag (`v0.4.5` → `0.4.5`) | pypi.org + npm (`latest`) + Docker `latest` |
+| `release: published` (prerelease) | From tag (`v0.5.0rc1` → `0.5.0rc1`) | test.pypi.org + npm (`rc` dist-tag) + versioned Docker tags |
 | `schedule` (nightly) | `{base}.dev{YYYYMMDD}` (from dev tag or fallback) | test.pypi.org |
 | `workflow_dispatch` dry_run=test-pypi | `{base}.dev{YYYYMMDD}` or manual `version` input | test.pypi.org |
-| `workflow_dispatch` dry_run=off | Manual `version` input | pypi.org + npm |
+| `workflow_dispatch` dry_run=off | Manual `version` input | Stable: pypi.org + npm (`latest`) + Docker `latest`; RC (`*rcN`): test.pypi.org + npm (`rc`) + versioned Docker tags |
 | `workflow_dispatch` dry_run=build-only | N/A | No publish |
 
 ## Automation Workflows
@@ -207,7 +271,7 @@ The unified workflow (`.github/workflows/pypi.yml`) builds and publishes all pac
 Triggered via `workflow_dispatch`. Takes a version and release branch as input, then:
 
 - Updates `fallback_version` to the release version in both `pyproject.toml` files
-- Updates `ogx-client` pins to `==X.Y.Z`
+- Updates `ogx-client` pins to the exact release version (`==X.Y.Z` or `==X.Y.ZrcN`)
 - Opens a PR to the release branch
 
 ### Post-release (`.github/workflows/post-release.yml`)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,6 +32,7 @@ scripts/
   generate_openai_coverage_docs.py # Generate OpenAI API coverage docs
   openai_coverage.py           # OpenAI API coverage analysis
   provider_compat_matrix.py    # Provider compatibility matrix
+  release.sh                   # Automated release script (patch, minor, RC)
   responses_test_coverage.py   # Responses API test coverage
 ```
 
@@ -66,6 +67,24 @@ uv run python scripts/diagnose_recordings.py
 # Normalize recordings
 uv run python scripts/normalize_recordings.py
 ```
+
+### Release
+
+```bash
+# Patch release
+./scripts/release.sh 1.0.3
+
+# Minor release (creates release branches in ogx + client repos)
+./scripts/release.sh 1.1.0 --minor
+
+# Release candidate
+./scripts/release.sh 1.1.0 --rc 1
+
+# Preview without executing
+./scripts/release.sh 1.0.3 --dry-run
+```
+
+See [RELEASE_PROCESS.md](../RELEASE_PROCESS.md) for the full release procedure.
 
 ### Remote test recording (via GitHub Actions)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+# =============================================================================
+# OGX Release Script
+# =============================================================================
+#
+# Automates the full release process for OGX patch and minor releases.
+#
+# Prerequisites:
+#   - gh CLI authenticated with write access to ogx-ai/ogx
+#   - git CLI with access to the remote
+#
+# Usage:
+#   ./scripts/release.sh <version>                    # patch release
+#   ./scripts/release.sh <version> --minor             # minor release (creates release branches)
+#   ./scripts/release.sh <version> --dry-run           # preview without executing
+#   ./scripts/release.sh <version> --rc <N>            # release candidate
+#
+# Examples:
+#   ./scripts/release.sh 0.4.5                         # patch on release-0.4.x
+#   ./scripts/release.sh 0.5.0 --minor                 # creates release-0.5.x in ogx + client repos
+#   ./scripts/release.sh 0.5.0 --rc 1                  # publishes v0.5.0rc1
+#   ./scripts/release.sh 0.4.5 --dry-run               # shows what would happen
+#
+# =============================================================================
+
+set -euo pipefail
+
+REPO="ogx-ai/ogx"
+CLIENT_REPOS=(
+    "ogx-ai/ogx-client-python"
+    "ogx-ai/ogx-client-typescript"
+)
+POLL_INTERVAL=15
+WORKFLOW_TIMEOUT=600
+PUBLISH_TIMEOUT=900
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}==>${RESET} ${BOLD}$*${RESET}"; }
+ok()    { echo -e "${GREEN}  ✓${RESET} $*"; }
+warn()  { echo -e "${YELLOW}  !${RESET} $*"; }
+err()   { echo -e "${RED}  ✗${RESET} $*" >&2; }
+fatal() { err "$@"; exit 1; }
+
+confirm() {
+    local prompt="$1"
+    echo -en "${YELLOW}  ? ${prompt} [y/N]${RESET} "
+    read -r answer
+    [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+branch_exists() {
+    local repo="$1"
+    local branch="$2"
+    gh api "repos/${repo}/branches/${branch}" >/dev/null 2>&1
+}
+
+create_branch_from_main() {
+    local repo="$1"
+    local branch="$2"
+    local main_sha=""
+
+    main_sha=$(gh api "repos/${repo}/git/ref/heads/main" --jq '.object.sha') \
+        || fatal "Failed to get main branch SHA for ${repo}"
+    gh api "repos/${repo}/git/refs" \
+        -f "ref=refs/heads/${branch}" \
+        -f "sha=${main_sha}" >/dev/null \
+        || fatal "Failed to create branch ${repo}:${branch}"
+    ok "Created ${repo}:${branch} from main (${main_sha:0:8})"
+}
+
+find_recent_workflow_run_id() {
+    local workflow="$1"
+    local event="$2"
+    local not_before="$3"
+    local branch_filter="${4:-}"
+
+    local run_id=""
+    local created_at=""
+    local head_branch=""
+
+    while IFS=$'\t' read -r run_id created_at head_branch; do
+        if [[ -n "$branch_filter" && "$head_branch" != "$branch_filter" ]]; then
+            continue
+        fi
+        if [[ "$created_at" == "$not_before" || "$created_at" > "$not_before" ]]; then
+            echo "$run_id"
+            return 0
+        fi
+    done < <(
+        gh run list \
+            --repo "$REPO" \
+            --workflow "$workflow" \
+            --event "$event" \
+            --limit 20 \
+            --json databaseId,createdAt,headBranch \
+            --jq '.[] | [.databaseId, .createdAt, (.headBranch // "")] | @tsv'
+    )
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+VERSION=""
+MINOR=false
+DRY_RUN=false
+RC=""
+REPOS_TO_CREATE=()
+
+usage() {
+    sed -n '/^# Usage:/,/^# ====/{/^# ====/d; s/^# \{0,3\}//; p}' "$0"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --minor)   MINOR=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --rc)
+            [[ $# -ge 2 ]] || fatal "Option --rc requires a value (e.g., --rc 1)"
+            RC="$2"
+            shift 2
+            ;;
+        --help|-h) usage ;;
+        -*)        fatal "Unknown option: $1" ;;
+        *)
+            if [[ -z "$VERSION" ]]; then
+                VERSION="$1"; shift
+            else
+                fatal "Unexpected argument: $1"
+            fi
+            ;;
+    esac
+done
+
+[[ -n "$VERSION" ]] || { err "Missing required argument: version"; usage; }
+
+# Validate version format
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    fatal "Invalid version format: ${VERSION}. Expected X.Y.Z (e.g., 0.5.1)"
+fi
+if [[ -n "$RC" ]] && ! [[ "$RC" =~ ^[1-9][0-9]*$ ]]; then
+    fatal "Invalid RC number: ${RC}. Expected a positive integer (e.g., 1)"
+fi
+
+# Parse version components
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR_V=$(echo "$VERSION" | cut -d. -f2)
+PATCH=$(echo "$VERSION" | cut -d. -f3)
+RELEASE_BRANCH="release-${MAJOR}.${MINOR_V}.x"
+
+# Build the tag — RC or final
+if [[ -n "$RC" ]]; then
+    TAG="v${VERSION}rc${RC}"
+    PREPARE_VERSION="${VERSION}rc${RC}"
+else
+    TAG="v${VERSION}"
+    PREPARE_VERSION="${VERSION}"
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+
+info "Preflight checks"
+
+command -v gh >/dev/null 2>&1 || fatal "gh CLI is not installed"
+command -v git >/dev/null 2>&1 || fatal "git CLI is not installed"
+
+# Verify gh is authenticated and has correct repo access
+gh auth status >/dev/null 2>&1 || fatal "gh CLI is not authenticated. Run: gh auth login"
+gh repo view "$REPO" --json name >/dev/null 2>&1 || fatal "Cannot access ${REPO}. Check your permissions."
+ok "gh CLI authenticated with access to ${REPO}"
+
+# Check if tag already exists
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+    fatal "Release ${TAG} already exists"
+fi
+ok "Tag ${TAG} is available"
+
+# ---------------------------------------------------------------------------
+# Branch setup
+# ---------------------------------------------------------------------------
+
+if [[ "$MINOR" == true ]]; then
+    info "Minor release: validating ${RELEASE_BRANCH} branch plan"
+
+    # Check if branch already exists
+    if branch_exists "$REPO" "$RELEASE_BRANCH"; then
+        fatal "Branch ${RELEASE_BRANCH} already exists. Use --minor only for new minor releases."
+    fi
+
+    REPOS_TO_CREATE+=("$REPO")
+
+    for client_repo in "${CLIENT_REPOS[@]}"; do
+        if branch_exists "$client_repo" "$RELEASE_BRANCH"; then
+            ok "Client branch ${client_repo}:${RELEASE_BRANCH} already exists"
+            continue
+        fi
+
+        REPOS_TO_CREATE+=("$client_repo")
+    done
+else
+    # Verify release branch exists for patch releases
+    if ! branch_exists "$REPO" "$RELEASE_BRANCH"; then
+        fatal "Branch ${RELEASE_BRANCH} does not exist. Use --minor to create it."
+    fi
+    ok "Release branch ${RELEASE_BRANCH} exists in ${REPO}"
+
+    for client_repo in "${CLIENT_REPOS[@]}"; do
+        if ! branch_exists "$client_repo" "$RELEASE_BRANCH"; then
+            fatal "Client branch ${client_repo}:${RELEASE_BRANCH} does not exist. Create it before releasing."
+        fi
+        ok "Client branch ${client_repo}:${RELEASE_BRANCH} exists"
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Summary and confirmation
+# ---------------------------------------------------------------------------
+
+echo ""
+info "Release plan"
+echo "  Version:        ${VERSION}"
+echo "  Tag:            ${TAG}"
+echo "  Release branch: ${RELEASE_BRANCH}"
+echo "  Type:           $(if [[ "$MINOR" == true ]]; then echo "minor"; else echo "patch"; fi)$(if [[ -n "$RC" ]]; then echo " (release candidate ${RC})"; fi)"
+if [[ "$MINOR" == true ]]; then
+    echo "  Branches to create from main:"
+    for target_repo in "${REPOS_TO_CREATE[@]}"; do
+        echo "    - ${target_repo}:${RELEASE_BRANCH}"
+    done
+fi
+echo ""
+echo "  Steps:"
+echo "    1. Run 'Prepare release' workflow (updates versions on ${RELEASE_BRANCH})"
+echo "    2. Create GitHub release ${TAG} targeting ${RELEASE_BRANCH}"
+echo "    3. Wait for packages to build and publish (pypi.yml)"
+echo "    4. Verify packages on PyPI and npm"
+if [[ -n "$RC" ]]; then
+    echo "    5. Post-release automation is skipped for prereleases"
+else
+    echo "    5. Post-release automation runs automatically"
+fi
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+    warn "[dry-run] Would execute the above steps. Exiting."
+    exit 0
+fi
+
+confirm "Proceed with release ${TAG}?" || { info "Aborted."; exit 0; }
+
+if [[ "$MINOR" == true ]]; then
+    echo ""
+    info "Creating release branches"
+    for target_repo in "${REPOS_TO_CREATE[@]}"; do
+        create_branch_from_main "$target_repo" "$RELEASE_BRANCH"
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: Trigger prepare-release workflow
+# ---------------------------------------------------------------------------
+
+echo ""
+info "Step 1/4: Running 'Prepare release' workflow"
+
+PREPARE_DISPATCHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+gh workflow run prepare-release.yml \
+    --repo "$REPO" \
+    --ref "$RELEASE_BRANCH" \
+    -f "version=${PREPARE_VERSION}" \
+    -f "release_branch=${RELEASE_BRANCH}"
+
+# Find the run ID for the workflow we just dispatched
+RUN_ID=""
+ATTEMPTS=0
+MAX_ATTEMPTS=24
+while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
+    RUN_ID="$(find_recent_workflow_run_id "prepare-release.yml" "workflow_dispatch" "$PREPARE_DISPATCHED_AT" "$RELEASE_BRANCH" || true)"
+    if [[ -n "$RUN_ID" ]]; then
+        break
+    fi
+    sleep 5
+    ATTEMPTS=$((ATTEMPTS + 1))
+done
+
+if [[ -z "$RUN_ID" ]]; then
+    fatal "Could not find the newly triggered prepare-release workflow run"
+fi
+
+ok "Workflow triggered (run ${RUN_ID})"
+echo "  https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+# Poll for completion
+ELAPSED=0
+while [[ $ELAPSED -lt $WORKFLOW_TIMEOUT ]]; do
+    STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status,conclusion --jq '.status')
+    if [[ "$STATUS" == "completed" ]]; then
+        CONCLUSION=$(gh run view "$RUN_ID" --repo "$REPO" --json conclusion --jq '.conclusion')
+        if [[ "$CONCLUSION" == "success" ]]; then
+            ok "Prepare release completed successfully"
+            break
+        else
+            fatal "Prepare release failed with conclusion: ${CONCLUSION}. Check: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+        fi
+    fi
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+done
+
+if [[ $ELAPSED -ge $WORKFLOW_TIMEOUT ]]; then
+    fatal "Prepare release timed out after ${WORKFLOW_TIMEOUT}s. Check: https://github.com/${REPO}/actions/runs/${RUN_ID}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Create GitHub release
+# ---------------------------------------------------------------------------
+
+echo ""
+info "Step 2/4: Creating GitHub release ${TAG}"
+
+RELEASE_ARGS=(
+    --repo "$REPO"
+    --target "$RELEASE_BRANCH"
+    --generate-notes
+)
+
+if [[ -n "$RC" ]]; then
+    RELEASE_ARGS+=(--prerelease)
+    RELEASE_ARGS+=(--title "${TAG}")
+else
+    RELEASE_ARGS+=(--title "OGX ${TAG}")
+fi
+
+PUBLISH_TRIGGERED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RELEASE_URL=$(gh release create "$TAG" "${RELEASE_ARGS[@]}" 2>&1 | tail -1)
+ok "Release created: ${RELEASE_URL}"
+
+# ---------------------------------------------------------------------------
+# Step 3: Wait for build and publish workflow
+# ---------------------------------------------------------------------------
+
+echo ""
+info "Step 3/4: Waiting for build and publish workflow"
+
+# The pypi.yml workflow triggers on release:published — give it a moment to start
+sleep 10
+
+# Find the pypi.yml run triggered by this release
+PYPI_RUN_ID=""
+ATTEMPTS=0
+MAX_ATTEMPTS=12
+while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
+    PYPI_RUN_ID="$(find_recent_workflow_run_id "pypi.yml" "release" "$PUBLISH_TRIGGERED_AT" || true)"
+    if [[ -n "$PYPI_RUN_ID" ]]; then
+        break
+    fi
+    sleep 5
+    ATTEMPTS=$((ATTEMPTS + 1))
+done
+
+if [[ -z "$PYPI_RUN_ID" ]]; then
+    warn "Could not find the pypi.yml workflow run automatically."
+    warn "Check https://github.com/${REPO}/actions/workflows/pypi.yml"
+    warn "The release ${TAG} was created — packages should publish when the workflow completes."
+else
+    ok "Build workflow triggered (run ${PYPI_RUN_ID})"
+    echo "  https://github.com/${REPO}/actions/runs/${PYPI_RUN_ID}"
+
+    ELAPSED=0
+    while [[ $ELAPSED -lt $PUBLISH_TIMEOUT ]]; do
+        STATUS=$(gh run view "$PYPI_RUN_ID" --repo "$REPO" --json status,conclusion --jq '.status')
+        if [[ "$STATUS" == "completed" ]]; then
+            CONCLUSION=$(gh run view "$PYPI_RUN_ID" --repo "$REPO" --json conclusion --jq '.conclusion')
+            if [[ "$CONCLUSION" == "success" ]]; then
+                ok "Build and publish completed successfully"
+                break
+            else
+                fatal "Build/publish workflow finished with: ${CONCLUSION}. Check: https://github.com/${REPO}/actions/runs/${PYPI_RUN_ID}"
+            fi
+        fi
+        # Show progress
+        ELAPSED=$((ELAPSED + POLL_INTERVAL))
+        printf "\r  … waiting (%ds / %ds)" "$ELAPSED" "$PUBLISH_TIMEOUT"
+        sleep "$POLL_INTERVAL"
+    done
+    echo ""
+
+    if [[ $ELAPSED -ge $PUBLISH_TIMEOUT ]]; then
+        warn "Build workflow still running after ${PUBLISH_TIMEOUT}s."
+        warn "Check: https://github.com/${REPO}/actions/runs/${PYPI_RUN_ID}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Verify packages
+# ---------------------------------------------------------------------------
+
+echo ""
+info "Step 4/4: Verifying published packages"
+
+if [[ -n "$RC" ]]; then
+    PYPI_API_BASE="https://test.pypi.org/pypi"
+    PYPI_PROJECT_BASE="https://test.pypi.org/project"
+    PYPI_LABEL="TestPyPI"
+else
+    PYPI_API_BASE="https://pypi.org/pypi"
+    PYPI_PROJECT_BASE="https://pypi.org/project"
+    PYPI_LABEL="PyPI"
+fi
+
+check_pypi() {
+    local pkg="$1"
+    local ver="$2"
+    local url="${PYPI_API_BASE}/${pkg}/${ver}/json"
+    if curl -sf "$url" >/dev/null 2>&1; then
+        ok "${pkg}==${ver} on ${PYPI_LABEL}"
+        return 0
+    else
+        warn "${pkg}==${ver} not yet on ${PYPI_LABEL}"
+        return 1
+    fi
+}
+
+check_npm() {
+    local pkg="$1"
+    local ver="$2"
+    local url="https://registry.npmjs.org/${pkg}/${ver}"
+    if curl -sf "$url" >/dev/null 2>&1; then
+        ok "${pkg}@${ver} on npm"
+        return 0
+    else
+        warn "${pkg}@${ver} not yet on npm"
+        return 1
+    fi
+}
+
+# For RCs the PyPI version format uses rcN suffix
+if [[ -n "$RC" ]]; then
+    PYPI_VERSION="${VERSION}rc${RC}"
+    NPM_VERSION="${VERSION}-rc${RC}"
+else
+    PYPI_VERSION="${VERSION}"
+    NPM_VERSION="${VERSION}"
+fi
+
+ALL_PUBLISHED=true
+check_pypi "ogx" "$PYPI_VERSION" || ALL_PUBLISHED=false
+check_pypi "ogx-api" "$PYPI_VERSION" || ALL_PUBLISHED=false
+check_pypi "ogx-client" "$PYPI_VERSION" || ALL_PUBLISHED=false
+check_npm "ogx-client" "$NPM_VERSION" || ALL_PUBLISHED=false
+
+if [[ "$ALL_PUBLISHED" == true ]]; then
+    ok "All packages published"
+else
+    echo ""
+    warn "Some packages are not yet available. They may still be propagating."
+    warn "Check manually:"
+    echo "    ${PYPI_PROJECT_BASE}/ogx/${PYPI_VERSION}/"
+    echo "    ${PYPI_PROJECT_BASE}/ogx-api/${PYPI_VERSION}/"
+    echo "    ${PYPI_PROJECT_BASE}/ogx-client/${PYPI_VERSION}/"
+    echo "    https://www.npmjs.com/package/ogx-client/v/${NPM_VERSION}"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+info "Release ${TAG} complete"
+echo ""
+echo "  Release:     ${RELEASE_URL:-https://github.com/${REPO}/releases/tag/${TAG}}"
+echo "  ${PYPI_LABEL}:     ${PYPI_PROJECT_BASE}/ogx/${PYPI_VERSION}/"
+echo "  npm:         https://www.npmjs.com/package/ogx-client/v/${NPM_VERSION}"
+echo "  Docker:      https://hub.docker.com/r/ogx-ai/ogx/tags"
+echo ""
+if [[ -z "$RC" ]]; then
+    echo "  Post-release automation will:"
+    echo "    • Tag main with v${MAJOR}.${MINOR_V}.$((PATCH + 1))-dev"
+    echo "    • Open PR to bump fallback_version on main"
+    echo "    • Open PR to update npm lockfile on ${RELEASE_BRANCH}"
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
# What does this PR do?

Adds `scripts/release.sh` to automate the entire release process in a single command — version preparation, GitHub release creation, build monitoring, and package verification. Supports patch, minor, and release candidate workflows with a `--dry-run` mode.

Updates CI workflows (`prepare-release.yml`, `pypi.yml`, `post-release.yml`) to handle RC prereleases: routing RC packages to test.pypi.org, publishing npm with the `rc` dist-tag instead of `latest`, producing versioned-only Docker tags, and skipping post-release housekeeping for prerelease tags.

Updates `RELEASE_PROCESS.md` to document the script as the primary release method and adds a manual fallback section. Updates `scripts/README.md` with the new script entry and usage examples.

## Test Plan

1. Verify the script validates inputs correctly:
```bash
./scripts/release.sh           # should error: missing version
./scripts/release.sh abc       # should error: invalid format
./scripts/release.sh 1.0.3 --dry-run  # should print plan without executing
```

2. Verify workflow YAML is valid:
```bash
uv run pre-commit run --all-files  # all checks pass including actionlint
```

3. Verify RC channel routing logic in `pypi.yml`:
   - Stable release (`v1.0.3`): publishes to pypi.org, npm `latest`, Docker `latest`
   - Prerelease (`v1.1.0rc1`): publishes to test.pypi.org, npm `rc`, versioned Docker tags only