### PR TITLE
feat(cli): add `ogx connect claude` command

### DIFF
--- a/docs/docs/building_applications/claude_code_integration.mdx
+++ b/docs/docs/building_applications/claude_code_integration.mdx
@@ -56,7 +56,7 @@ The `ogx connect claude` command:
 1. Queries the running OGX server for available models
 2. Filters out non-LLM models (embeddings, rerankers)
 3. Maps all discovered LLM models to Claude Code's three tiers (haiku/sonnet/opus)
-4. Sets the required environment variables (`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, model tier mappings)
+4. Sets the required environment variables (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, model tier mappings)
 5. Unsets any Vertex/Bedrock variables that would cause Claude Code to bypass OGX
 6. Launches Claude Code
 
@@ -161,7 +161,7 @@ You can also configure Claude Code manually without the `ogx connect claude` com
 
 ```bash
 export ANTHROPIC_BASE_URL="http://localhost:8321"
-export ANTHROPIC_API_KEY="fake"  # Not validated when using local providers
+export ANTHROPIC_AUTH_TOKEN="ogx"  # Bearer token — no interactive approval needed
 
 # Map Claude model tiers to your backend models
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="openai/gpt-4o-mini"   # Fast/cheap tier

--- a/docs/docs/building_applications/claude_code_integration.mdx
+++ b/docs/docs/building_applications/claude_code_integration.mdx
@@ -7,37 +7,33 @@ sidebar_position: 4
 
 # Claude Code Integration
 
-Llama Stack can act as a backend for [Claude Code](https://claude.com/claude-code), Anthropic's AI coding assistant. Point Claude Code at your Llama Stack server and use any model—from local open models (vLLM, Ollama) to cloud providers (OpenAI, Fireworks, Groq).
+OGX includes built-in support for connecting [Claude Code](https://claude.com/claude-code), Anthropic's AI coding assistant, with a single command. All available models on your OGX server are automatically discovered and mapped to Claude Code's model tiers.
 
 ## Quick Start
 
-### 1. Start Llama Stack
+### 1. Start OGX
 
 ```bash
 # With any provider (examples)
 export OPENAI_API_KEY="your-key-here"
-llama stack run starter
+ogx run starter
 
 # Or with vLLM
 export VLLM_URL="http://localhost:8000/v1"
-llama stack run starter
+ogx run starter
 
 # Or with Ollama
 export OLLAMA_URL="http://localhost:11434/v1"
-llama stack run starter
+ogx run starter
 ```
 
-### 2. Configure Claude Code
-
-Point Claude Code at your Llama Stack server using the `ANTHROPIC_BASE_URL` environment variable:
+### 2. Connect Claude Code
 
 ```bash
-export ANTHROPIC_BASE_URL="http://localhost:8321"
-export ANTHROPIC_API_KEY="fake"  # Not validated when using local providers
-
-# Use Claude Code normally
-claude "Write a hello world function in Python"
+ogx connect claude
 ```
+
+That's it. Claude Code launches with all your OGX models mapped to Claude's haiku/sonnet/opus tiers.
 
 ### 3. Test it out
 
@@ -55,15 +51,32 @@ claude "Add documentation and tests"
 
 ## How It Works
 
-Claude Code sends requests to the Anthropic Messages API (`/v1/messages`). Llama Stack implements this API, translating between formats as needed:
+The `ogx connect claude` command:
+
+1. Queries the running OGX server for available models
+2. Filters out non-LLM models (embeddings, rerankers)
+3. Maps all discovered LLM models to Claude Code's three tiers (haiku/sonnet/opus)
+4. Sets the required environment variables (`ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, model tier mappings)
+5. Unsets any Vertex/Bedrock variables that would cause Claude Code to bypass OGX
+6. Launches Claude Code
 
 ```
-Claude Code → Llama Stack /v1/messages → Provider
-                          ↓
-                     (translate if needed)
-                          ↓
-                     OpenAI, vLLM, etc.
+ogx connect claude
+       |
+       v
+  GET /v1/models (discover available models)
+       |
+       v
+  Map models to Claude tiers (haiku/sonnet/opus)
+       |
+       v
+  Launch claude with ANTHROPIC_BASE_URL + tier env vars
+       |
+       v
+  Claude Code (connected to OGX)
 ```
+
+Claude Code sends requests to the Anthropic Messages API (`/v1/messages`). OGX implements this API, translating between formats as needed:
 
 **What gets translated:**
 - **Messages format**: Anthropic → OpenAI format (when provider doesn't support Messages API natively)
@@ -75,30 +88,87 @@ Claude Code → Llama Stack /v1/messages → Provider
 - Ollama with `/v1/messages` support
 - vLLM with Anthropic format support
 
-## Model Configuration
-
-### Specifying Models
-
-You can use `--model` to specify which OGX model to use directly:
+## CLI Reference
 
 ```bash
-claude --model "ollama/llama3.2:3b" "Hello world"
-claude --model "vllm/Qwen/Qwen3-8B" "Write code"
+ogx connect claude [--model MODEL] [--haiku-model MODEL] [--sonnet-model MODEL]
+                   [--opus-model MODEL] [--host HOST] [--port PORT]
+                   [--print-env] [-- CLAUDE_ARGS...]
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--model` | First available model | Model ID to map to all three Claude tiers |
+| `--haiku-model` | `--model` value | Model ID for the haiku (fast) tier. Overrides `--model` |
+| `--sonnet-model` | `--model` value | Model ID for the sonnet (balanced) tier. Overrides `--model` |
+| `--opus-model` | `--model` value | Model ID for the opus (capable) tier. Overrides `--model` |
+| `--host` | `localhost` | OGX server host |
+| `--port` | `8321` | OGX server port (also reads `OGX_PORT` env var) |
+| `--print-env` | off | Print shell `export`/`unset` statements instead of launching Claude Code |
+
+Arguments after `--` are forwarded to the `claude` command.
+
+## Model Configuration
+
+### Default behavior
+
+With no model flags, `ogx connect claude` maps all three Claude tiers to the first available LLM model on your OGX server.
+
+### Setting a specific model for all tiers
+
+```bash
+ogx connect claude --model openai/gpt-4o
+```
+
+### Setting different models per tier
+
+```bash
+ogx connect claude \
+  --haiku-model openai/gpt-4o-mini \
+  --sonnet-model openai/gpt-4o \
+  --opus-model openai/o1
+```
+
+### Forwarding arguments to Claude Code
+
+```bash
+# Launch Claude Code in print mode
+ogx connect claude -- -p "Write a hello world function"
+
+# Specify a Claude model name directly
+ogx connect claude -- --model claude-sonnet-4-5
+```
+
+### Using `--print-env` for shell integration
+
+Instead of launching Claude Code, print the environment variables for manual use:
+
+```bash
+# Print and eval
+eval "$(ogx connect claude --print-env --model openai/gpt-4o)"
+claude "Hello world"
 ```
 
 :::note
-Some providers may return errors when Claude Code requests a `max_tokens` value higher than the model supports (e.g., OpenAI models). In that case, use the environment variable approach below, which lets OGX handle the mapping automatically.
+Some providers may return errors when Claude Code requests a `max_tokens` value higher than the model supports (e.g., OpenAI models). In that case, use `--model` to select a model that supports higher token limits, or use the per-tier flags to route different workloads to different models.
 :::
 
-### Model Aliasing via Environment Variables (Recommended)
+### Manual Environment Variable Setup
 
-The recommended approach is to let OGX map Claude's internal model names to your backend models. Claude Code internally uses Claude model names (e.g., `claude-sonnet-4-5`, `claude-haiku-4-5-20251001`) for different tiers of work. You control which backend model each tier maps to with environment variables:
+You can also configure Claude Code manually without the `ogx connect claude` command. Set these environment variables:
 
 ```bash
+export ANTHROPIC_BASE_URL="http://localhost:8321"
+export ANTHROPIC_API_KEY="fake"  # Not validated when using local providers
+
 # Map Claude model tiers to your backend models
 export ANTHROPIC_DEFAULT_HAIKU_MODEL="openai/gpt-4o-mini"   # Fast/cheap tier
 export ANTHROPIC_DEFAULT_SONNET_MODEL="openai/gpt-4o"       # Balanced tier
 export ANTHROPIC_DEFAULT_OPUS_MODEL="openai/o1"              # Most capable tier
+
+claude "Write a hello world function in Python"
 ```
 
 When Claude Code sends a request for `claude-haiku-4-5-20251001`, OGX routes it to the model specified by `ANTHROPIC_DEFAULT_HAIKU_MODEL`. The starter distribution automatically registers these aliases across all providers:
@@ -138,13 +208,12 @@ Different providers have different strengths when used with Claude Code:
 ### Using OpenAI Models
 
 ```bash
+# Terminal 1: Start OGX
 export OPENAI_API_KEY="sk-..."
-export ANTHROPIC_BASE_URL="http://localhost:8321"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="openai/gpt-4o-mini"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="openai/gpt-4o"
+ogx run starter
 
-llama stack run starter
-claude "Implement a binary search tree"
+# Terminal 2: Connect Claude Code
+ogx connect claude --model openai/gpt-4o
 ```
 
 ### Using vLLM with Qwen Models
@@ -153,77 +222,81 @@ claude "Implement a binary search tree"
 # Start vLLM server
 vllm serve Qwen/Qwen3-8B --api-key fake
 
-# Start Llama Stack
+# Terminal 1: Start OGX
 export VLLM_URL="http://localhost:8000/v1"
-export ANTHROPIC_BASE_URL="http://localhost:8321"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="vllm/Qwen/Qwen3-8B"
+ogx run starter
 
-llama stack run starter
-claude "Write a Fibonacci function"
+# Terminal 2: Connect Claude Code
+ogx connect claude --model vllm/Qwen/Qwen3-8B
 ```
 
 ### Using Ollama with Llama Models
 
 ```bash
-# Start Ollama
+# Start Ollama and pull a model
 ollama serve
-
-# Pull a model
 ollama pull llama3.3:70b
 
-# Start Llama Stack
+# Terminal 1: Start OGX
 export OLLAMA_URL="http://localhost:11434/v1"
-export ANTHROPIC_BASE_URL="http://localhost:8321"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="ollama/llama3.3:70b"
+ogx run starter
 
-llama stack run starter
-claude "Explain quicksort"
+# Terminal 2: Connect Claude Code
+ogx connect claude --model ollama/llama3.3:70b
 ```
 
 ### Using Multiple Providers
 
-You can configure different Claude model tiers to route to different providers:
+Route different Claude tiers to different backend models:
 
 ```bash
-# Fast model → local vLLM
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="vllm/Qwen/Qwen3-8B"
+# Terminal 1: Start OGX with multiple providers
+export VLLM_URL="http://localhost:8000/v1"
+export OPENAI_API_KEY="sk-..."
+ogx run starter
 
-# Balanced model → OpenAI GPT-4o
-export ANTHROPIC_DEFAULT_SONNET_MODEL="openai/gpt-4o"
-
-# Most capable → OpenAI o1
-export ANTHROPIC_DEFAULT_OPUS_MODEL="openai/o1"
-
-# Claude Code routes based on which model name it sends internally
-claude "Quick task"  # Uses haiku → vLLM
-claude "Complex task"  # Uses sonnet → OpenAI GPT-4o
+# Terminal 2: Connect with per-tier model mapping
+ogx connect claude \
+  --haiku-model vllm/Qwen/Qwen3-8B \
+  --sonnet-model openai/gpt-4o \
+  --opus-model openai/o1
 ```
+
+### With a Remote OGX Server
+
+```bash
+ogx connect claude --host 192.168.1.100 --port 9000
+```
+
+## Prerequisites
+
+- **Claude Code** must be installed and available in your `PATH`. Install it from [claude.com/download](https://claude.com/download).
+- **OGX server** must be running before connecting Claude Code. Start it with `ogx run starter` or `ogx stack run`.
 
 ## Troubleshooting
 
-### "Model not found" errors
+### "Failed to find 'claude' in PATH"
 
-**Symptom**: `404 Model 'claude-haiku-4-5-20251001' not found`
+Install Claude Code following the instructions at [claude.com/download](https://claude.com/download).
 
-**Solution**: Either pass the model directly or set the appropriate environment variable:
+### "Failed to connect to OGX server"
+
+The OGX server is not running or not reachable at the specified host and port. Start it first:
 
 ```bash
-# Option 1: Direct model specification
-claude --model "your-provider/your-model" "your prompt"
-
-# Option 2: Environment variable mapping (recommended)
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="your-provider/your-model"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="your-provider/your-model"
+ogx run starter
 ```
 
-### "API key not valid" errors when using local providers
+### "Failed to find any LLM models"
 
-**Symptom**: Authentication errors even though you're using a local provider
+The OGX server is running but has no LLM models registered. Check your distribution configuration and ensure at least one inference provider is configured.
 
-**Solution**: Set a fake API key (not validated by llama-stack):
+### Model not found with `--model`
+
+The specified model ID must match exactly what the OGX server reports. List available models:
 
 ```bash
-export ANTHROPIC_API_KEY="fake"
+curl http://localhost:8321/v1/models | python -m json.tool
 ```
 
 ### `max_tokens` errors with OpenAI models
@@ -232,15 +305,15 @@ export ANTHROPIC_API_KEY="fake"
 
 **Explanation**: Claude Code requests a `max_tokens` value based on Claude model limits, which may exceed what the backend model supports. This is common with OpenAI models.
 
-**Workaround**: Use a model that supports a higher token limit, or use the environment variable approach which allows OGX to handle the mapping. This is a known limitation when using `--model` with providers that enforce strict token limits.
+**Workaround**: Use a model that supports a higher token limit, or use per-tier model mapping to route different workloads appropriately.
 
-### Claude Code ignores `ANTHROPIC_BASE_URL`
+### Claude Code ignores `ANTHROPIC_BASE_URL` (manual setup)
 
 **Symptom**: Claude Code connects directly to Anthropic (or Vertex AI / Bedrock) instead of your OGX server.
 
-**Explanation**: If `CLAUDE_CODE_USE_VERTEX=1`, `CLAUDE_CODE_USE_BEDROCK=1`, or related Vertex/Bedrock environment variables are set, Claude Code bypasses `ANTHROPIC_BASE_URL` entirely.
+**Explanation**: If `CLAUDE_CODE_USE_VERTEX=1`, `CLAUDE_CODE_USE_BEDROCK=1`, or related Vertex/Bedrock environment variables are set, Claude Code bypasses `ANTHROPIC_BASE_URL` entirely. The `ogx connect claude` command handles this automatically by unsetting these variables.
 
-**Solution**: Unset these variables before starting Claude Code:
+**Solution** (if not using `ogx connect claude`): Unset these variables before starting Claude Code:
 
 ```bash
 unset CLAUDE_CODE_USE_VERTEX
@@ -253,20 +326,20 @@ unset ANTHROPIC_BEDROCK_SESSION_TOKEN
 
 **Symptom**: Long latency when using OpenAI, Fireworks, etc.
 
-**Explanation**: There's a double proxy overhead (Claude Code → llama-stack → provider). Consider using local providers (vLLM, Ollama) for better performance.
+**Explanation**: There's a double proxy overhead (Claude Code → OGX → provider). Consider using local providers (vLLM, Ollama) for better performance.
 
 ### Tool use not working
 
 **Symptom**: Claude Code can't execute shell commands or file operations
 
-**Explanation**: Tool execution happens in Claude Code's runtime, not llama-stack. Ensure Claude Code has proper permissions and your model supports tool use.
+**Explanation**: Tool execution happens in Claude Code's runtime, not OGX. Ensure Claude Code has proper permissions and your model supports tool use.
 
 ## Performance Considerations
 
 ### Latency Breakdown
 
 ```
-Total latency = Claude Code overhead + llama-stack processing + provider API call + translation overhead
+Total latency = Claude Code overhead + OGX processing + provider API call + translation overhead
 ```
 
 - **Local providers** (vLLM, Ollama): Minimal translation overhead, total latency dominated by inference
@@ -276,15 +349,15 @@ Total latency = Claude Code overhead + llama-stack processing + provider API cal
 ### Optimization Tips
 
 1. **Use local providers** when possible (vLLM, Ollama) to minimize network latency
-2. **Enable prompt caching** with providers that support it (set `ANTHROPIC_API_KEY` to use Bedrock)
+2. **Enable prompt caching** with providers that support it
 3. **Configure native Messages API** support in vLLM/Ollama to skip translation overhead
 4. **Use streaming** (enabled by default in Claude Code) for faster perceived response times
 
 ## Differences from Anthropic Claude
 
-While llama-stack provides full Messages API compatibility, there are some behavioral differences when using alternative models:
+While OGX provides full Messages API compatibility, there are some behavioral differences when using alternative models:
 
-| Feature | Anthropic Claude | Open Models (via llama-stack) |
+| Feature | Anthropic Claude | Open Models (via OGX) |
 |---------|------------------|-------------------------------|
 | **Thinking blocks** | Native support | Varies by model (GPT-4o has reasoning) |
 | **Prompt caching** | Available | Only if provider supports it |
@@ -299,8 +372,8 @@ While llama-stack provides full Messages API compatibility, there are some behav
 If you want more control over how Claude model names map to your providers, you can register models explicitly:
 
 ```bash
-# Start llama stack
-llama stack run starter
+# Start OGX
+ogx run starter
 
 # Register models via API (after startup)
 curl http://localhost:8321/v1/models \
@@ -326,7 +399,7 @@ registered_resources:
 
 ### Using with Claude Agent SDK
 
-If you're building custom agents with the Claude Agent SDK, llama-stack works as a drop-in backend:
+If you're building custom agents with the Claude Agent SDK, OGX works as a drop-in backend:
 
 ```python
 from claude_agent_sdk import Agent
@@ -340,16 +413,6 @@ agent = Agent(
 response = agent.send("Write a function to parse CSV files")
 ```
 
-## Related Documentation
+---
 
-- [Anthropic Messages API](/docs/api-anthropic-messages) - Full API reference and conformance details
-- [Providers](/docs/providers) - Available inference providers and configuration
-- [Starter Distribution](/docs/distributions/starter) - Default distribution setup
-
-## Contributing
-
-Found an issue or want to improve Claude Code integration? Contributions welcome:
-
-- **Report bugs**: [GitHub Issues](https://github.com/meta-llama/llama-stack/issues)
-- **Improve docs**: [Documentation source](https://github.com/meta-llama/llama-stack/tree/main/docs)
-- **Add features**: See [CONTRIBUTING.md](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md)
+For more information about OGX's provider architecture, see [Providers Overview](/docs/providers). For Anthropic Messages API conformance details, see [Anthropic Messages API](/docs/api-anthropic-messages).

--- a/docs/docs/references/ogx_cli_reference/index.md
+++ b/docs/docs/references/ogx_cli_reference/index.md
@@ -31,7 +31,7 @@ You have two ways to install OGX:
 ## `ogx` subcommands
 
 1. `stack`: Allows you to build a stack using the `ogx` distribution and run a OGX server. You can read more about how to build a OGX distribution in the [Build your own Distribution](../../distributions/building_distro) documentation.
-2. `connect`: Connect third-party tools to the running OGX server. Currently supports `opencode`. See [OpenCode Integration](../../building_applications/opencode_integration) for details.
+2. `connect`: Connect third-party tools to the running OGX server. Supports [`claude`](../../building_applications/claude_code_integration) and [`opencode`](../../building_applications/opencode_integration).
 
 For downloading models, we recommend using the [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/guides/cli). See [Downloading models](#downloading-models) for more information.
 

--- a/src/ogx/cli/connect/claude.py
+++ b/src/ogx/cli/connect/claude.py
@@ -117,7 +117,7 @@ class ConnectClaude(Subcommand):
         env = self._build_env(base_url, model_mapping)
 
         if args.print_env:
-            for key in ["ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY"]:
+            for key in ["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"]:
                 print(f"export {key}={env[key]}")
             for key in [
                 "ANTHROPIC_DEFAULT_HAIKU_MODEL",
@@ -150,7 +150,7 @@ class ConnectClaude(Subcommand):
             response = client.models.list()
         except APIConnectionError:
             cprint(
-                f"Failed to connect to OGX server at {base_url}\nStart the server first with: ogx stack run <config>",
+                f"Failed to connect to OGX server at {base_url}\nStart the server first with: ogx run <config>",
                 color="red",
                 file=sys.stderr,
             )
@@ -202,7 +202,7 @@ class ConnectClaude(Subcommand):
     def _build_env(self, base_url: str, model_mapping: dict[str, str]) -> dict[str, str]:
         env = {**os.environ}
         env["ANTHROPIC_BASE_URL"] = base_url
-        env["ANTHROPIC_API_KEY"] = "ogx"
+        env["ANTHROPIC_AUTH_TOKEN"] = "ogx"  # noqa: S105 — placeholder, not a real secret
         env.update(model_mapping)
         for key in _VARS_TO_UNSET:
             env.pop(key, None)

--- a/src/ogx/cli/connect/claude.py
+++ b/src/ogx/cli/connect/claude.py
@@ -1,0 +1,215 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+from openai import APIConnectionError, APIStatusError, OpenAI
+from termcolor import cprint
+
+from ogx.cli.subcommand import Subcommand
+from ogx.log import get_logger
+
+logger = get_logger(name=__name__, category="cli")
+
+_VARS_TO_UNSET = [
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "ANTHROPIC_BEDROCK_SESSION_TOKEN",
+]
+
+
+class ConnectClaude(Subcommand):
+    """Connect Claude Code to the running OGX server."""
+
+    def __init__(self, subparsers: argparse._SubParsersAction) -> None:
+        super().__init__()
+        self.parser = subparsers.add_parser(
+            "claude",
+            prog="ogx connect claude",
+            description="Launch Claude Code connected to the running OGX server.",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        self._add_arguments()
+        self.parser.set_defaults(func=self._run_connect_claude_cmd)
+
+    def _add_arguments(self) -> None:
+        self.parser.add_argument(
+            "--model",
+            type=str,
+            default=None,
+            help="Model ID to map to all Claude tiers (haiku/sonnet/opus). If omitted, the first available model is used.",
+        )
+        self.parser.add_argument(
+            "--haiku-model",
+            type=str,
+            default=None,
+            help="Model ID for the haiku (fast) tier. Overrides --model for this tier.",
+        )
+        self.parser.add_argument(
+            "--sonnet-model",
+            type=str,
+            default=None,
+            help="Model ID for the sonnet (balanced) tier. Overrides --model for this tier.",
+        )
+        self.parser.add_argument(
+            "--opus-model",
+            type=str,
+            default=None,
+            help="Model ID for the opus (capable) tier. Overrides --model for this tier.",
+        )
+        self.parser.add_argument(
+            "--port",
+            type=int,
+            help="OGX server port.",
+            default=int(os.getenv("OGX_PORT", 8321)),
+        )
+        self.parser.add_argument(
+            "--host",
+            type=str,
+            default="localhost",
+            help="OGX server host.",
+        )
+        self.parser.add_argument(
+            "--print-env",
+            action="store_true",
+            default=False,
+            help="Print environment variables as shell export statements instead of launching Claude Code.",
+        )
+        self.parser.add_argument(
+            "claude_args",
+            nargs=argparse.REMAINDER,
+            help="Additional arguments forwarded to the claude command (place after --).",
+        )
+
+    def _run_connect_claude_cmd(self, args: argparse.Namespace) -> None:
+        if not args.print_env and not shutil.which("claude"):
+            cprint(
+                "Failed to find 'claude' in PATH. Install it from https://claude.com/download",
+                color="red",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        api_url = f"http://{args.host}:{args.port}/v1"
+        base_url = f"http://{args.host}:{args.port}"
+
+        models = self._fetch_models(api_url)
+        if not models:
+            cprint("Failed to find any LLM models on the OGX server.", color="red", file=sys.stderr)
+            sys.exit(1)
+
+        model_mapping = self._resolve_model_mapping(
+            model=args.model,
+            haiku_model=args.haiku_model,
+            sonnet_model=args.sonnet_model,
+            opus_model=args.opus_model,
+            available_models=models,
+        )
+
+        env = self._build_env(base_url, model_mapping)
+
+        if args.print_env:
+            for key in ["ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY"]:
+                print(f"export {key}={env[key]}")
+            for key in [
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            ]:
+                if key in env:
+                    print(f"export {key}={env[key]}")
+            for key in _VARS_TO_UNSET:
+                print(f"unset {key}")
+            return
+
+        claude_args = _strip_leading_separator(args.claude_args)
+
+        logger.info(
+            "Connecting to Claude Code",
+            haiku=model_mapping.get("ANTHROPIC_DEFAULT_HAIKU_MODEL"),
+            sonnet=model_mapping.get("ANTHROPIC_DEFAULT_SONNET_MODEL"),
+            opus=model_mapping.get("ANTHROPIC_DEFAULT_OPUS_MODEL"),
+            models=len(models),
+            base_url=base_url,
+        )
+
+        result = subprocess.run(["claude", *claude_args], env=env)
+        sys.exit(result.returncode)
+
+    def _fetch_models(self, base_url: str) -> list[str]:
+        client = OpenAI(base_url=base_url, api_key="unused")
+        try:
+            response = client.models.list()
+        except APIConnectionError:
+            cprint(
+                f"Failed to connect to OGX server at {base_url}\nStart the server first with: ogx stack run <config>",
+                color="red",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        except APIStatusError as e:
+            cprint(
+                f"Failed to query models from OGX server at {base_url} (HTTP {e.status_code})",
+                color="red",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        models: list[str] = []
+        for model in response.data:
+            metadata = (model.model_extra or {}).get("custom_metadata") or {}
+            if metadata.get("model_type") != "embedding":
+                models.append(model.id)
+        return models
+
+    def _resolve_model_mapping(
+        self,
+        model: str | None,
+        haiku_model: str | None,
+        sonnet_model: str | None,
+        opus_model: str | None,
+        available_models: list[str],
+    ) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        tiers = [
+            ("ANTHROPIC_DEFAULT_HAIKU_MODEL", haiku_model),
+            ("ANTHROPIC_DEFAULT_SONNET_MODEL", sonnet_model),
+            ("ANTHROPIC_DEFAULT_OPUS_MODEL", opus_model),
+        ]
+
+        for env_var, tier_model in tiers:
+            resolved = tier_model or model or available_models[0]
+            if resolved not in available_models:
+                cprint(
+                    f"Failed to find model '{resolved}' on the OGX server.\n"
+                    f"Available models: {', '.join(available_models)}",
+                    color="red",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            mapping[env_var] = resolved
+
+        return mapping
+
+    def _build_env(self, base_url: str, model_mapping: dict[str, str]) -> dict[str, str]:
+        env = {**os.environ}
+        env["ANTHROPIC_BASE_URL"] = base_url
+        env["ANTHROPIC_API_KEY"] = "ogx"
+        env.update(model_mapping)
+        for key in _VARS_TO_UNSET:
+            env.pop(key, None)
+        return env
+
+
+def _strip_leading_separator(args: list[str]) -> list[str]:
+    if args and args[0] == "--":
+        return args[1:]
+    return args

--- a/src/ogx/cli/connect/claude.py
+++ b/src/ogx/cli/connect/claude.py
@@ -45,7 +45,7 @@ class ConnectClaude(Subcommand):
             "--model",
             type=str,
             default=None,
-            help="Model ID to map to all Claude tiers (haiku/sonnet/opus). If omitted, the first available model is used.",
+            help="Model ID to map to all Claude tiers (haiku/sonnet/opus). If omitted, tiers are auto-detected from available models.",
         )
         self.parser.add_argument(
             "--haiku-model",
@@ -65,17 +65,12 @@ class ConnectClaude(Subcommand):
             default=None,
             help="Model ID for the opus (capable) tier. Overrides --model for this tier.",
         )
+        default_port = os.getenv("OGX_PORT", "8321")
         self.parser.add_argument(
-            "--port",
-            type=int,
-            help="OGX server port.",
-            default=int(os.getenv("OGX_PORT", 8321)),
-        )
-        self.parser.add_argument(
-            "--host",
+            "--url",
             type=str,
-            default="localhost",
-            help="OGX server host.",
+            default=f"http://localhost:{default_port}",
+            help="OGX server URL.",
         )
         self.parser.add_argument(
             "--print-env",
@@ -98,8 +93,8 @@ class ConnectClaude(Subcommand):
             )
             sys.exit(1)
 
-        api_url = f"http://{args.host}:{args.port}/v1"
-        base_url = f"http://{args.host}:{args.port}"
+        base_url = args.url.rstrip("/")
+        api_url = f"{base_url}/v1"
 
         models = self._fetch_models(api_url)
         if not models:
@@ -179,14 +174,15 @@ class ConnectClaude(Subcommand):
         available_models: list[str],
     ) -> dict[str, str]:
         mapping: dict[str, str] = {}
+        auto_detected = _detect_tier_models(available_models)
         tiers = [
-            ("ANTHROPIC_DEFAULT_HAIKU_MODEL", haiku_model),
-            ("ANTHROPIC_DEFAULT_SONNET_MODEL", sonnet_model),
-            ("ANTHROPIC_DEFAULT_OPUS_MODEL", opus_model),
+            ("ANTHROPIC_DEFAULT_HAIKU_MODEL", haiku_model, "haiku"),
+            ("ANTHROPIC_DEFAULT_SONNET_MODEL", sonnet_model, "sonnet"),
+            ("ANTHROPIC_DEFAULT_OPUS_MODEL", opus_model, "opus"),
         ]
 
-        for env_var, tier_model in tiers:
-            resolved = tier_model or model or available_models[0]
+        for env_var, tier_model, tier_name in tiers:
+            resolved = tier_model or model or auto_detected.get(tier_name) or available_models[0]
             if resolved not in available_models:
                 cprint(
                     f"Failed to find model '{resolved}' on the OGX server.\n"
@@ -207,6 +203,16 @@ class ConnectClaude(Subcommand):
         for key in _VARS_TO_UNSET:
             env.pop(key, None)
         return env
+
+
+def _detect_tier_models(available_models: list[str]) -> dict[str, str]:
+    """Match available models to Claude tiers by looking for tier keywords in model names."""
+    detected: dict[str, str] = {}
+    for tier in ("haiku", "sonnet", "opus"):
+        matches = [m for m in available_models if tier in m.lower()]
+        if matches:
+            detected[tier] = matches[0]
+    return detected
 
 
 def _strip_leading_separator(args: list[str]) -> list[str]:

--- a/src/ogx/cli/connect/claude.py
+++ b/src/ogx/cli/connect/claude.py
@@ -94,9 +94,8 @@ class ConnectClaude(Subcommand):
             sys.exit(1)
 
         base_url = args.url.rstrip("/")
-        api_url = f"{base_url}/v1"
 
-        models = self._fetch_models(api_url)
+        models = self._fetch_models(base_url)
         if not models:
             cprint("Failed to find any LLM models on the OGX server.", color="red", file=sys.stderr)
             sys.exit(1)

--- a/src/ogx/cli/connect/connect.py
+++ b/src/ogx/cli/connect/connect.py
@@ -9,6 +9,7 @@ import argparse
 from ogx.cli.stack.utils import print_subcommand_description
 from ogx.cli.subcommand import Subcommand
 
+from .claude import ConnectClaude
 from .opencode import ConnectOpenCode
 
 
@@ -31,5 +32,6 @@ class ConnectParser(Subcommand):
 
         subparsers = self.parser.add_subparsers(title="connect_subcommands")
 
+        ConnectClaude.create(subparsers)
         ConnectOpenCode.create(subparsers)
         print_subcommand_description(self.parser, subparsers)

--- a/src/ogx/cli/connect/opencode.py
+++ b/src/ogx/cli/connect/opencode.py
@@ -87,7 +87,7 @@ class ConnectOpenCode(Subcommand):
             response = client.models.list()
         except APIConnectionError:
             cprint(
-                f"Failed to connect to OGX server at {base_url}\nStart the server first with: ogx stack run <config>",
+                f"Failed to connect to OGX server at {base_url}\nStart the server first with: ogx run <config>",
                 color="red",
                 file=sys.stderr,
             )

--- a/tests/unit/cli/test_connect_claude.py
+++ b/tests/unit/cli/test_connect_claude.py
@@ -1,0 +1,371 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for `ogx connect claude` CLI command."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from openai import APIConnectionError, APIStatusError
+
+from ogx.cli.connect.claude import ConnectClaude, _strip_leading_separator
+
+
+@pytest.fixture
+def connect_claude() -> ConnectClaude:
+    subparsers = argparse.ArgumentParser().add_subparsers()
+    return ConnectClaude(subparsers)
+
+
+def _make_model(model_id: str, model_type: str = "llm") -> MagicMock:
+    model = MagicMock()
+    model.id = model_id
+    model.model_extra = {"custom_metadata": {"model_type": model_type}}
+    return model
+
+
+def _make_mock_client(models: list[MagicMock]) -> MagicMock:
+    client = MagicMock()
+    response = MagicMock()
+    response.data = models
+    client.models.list.return_value = response
+    return client
+
+
+class TestArguments:
+    def test_defaults(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args([])
+        assert args.port == 8321
+        assert args.host == "localhost"
+        assert args.model is None
+        assert args.haiku_model is None
+        assert args.sonnet_model is None
+        assert args.opus_model is None
+        assert args.print_env is False
+        assert args.claude_args == []
+
+    def test_port_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--port", "9000"])
+        assert args.port == 9000
+
+    def test_host_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--host", "0.0.0.0"])
+        assert args.host == "0.0.0.0"
+
+    def test_model_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--model", "gpt-4o"])
+        assert args.model == "gpt-4o"
+
+    def test_haiku_model_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--haiku-model", "gpt-4o-mini"])
+        assert args.haiku_model == "gpt-4o-mini"
+
+    def test_sonnet_model_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--sonnet-model", "gpt-4o"])
+        assert args.sonnet_model == "gpt-4o"
+
+    def test_opus_model_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--opus-model", "o1"])
+        assert args.opus_model == "o1"
+
+    def test_print_env_flag(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--print-env"])
+        assert args.print_env is True
+
+    def test_port_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OGX_PORT", "9999")
+        subparsers = argparse.ArgumentParser().add_subparsers()
+        instance = ConnectClaude(subparsers)
+        args = instance.parser.parse_args([])
+        assert args.port == 9999
+
+    def test_claude_args_after_separator(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--", "-p", "hello world"])
+        assert args.claude_args == ["--", "-p", "hello world"]
+
+
+class TestClaudeDetection:
+    def test_exits_when_claude_not_in_path(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args([])
+        with patch("ogx.cli.connect.claude.shutil.which", return_value=None):
+            with pytest.raises(SystemExit):
+                connect_claude._run_connect_claude_cmd(args)
+
+    def test_continues_when_claude_found(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--model", "gpt-4o"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with (
+            patch("ogx.cli.connect.claude.shutil.which", return_value="/usr/bin/claude"),
+            patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client),
+            patch("ogx.cli.connect.claude.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            with pytest.raises(SystemExit) as exc_info:
+                connect_claude._run_connect_claude_cmd(args)
+            assert exc_info.value.code == 0
+
+
+class TestServerProbe:
+    def test_exits_when_server_unreachable(self, connect_claude: ConnectClaude) -> None:
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = APIConnectionError(request=httpx.Request("GET", "http://localhost"))
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            with pytest.raises(SystemExit):
+                connect_claude._fetch_models("http://localhost:8321/v1")
+
+    def test_exits_on_server_error(self, connect_claude: ConnectClaude) -> None:
+        mock_client = MagicMock()
+        mock_response = httpx.Response(500, request=httpx.Request("GET", "http://localhost"))
+        mock_client.models.list.side_effect = APIStatusError("server error", response=mock_response, body=None)
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            with pytest.raises(SystemExit):
+                connect_claude._fetch_models("http://localhost:8321/v1")
+
+    def test_returns_models_on_success(self, connect_claude: ConnectClaude) -> None:
+        mock_client = _make_mock_client([_make_model("gpt-4o"), _make_model("llama-3.1-8b")])
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            models = connect_claude._fetch_models("http://localhost:8321/v1")
+        assert models == ["gpt-4o", "llama-3.1-8b"]
+
+    def test_filters_out_embedding_models(self, connect_claude: ConnectClaude) -> None:
+        mock_client = _make_mock_client(
+            [
+                _make_model("gpt-4o"),
+                _make_model("text-embedding-3-small", model_type="embedding"),
+            ]
+        )
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            models = connect_claude._fetch_models("http://localhost:8321/v1")
+        assert "text-embedding-3-small" not in models
+        assert "gpt-4o" in models
+
+
+class TestModelMapping:
+    def test_all_tiers_default_to_first_model(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model=None,
+            haiku_model=None,
+            sonnet_model=None,
+            opus_model=None,
+            available_models=["gpt-4o", "llama-3.1-8b"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "gpt-4o"
+        assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "gpt-4o"
+        assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "gpt-4o"
+
+    def test_model_flag_sets_all_tiers(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model="llama-3.1-8b",
+            haiku_model=None,
+            sonnet_model=None,
+            opus_model=None,
+            available_models=["gpt-4o", "llama-3.1-8b"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "llama-3.1-8b"
+        assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "llama-3.1-8b"
+        assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "llama-3.1-8b"
+
+    def test_per_tier_overrides_model_flag(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model="gpt-4o",
+            haiku_model="llama-3.1-8b",
+            sonnet_model=None,
+            opus_model=None,
+            available_models=["gpt-4o", "llama-3.1-8b"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "llama-3.1-8b"
+        assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "gpt-4o"
+        assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "gpt-4o"
+
+    def test_all_tiers_individually_set(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model=None,
+            haiku_model="gpt-4o-mini",
+            sonnet_model="gpt-4o",
+            opus_model="o1",
+            available_models=["gpt-4o-mini", "gpt-4o", "o1"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "gpt-4o-mini"
+        assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "gpt-4o"
+        assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "o1"
+
+    def test_exits_when_model_not_available(self, connect_claude: ConnectClaude) -> None:
+        with pytest.raises(SystemExit):
+            connect_claude._resolve_model_mapping(
+                model="nonexistent", haiku_model=None, sonnet_model=None, opus_model=None, available_models=["gpt-4o"]
+            )
+
+    def test_exits_when_tier_model_not_available(self, connect_claude: ConnectClaude) -> None:
+        with pytest.raises(SystemExit):
+            connect_claude._resolve_model_mapping(
+                model=None, haiku_model="nonexistent", sonnet_model=None, opus_model=None, available_models=["gpt-4o"]
+            )
+
+    def test_model_ids_with_slashes(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model="ollama/llama3.3:70b",
+            haiku_model=None,
+            sonnet_model=None,
+            opus_model=None,
+            available_models=["ollama/llama3.3:70b"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "ollama/llama3.3:70b"
+
+
+class TestEnvironment:
+    def test_sets_anthropic_base_url(self, connect_claude: ConnectClaude) -> None:
+        env = connect_claude._build_env("http://localhost:8321", {})
+        assert env["ANTHROPIC_BASE_URL"] == "http://localhost:8321"
+
+    def test_base_url_has_no_v1_suffix(self, connect_claude: ConnectClaude) -> None:
+        env = connect_claude._build_env("http://localhost:8321", {})
+        assert not env["ANTHROPIC_BASE_URL"].endswith("/v1")
+
+    def test_sets_anthropic_api_key(self, connect_claude: ConnectClaude) -> None:
+        env = connect_claude._build_env("http://localhost:8321", {})
+        assert env["ANTHROPIC_API_KEY"] == "ogx"
+
+    def test_sets_model_tier_env_vars(self, connect_claude: ConnectClaude) -> None:
+        mapping = {
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-4o-mini",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-4o",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "o1",
+        }
+        env = connect_claude._build_env("http://localhost:8321", mapping)
+        assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "gpt-4o-mini"
+        assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "gpt-4o"
+        assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "o1"
+
+    def test_unsets_vertex_vars(self, connect_claude: ConnectClaude, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-project")
+        env = connect_claude._build_env("http://localhost:8321", {})
+        assert "CLAUDE_CODE_USE_VERTEX" not in env
+        assert "ANTHROPIC_VERTEX_PROJECT_ID" not in env
+
+    def test_unsets_bedrock_vars(self, connect_claude: ConnectClaude, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+        monkeypatch.setenv("ANTHROPIC_BEDROCK_SESSION_TOKEN", "tok")
+        env = connect_claude._build_env("http://localhost:8321", {})
+        assert "CLAUDE_CODE_USE_BEDROCK" not in env
+        assert "ANTHROPIC_BEDROCK_SESSION_TOKEN" not in env
+
+    def test_preserves_existing_env_vars(self, connect_claude: ConnectClaude, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_CUSTOM_VAR", "hello")
+        env = connect_claude._build_env("http://localhost:8321", {})
+        assert env["MY_CUSTOM_VAR"] == "hello"
+
+
+class TestPrintEnv:
+    def test_prints_export_statements(self, connect_claude: ConnectClaude, capsys: pytest.CaptureFixture[str]) -> None:
+        args = connect_claude.parser.parse_args(["--print-env", "--model", "gpt-4o"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            connect_claude._run_connect_claude_cmd(args)
+
+        output = capsys.readouterr().out
+        assert "export ANTHROPIC_BASE_URL=http://localhost:8321" in output
+        assert "export ANTHROPIC_API_KEY=ogx" in output
+        assert "export ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-4o" in output
+        assert "export ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-4o" in output
+        assert "export ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-4o" in output
+        assert "unset CLAUDE_CODE_USE_VERTEX" in output
+        assert "unset CLAUDE_CODE_USE_BEDROCK" in output
+
+    def test_does_not_launch_subprocess(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--print-env", "--model", "gpt-4o"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with (
+            patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client),
+            patch("ogx.cli.connect.claude.subprocess.run") as mock_run,
+        ):
+            connect_claude._run_connect_claude_cmd(args)
+            mock_run.assert_not_called()
+
+    def test_skips_claude_binary_check(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--print-env", "--model", "gpt-4o"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with (
+            patch("ogx.cli.connect.claude.shutil.which", return_value=None) as mock_which,
+            patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client),
+        ):
+            connect_claude._run_connect_claude_cmd(args)
+            mock_which.assert_not_called()
+
+
+class TestConnect:
+    def test_launches_claude_with_env(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--model", "gpt-4o"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with (
+            patch("ogx.cli.connect.claude.shutil.which", return_value="/usr/bin/claude"),
+            patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client),
+            patch("ogx.cli.connect.claude.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            with pytest.raises(SystemExit):
+                connect_claude._run_connect_claude_cmd(args)
+
+            mock_run.assert_called_once()
+            call_env = mock_run.call_args.kwargs["env"]
+            assert call_env["ANTHROPIC_BASE_URL"] == "http://localhost:8321"
+            assert call_env["ANTHROPIC_API_KEY"] == "ogx"
+            assert call_env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "gpt-4o"
+
+    def test_forwards_extra_args(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--model", "gpt-4o", "--", "-p", "hello"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with (
+            patch("ogx.cli.connect.claude.shutil.which", return_value="/usr/bin/claude"),
+            patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client),
+            patch("ogx.cli.connect.claude.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            with pytest.raises(SystemExit):
+                connect_claude._run_connect_claude_cmd(args)
+
+            cmd = mock_run.call_args.args[0]
+            assert cmd == ["claude", "-p", "hello"]
+
+    def test_propagates_exit_code(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--model", "gpt-4o"])
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with (
+            patch("ogx.cli.connect.claude.shutil.which", return_value="/usr/bin/claude"),
+            patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client),
+            patch("ogx.cli.connect.claude.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=42)
+            with pytest.raises(SystemExit) as exc_info:
+                connect_claude._run_connect_claude_cmd(args)
+            assert exc_info.value.code == 42
+
+
+class TestStripLeadingSeparator:
+    def test_strips_leading_double_dash(self) -> None:
+        assert _strip_leading_separator(["--", "-p", "hello"]) == ["-p", "hello"]
+
+    def test_preserves_args_without_separator(self) -> None:
+        assert _strip_leading_separator(["-p", "hello"]) == ["-p", "hello"]
+
+    def test_empty_list(self) -> None:
+        assert _strip_leading_separator([]) == []
+
+    def test_only_separator(self) -> None:
+        assert _strip_leading_separator(["--"]) == []

--- a/tests/unit/cli/test_connect_claude.py
+++ b/tests/unit/cli/test_connect_claude.py
@@ -231,9 +231,9 @@ class TestEnvironment:
         env = connect_claude._build_env("http://localhost:8321", {})
         assert not env["ANTHROPIC_BASE_URL"].endswith("/v1")
 
-    def test_sets_anthropic_api_key(self, connect_claude: ConnectClaude) -> None:
+    def test_sets_anthropic_auth_token(self, connect_claude: ConnectClaude) -> None:
         env = connect_claude._build_env("http://localhost:8321", {})
-        assert env["ANTHROPIC_API_KEY"] == "ogx"
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "ogx"
 
     def test_sets_model_tier_env_vars(self, connect_claude: ConnectClaude) -> None:
         mapping = {
@@ -276,7 +276,7 @@ class TestPrintEnv:
 
         output = capsys.readouterr().out
         assert "export ANTHROPIC_BASE_URL=http://localhost:8321" in output
-        assert "export ANTHROPIC_API_KEY=ogx" in output
+        assert "export ANTHROPIC_AUTH_TOKEN=ogx" in output
         assert "export ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-4o" in output
         assert "export ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-4o" in output
         assert "export ANTHROPIC_DEFAULT_OPUS_MODEL=gpt-4o" in output
@@ -323,7 +323,7 @@ class TestConnect:
             mock_run.assert_called_once()
             call_env = mock_run.call_args.kwargs["env"]
             assert call_env["ANTHROPIC_BASE_URL"] == "http://localhost:8321"
-            assert call_env["ANTHROPIC_API_KEY"] == "ogx"
+            assert call_env["ANTHROPIC_AUTH_TOKEN"] == "ogx"
             assert call_env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "gpt-4o"
 
     def test_forwards_extra_args(self, connect_claude: ConnectClaude) -> None:

--- a/tests/unit/cli/test_connect_claude.py
+++ b/tests/unit/cli/test_connect_claude.py
@@ -13,7 +13,7 @@ import httpx
 import pytest
 from openai import APIConnectionError, APIStatusError
 
-from ogx.cli.connect.claude import ConnectClaude, _strip_leading_separator
+from ogx.cli.connect.claude import ConnectClaude, _detect_tier_models, _strip_leading_separator
 
 
 @pytest.fixture
@@ -40,8 +40,7 @@ def _make_mock_client(models: list[MagicMock]) -> MagicMock:
 class TestArguments:
     def test_defaults(self, connect_claude: ConnectClaude) -> None:
         args = connect_claude.parser.parse_args([])
-        assert args.port == 8321
-        assert args.host == "localhost"
+        assert args.url == "http://localhost:8321"
         assert args.model is None
         assert args.haiku_model is None
         assert args.sonnet_model is None
@@ -49,13 +48,9 @@ class TestArguments:
         assert args.print_env is False
         assert args.claude_args == []
 
-    def test_port_override(self, connect_claude: ConnectClaude) -> None:
-        args = connect_claude.parser.parse_args(["--port", "9000"])
-        assert args.port == 9000
-
-    def test_host_override(self, connect_claude: ConnectClaude) -> None:
-        args = connect_claude.parser.parse_args(["--host", "0.0.0.0"])
-        assert args.host == "0.0.0.0"
+    def test_url_override(self, connect_claude: ConnectClaude) -> None:
+        args = connect_claude.parser.parse_args(["--url", "https://ogx.example.com"])
+        assert args.url == "https://ogx.example.com"
 
     def test_model_override(self, connect_claude: ConnectClaude) -> None:
         args = connect_claude.parser.parse_args(["--model", "gpt-4o"])
@@ -77,12 +72,12 @@ class TestArguments:
         args = connect_claude.parser.parse_args(["--print-env"])
         assert args.print_env is True
 
-    def test_port_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OGX_PORT", "9999")
         subparsers = argparse.ArgumentParser().add_subparsers()
         instance = ConnectClaude(subparsers)
         args = instance.parser.parse_args([])
-        assert args.port == 9999
+        assert args.url == "http://localhost:9999"
 
     def test_claude_args_after_separator(self, connect_claude: ConnectClaude) -> None:
         args = connect_claude.parser.parse_args(["--", "-p", "hello world"])
@@ -151,7 +146,7 @@ class TestServerProbe:
 
 
 class TestModelMapping:
-    def test_all_tiers_default_to_first_model(self, connect_claude: ConnectClaude) -> None:
+    def test_all_tiers_default_to_first_model_when_no_keywords(self, connect_claude: ConnectClaude) -> None:
         mapping = connect_claude._resolve_model_mapping(
             model=None,
             haiku_model=None,
@@ -162,6 +157,30 @@ class TestModelMapping:
         assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "gpt-4o"
         assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "gpt-4o"
         assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "gpt-4o"
+
+    def test_auto_detects_tiers_from_model_names(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model=None,
+            haiku_model=None,
+            sonnet_model=None,
+            opus_model=None,
+            available_models=["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-7"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "claude-haiku-4-5"
+        assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude-sonnet-4-6"
+        assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-4-7"
+
+    def test_auto_detects_partial_tiers(self, connect_claude: ConnectClaude) -> None:
+        mapping = connect_claude._resolve_model_mapping(
+            model=None,
+            haiku_model=None,
+            sonnet_model=None,
+            opus_model=None,
+            available_models=["claude-sonnet-4-6", "llama-3.3-70b"],
+        )
+        assert mapping["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "claude-sonnet-4-6"
+        assert mapping["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude-sonnet-4-6"
+        assert mapping["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-sonnet-4-6"
 
     def test_model_flag_sets_all_tiers(self, connect_claude: ConnectClaude) -> None:
         mapping = connect_claude._resolve_model_mapping(
@@ -283,6 +302,34 @@ class TestPrintEnv:
         assert "unset CLAUDE_CODE_USE_VERTEX" in output
         assert "unset CLAUDE_CODE_USE_BEDROCK" in output
 
+    def test_prints_https_url(self, connect_claude: ConnectClaude, capsys: pytest.CaptureFixture[str]) -> None:
+        args = connect_claude.parser.parse_args(
+            ["--print-env", "--url", "https://ogx.example.com", "--model", "gpt-4o"]
+        )
+        mock_client = _make_mock_client([_make_model("gpt-4o")])
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            connect_claude._run_connect_claude_cmd(args)
+
+        output = capsys.readouterr().out
+        assert "export ANTHROPIC_BASE_URL=https://ogx.example.com" in output
+
+    def test_auto_detects_models_in_print_env(
+        self, connect_claude: ConnectClaude, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = connect_claude.parser.parse_args(["--print-env"])
+        mock_client = _make_mock_client(
+            [_make_model("claude-haiku-4-5"), _make_model("claude-sonnet-4-6"), _make_model("claude-opus-4-7")]
+        )
+
+        with patch("ogx.cli.connect.claude.OpenAI", return_value=mock_client):
+            connect_claude._run_connect_claude_cmd(args)
+
+        output = capsys.readouterr().out
+        assert "export ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5" in output
+        assert "export ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6" in output
+        assert "export ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-7" in output
+
     def test_does_not_launch_subprocess(self, connect_claude: ConnectClaude) -> None:
         args = connect_claude.parser.parse_args(["--print-env", "--model", "gpt-4o"])
         mock_client = _make_mock_client([_make_model("gpt-4o")])
@@ -355,6 +402,28 @@ class TestConnect:
             with pytest.raises(SystemExit) as exc_info:
                 connect_claude._run_connect_claude_cmd(args)
             assert exc_info.value.code == 42
+
+
+class TestDetectTierModels:
+    def test_detects_all_tiers(self) -> None:
+        result = _detect_tier_models(["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-7"])
+        assert result == {"haiku": "claude-haiku-4-5", "sonnet": "claude-sonnet-4-6", "opus": "claude-opus-4-7"}
+
+    def test_detects_partial_tiers(self) -> None:
+        result = _detect_tier_models(["claude-sonnet-4-6", "llama-3.3-70b"])
+        assert result == {"sonnet": "claude-sonnet-4-6"}
+
+    def test_no_matches(self) -> None:
+        result = _detect_tier_models(["gpt-4o", "llama-3.3-70b"])
+        assert result == {}
+
+    def test_picks_first_match_per_tier(self) -> None:
+        result = _detect_tier_models(["claude-haiku-4-5", "claude-haiku-4-5-20251001"])
+        assert result == {"haiku": "claude-haiku-4-5"}
+
+    def test_case_insensitive(self) -> None:
+        result = _detect_tier_models(["Claude-Haiku-4-5"])
+        assert result == {"haiku": "Claude-Haiku-4-5"}
 
 
 class TestStripLeadingSeparator:


### PR DESCRIPTION


# What does this PR do?
Add a new CLI subcommand that launches Claude Code connected to a running OGX server, handling model discovery, tier mapping, and environment variable configuration automatically. The command probes the server for available LLM models, maps them to Claude's haiku/sonnet/opus tiers, and launches claude with the appropriate ANTHROPIC_BASE_URL and model tier env vars set. Includes --print-env flag for shell integration and per-tier model overrides. Updates Claude Code integration docs to use the new command as the primary quick-start workflow.

Closes #5870 

## Test Plan
Unit tests added, manual test steps below (non-destructive for those with existing Claude setups)

```bash
# Start an OGX server
export OPENAI_API_KEY="your-key"
ogx run starter

# Dry-run with --print-env (no claude process launched)
ogx connect claude --print-env

# Real launch of Claude with OGX
ogx connect claude
```

