### PR TITLE
fix(concurrency): resolve four high-severity race conditions

### DIFF
--- a/src/ogx/core/prompts/prompts.py
+++ b/src/ogx/core/prompts/prompts.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 import time
 from typing import Any
 
@@ -56,12 +57,18 @@ class PromptServiceImpl(Prompts):
         self.config = config
         self.deps = deps
         self.policy = config.policy
+        self._prompt_locks: dict[str, asyncio.Lock] = {}
 
         prompts_ref = config.config.storage.stores.prompts
         if not prompts_ref:
             raise ServiceNotEnabledError("storage.stores.prompts")
 
         self._prompts_ref = prompts_ref
+
+    def _get_prompt_lock(self, prompt_id: str) -> asyncio.Lock:
+        if prompt_id not in self._prompt_locks:
+            self._prompt_locks[prompt_id] = asyncio.Lock()
+        return self._prompt_locks[prompt_id]
 
     async def initialize(self) -> None:
         self.sql_store = await authorized_sqlstore(self._prompts_ref, self.policy)
@@ -143,39 +150,40 @@ class PromptServiceImpl(Prompts):
             raise ValueError("Version must be >= 1")
         variables = request.variables if request.variables is not None else []
 
-        prompt_versions = await self.list_prompt_versions(ListPromptVersionsRequest(prompt_id=request.prompt_id))
-        latest_prompt = max(prompt_versions.data, key=lambda x: int(x.version))
+        async with self._get_prompt_lock(request.prompt_id):
+            prompt_versions = await self.list_prompt_versions(ListPromptVersionsRequest(prompt_id=request.prompt_id))
+            latest_prompt = max(prompt_versions.data, key=lambda x: int(x.version))
 
-        if request.version and latest_prompt.version != request.version:
-            raise ValueError(
-                f"'{request.version}' is not the latest prompt version for prompt_id='{request.prompt_id}'. Use the latest version '{latest_prompt.version}' in request."
+            if request.version and latest_prompt.version != request.version:
+                raise ValueError(
+                    f"'{request.version}' is not the latest prompt version for prompt_id='{request.prompt_id}'. Use the latest version '{latest_prompt.version}' in request."
+                )
+
+            current_version = latest_prompt.version if request.version is None else request.version
+            new_version = current_version + 1
+            created_at = int(time.time())
+
+            updated_prompt = Prompt(
+                prompt_id=request.prompt_id, prompt=request.prompt, version=new_version, variables=variables
             )
 
-        current_version = latest_prompt.version if request.version is None else request.version
-        new_version = current_version + 1
-        created_at = int(time.time())
-
-        updated_prompt = Prompt(
-            prompt_id=request.prompt_id, prompt=request.prompt, version=new_version, variables=variables
-        )
-
-        await self.sql_store.insert(
-            table=TABLE_PROMPTS,
-            data={
-                "id": f"{request.prompt_id}:{new_version}",
-                "prompt_id": request.prompt_id,
-                "version": new_version,
-                "is_default": False,
-                "created_at": created_at,
-                "prompt_data": {
-                    "prompt": request.prompt,
-                    "variables": variables,
+            await self.sql_store.insert(
+                table=TABLE_PROMPTS,
+                data={
+                    "id": f"{request.prompt_id}:{new_version}",
+                    "prompt_id": request.prompt_id,
+                    "version": new_version,
+                    "is_default": False,
+                    "created_at": created_at,
+                    "prompt_data": {
+                        "prompt": request.prompt,
+                        "variables": variables,
+                    },
                 },
-            },
-        )
+            )
 
-        if request.set_as_default:
-            await self.set_default_version(SetDefaultVersionRequest(prompt_id=request.prompt_id, version=new_version))
+            if request.set_as_default:
+                await self._set_default_version_locked(request.prompt_id, new_version)
 
         return updated_prompt
 
@@ -201,31 +209,33 @@ class PromptServiceImpl(Prompts):
 
     async def set_default_version(self, request: SetDefaultVersionRequest) -> Prompt:
         """Set which version of a prompt should be the default."""
+        async with self._get_prompt_lock(request.prompt_id):
+            return await self._set_default_version_locked(request.prompt_id, request.version)
+
+    async def _set_default_version_locked(self, prompt_id: str, version: int) -> Prompt:
+        """Set the default version for a prompt. Caller must hold the prompt lock."""
         record = await self.sql_store.fetch_one(
             table=TABLE_PROMPTS,
-            where={"prompt_id": request.prompt_id, "version": request.version},
+            where={"prompt_id": prompt_id, "version": version},
         )
         if record is None:
-            raise ValueError(f"Prompt {request.prompt_id} version {request.version} not found")
+            raise ValueError(f"Prompt {prompt_id} version {version} not found")
 
-        # Clear all defaults first, then set the target. This avoids the race where
-        # two concurrent calls interleave "set" and "clear" and remove each other's
-        # target, leaving zero defaults.
         all_versions = await self.sql_store.fetch_all(
             table=TABLE_PROMPTS,
-            where={"prompt_id": request.prompt_id, "is_default": True},
+            where={"prompt_id": prompt_id, "is_default": True},
         )
         for row in all_versions.data:
             await self.sql_store.update(
                 table=TABLE_PROMPTS,
                 data={"is_default": False},
-                where={"prompt_id": request.prompt_id, "version": row["version"]},
+                where={"prompt_id": prompt_id, "version": row["version"]},
             )
 
         await self.sql_store.update(
             table=TABLE_PROMPTS,
             data={"is_default": True},
-            where={"prompt_id": request.prompt_id, "version": request.version},
+            where={"prompt_id": prompt_id, "version": version},
         )
 
         return self._row_to_prompt(record, is_default=True)

--- a/src/ogx/providers/inline/batches/reference/batches.py
+++ b/src/ogx/providers/inline/batches/reference/batches.py
@@ -278,19 +278,30 @@ class ReferenceBatchesImpl(Batches):
 
     async def cancel_batch(self, request: CancelBatchRequest) -> BatchObject:
         """Cancel a batch that is in progress."""
-        batch = await self.retrieve_batch(RetrieveBatchRequest(batch_id=request.batch_id))
+        terminal_statuses = {"completed", "failed", "expired"}
+        cancel_statuses = {"cancelled", "cancelling"}
 
-        if batch.status in ["cancelled", "cancelling"]:
-            return batch
+        async with self._update_batch_lock:
+            batch = await self.retrieve_batch(RetrieveBatchRequest(batch_id=request.batch_id))
 
-        if batch.status in ["completed", "failed", "expired"]:
-            raise ConflictError(f"Cannot cancel batch '{request.batch_id}' with status '{batch.status}'")
+            if batch.status in cancel_statuses:
+                return batch
 
-        await self._update_batch(request.batch_id, status="cancelling", cancelling_at=int(time.time()))
+            if batch.status in terminal_statuses:
+                raise ConflictError(f"Cannot cancel batch '{request.batch_id}' with status '{batch.status}'")
+
+            batch_dict = batch.model_dump()
+            batch_dict["status"] = "cancelling"
+            batch_dict["cancelling_at"] = int(time.time())
+
+            await self.sql_store.update(
+                table=TABLE_BATCHES,
+                data={"status": "cancelling", "batch_data": batch_dict},
+                where={"id": request.batch_id},
+            )
 
         if request.batch_id in self._processing_tasks:
             self._processing_tasks[request.batch_id].cancel()
-            # note: task removal and status="cancelled" handled in finally block of _process_batch
 
         return await self.retrieve_batch(RetrieveBatchRequest(batch_id=request.batch_id))
 
@@ -340,11 +351,23 @@ class ReferenceBatchesImpl(Batches):
 
     async def _update_batch(self, batch_id: str, **updates) -> None:
         """Update batch fields in SQL store."""
+        terminal_statuses = {"completed", "failed", "expired", "cancelled"}
+
         async with self._update_batch_lock:
             try:
                 batch = await self.retrieve_batch(RetrieveBatchRequest(batch_id=batch_id))
 
-                # batch processing is async. once cancelling, only allow "cancelled" status updates
+                # Once a batch reaches a terminal state, reject all further updates
+                if batch.status in terminal_statuses:
+                    logger.info(
+                        "Skipping update for batch in terminal state",
+                        batch_id=batch_id,
+                        current_status=batch.status,
+                        attempted_status=updates.get("status"),
+                    )
+                    return
+
+                # Once cancelling, only allow "cancelled" status updates
                 if batch.status == "cancelling" and updates.get("status") != "cancelled":
                     logger.info(
                         "Skipping status update for cancelled batch",

--- a/src/ogx/providers/remote/files/s3/files.py
+++ b/src/ogx/providers/remote/files/s3/files.py
@@ -253,8 +253,6 @@ class S3FilesImpl(Files):
             "expires_at": expires_at,
         }
 
-        await self.sql_store.insert("openai_files", entry)
-
         try:
             await asyncio.to_thread(
                 self.client.put_object,
@@ -264,9 +262,17 @@ class S3FilesImpl(Files):
                 # TODO: enable server-side encryption
             )
         except ClientError as e:
-            await self.sql_store.delete("openai_files", where={"id": file_id})
-
             raise RuntimeError(f"Failed to upload file to S3: {e}") from e
+
+        try:
+            await self.sql_store.insert("openai_files", entry)
+        except Exception as e:
+            await asyncio.to_thread(
+                self.client.delete_object,
+                Bucket=self._config.bucket_name,
+                Key=file_id,
+            )
+            raise RuntimeError(f"Failed to register uploaded file: {e}") from e
 
         return _make_file_object(**entry)
 

--- a/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
@@ -160,6 +160,7 @@ class OpenAIVectorStoreMixin(ABC):
         self._last_file_batch_cleanup_time = 0
         self._file_batch_tasks: dict[str, asyncio.Task[None]] = {}
         self._vector_store_locks: dict[str, asyncio.Lock] = {}
+        self._in_flight_attachments: set[tuple[str, str]] = set()
 
     def _get_vector_store_lock(self, vector_store_id: str) -> asyncio.Lock:
         """Get or create a lock for a specific vector store."""
@@ -1226,15 +1227,27 @@ class OpenAIVectorStoreMixin(ABC):
         if vector_store_id not in self.openai_vector_stores:
             raise VectorStoreNotFoundError(vector_store_id)
 
-        # Check if file is already attached to this vector store
-        store_info = self.openai_vector_stores[vector_store_id]
-        if file_id in store_info["file_ids"]:
-            logger.warning(
-                "File is already attached to vector store, skipping", file_id=file_id, vector_store_id=vector_store_id
-            )
-            # Return existing file object
-            file_info = await self._load_openai_vector_store_file(vector_store_id, file_id)
-            return VectorStoreFileObject(**file_info)
+        # Check if file is already attached or being attached under the lock
+        async with self._get_vector_store_lock(vector_store_id):
+            store_info = self.openai_vector_stores[vector_store_id]
+            if file_id in store_info["file_ids"]:
+                logger.warning(
+                    "File is already attached to vector store, skipping",
+                    file_id=file_id,
+                    vector_store_id=vector_store_id,
+                )
+                file_info = await self._load_openai_vector_store_file(vector_store_id, file_id)
+                return VectorStoreFileObject(**file_info)
+
+            attach_key = (vector_store_id, file_id)
+            if attach_key in self._in_flight_attachments:
+                logger.warning(
+                    "File attachment already in progress, skipping",
+                    file_id=file_id,
+                    vector_store_id=vector_store_id,
+                )
+                raise ValueError(f"File '{file_id}' is already being attached to vector store '{vector_store_id}'")
+            self._in_flight_attachments.add(attach_key)
 
         attributes = request.attributes or {}
         chunking_strategy = request.chunking_strategy or VectorStoreChunkingStrategyAuto()
@@ -1254,6 +1267,7 @@ class OpenAIVectorStoreMixin(ABC):
         )
 
         if not self.files_api:
+            self._in_flight_attachments.discard((vector_store_id, file_id))
             vector_store_file_object.status = "failed"
             vector_store_file_object.last_error = VectorStoreFileLastError(
                 code="server_error",
@@ -1401,6 +1415,8 @@ class OpenAIVectorStoreMixin(ABC):
         # Update file_ids and file_counts in vector store metadata
         # Use lock to prevent race condition when multiple files are attached concurrently
         async with self._get_vector_store_lock(vector_store_id):
+            self._in_flight_attachments.discard((vector_store_id, file_id))
+
             store_info = self.openai_vector_stores[vector_store_id].copy()
             # Deep copy file_counts to avoid mutating shared dict
             store_info["file_counts"] = store_info["file_counts"].copy()


### PR DESCRIPTION
# What does this PR do?

Fixes four high-severity concurrency bugs identified by Clawpatch static analysis across batches, prompts, S3 file uploads, and vector store file attachments.

1. **Batch cancel race** — `cancel_batch()` now performs its status check and `cancelling` write atomically under `_update_batch_lock`, preventing a concurrent worker completion from being overwritten. `_update_batch()` also rejects updates to batches already in terminal states.

2. **Prompt writes non-atomic** — Added per-prompt `asyncio.Lock` to serialize `update_prompt()` and `set_default_version()` for the same `prompt_id`, preventing duplicate versions and broken default invariants from concurrent callers.

3. **S3 upload metadata-before-object** — Reversed operation order so the S3 `put_object` runs before the metadata insert. Concurrent readers can no longer discover a file ID whose S3 object doesn't exist yet, eliminating orphaned uploads.

4. **Concurrent file attach double-insert** — Added `_in_flight_attachments` tracking set checked under the vector store lock before file processing begins, preventing two concurrent attachments of the same `file_id` from both inserting chunks and corrupting file counts.

## Test Plan

All existing unit tests pass (87 tests across batches, prompts, and S3 files):

```bash
uv run pytest tests/unit/providers/batches/ tests/unit/prompts/ tests/unit/providers/files/test_s3_files.py -x --tb=short -q
# 87 passed

uv run pre-commit run --files src/ogx/core/prompts/prompts.py \
  src/ogx/providers/inline/batches/reference/batches.py \
  src/ogx/providers/remote/files/s3/files.py \
  src/ogx/providers/utils/memory/openai_vector_store_mixin.py
# All passed (ruff, mypy, format, logging checks)
```