### PR TITLE
fix(build): add missing chardet dependency and fix CI matrix path filtering

### DIFF
--- a/scripts/generate_ci_matrix.py
+++ b/scripts/generate_ci_matrix.py
@@ -68,7 +68,7 @@ def _setups_from_changed_files(changed_files: list[str]) -> set[str] | None:
                 matched = True
                 break
 
-        if not matched and filepath.startswith("src/ogx/providers/remote/inference/"):
+        if not matched:
             return None
 
     return setups

--- a/src/ogx/providers/registry/file_processors.py
+++ b/src/ogx/providers/registry/file_processors.py
@@ -22,7 +22,7 @@ def available_providers() -> list[ProviderSpec]:
         InlineProviderSpec(
             api=Api.file_processors,
             provider_type="inline::auto",
-            pip_packages=["pypdf>=6.7.2", "markitdown[all]"],
+            pip_packages=["chardet", "pypdf>=6.7.2", "markitdown[all]"],
             module="ogx.providers.inline.file_processor.auto",
             config_class="ogx.providers.inline.file_processor.auto.AutoFileProcessorConfig",
             api_dependencies=[Api.files],
@@ -36,7 +36,7 @@ def available_providers() -> list[ProviderSpec]:
         InlineProviderSpec(
             api=Api.file_processors,
             provider_type="inline::pypdf",
-            pip_packages=["pypdf>=6.7.2"],
+            pip_packages=["chardet", "pypdf>=6.7.2"],
             module="ogx.providers.inline.file_processor.pypdf",
             config_class="ogx.providers.inline.file_processor.pypdf.PyPDFFileProcessorConfig",
             api_dependencies=[Api.files],


### PR DESCRIPTION
# What does this PR do?

Fixes two high-severity build-release issues identified by Clawpatch analysis:

1. **Missing `chardet` dependency** — `inline::pypdf` and `inline::auto` file processor provider specs now declare `chardet` in their `pip_packages`. The PyPDF implementation imports `chardet` at module load, but neither spec declared it, causing `ModuleNotFoundError` on clean installs driven by registry metadata.

2. **CI path-filter collapse** — `_setups_from_changed_files()` in the CI matrix generator now returns `None` (full matrix) for any unrecognized changed file path, not just unrecognized paths under `src/ogx/providers/remote/inference/`. Previously, changes to shared files like `scripts/integration-tests.sh`, registry code, or other non-provider paths silently collapsed CI to the Ollama smoke subset, missing real regressions.

## Test Plan

1. Verified `chardet` is already declared in `DEFAULT_VECTOR_IO_DEPS` in `vector_io.py`, confirming the omission in `file_processors.py` was accidental.
2. Ran provider codegen (`provider_codegen.py`) — no additional generated files changed.
3. Validated CI matrix logic with inline tests:

```python
from scripts.generate_ci_matrix import _setups_from_changed_files

# Unrecognized path → full matrix (was: empty set → Ollama only)
assert _setups_from_changed_files(['scripts/integration-tests.sh']) is None

# Provider-specific path → targeted set (unchanged)
assert 'ollama' in _setups_from_changed_files(['src/ogx/providers/remote/inference/ollama/foo.py'])

# Core path → full matrix (unchanged)
assert _setups_from_changed_files(['src/ogx/core/foo.py']) is None
```

4. Pre-commit checks pass on both changed files.