### PR TITLE
fix: resolve 6 documentation-vs-code contract mismatches

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -15298,7 +15298,9 @@ components:
           nullable: true
         limit:
           anyOf:
-          - type: integer
+          - maximum: 100
+            minimum: 1
+            type: integer
           - type: 'null'
           description: A limit on the number of objects to be returned (1-100, default 20).
           nullable: true

--- a/docs/static/deprecated-ogx-spec.yaml
+++ b/docs/static/deprecated-ogx-spec.yaml
@@ -9820,7 +9820,9 @@ components:
           nullable: true
         limit:
           anyOf:
-          - type: integer
+          - maximum: 100
+            minimum: 1
+            type: integer
           - type: 'null'
           description: A limit on the number of objects to be returned (1-100, default 20).
           nullable: true

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -10673,7 +10673,9 @@ components:
           nullable: true
         limit:
           anyOf:
-          - type: integer
+          - maximum: 100
+            minimum: 1
+            type: integer
           - type: 'null'
           description: A limit on the number of objects to be returned (1-100, default 20).
           nullable: true

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -14447,7 +14447,9 @@ components:
           nullable: true
         limit:
           anyOf:
-          - type: integer
+          - maximum: 100
+            minimum: 1
+            type: integer
           - type: 'null'
           description: A limit on the number of objects to be returned (1-100, default 20).
           nullable: true

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -15298,7 +15298,9 @@ components:
           nullable: true
         limit:
           anyOf:
-          - type: integer
+          - maximum: 100
+            minimum: 1
+            type: integer
           - type: 'null'
           description: A limit on the number of objects to be returned (1-100, default 20).
           nullable: true

--- a/src/ogx/providers/utils/inference/http_client.py
+++ b/src/ogx/providers/utils/inference/http_client.py
@@ -100,21 +100,31 @@ def _build_proxy_mounts(proxy_config: ProxyConfig) -> dict[str, httpx.AsyncHTTPT
         # Convert Path to string for httpx
         transport_kwargs["verify"] = str(proxy_config.cacert)
 
+    mounts: dict[str, httpx.AsyncHTTPTransport] = {}
+
     if proxy_config.url:
-        # Convert HttpUrl to string for httpx
         proxy_url = str(proxy_config.url)
-        return {
-            "http://": httpx.AsyncHTTPTransport(proxy=proxy_url, **transport_kwargs),
-            "https://": httpx.AsyncHTTPTransport(proxy=proxy_url, **transport_kwargs),
-        }
+        mounts["http://"] = httpx.AsyncHTTPTransport(proxy=proxy_url, **transport_kwargs)
+        mounts["https://"] = httpx.AsyncHTTPTransport(proxy=proxy_url, **transport_kwargs)
+    else:
+        if proxy_config.http:
+            mounts["http://"] = httpx.AsyncHTTPTransport(proxy=str(proxy_config.http), **transport_kwargs)
+        if proxy_config.https:
+            mounts["https://"] = httpx.AsyncHTTPTransport(proxy=str(proxy_config.https), **transport_kwargs)
 
-    mounts = {}
-    if proxy_config.http:
-        mounts["http://"] = httpx.AsyncHTTPTransport(proxy=str(proxy_config.http), **transport_kwargs)
-    if proxy_config.https:
-        mounts["https://"] = httpx.AsyncHTTPTransport(proxy=str(proxy_config.https), **transport_kwargs)
+    if not mounts:
+        return None
 
-    return mounts if mounts else None
+    # Apply no_proxy bypass: direct (non-proxied) transports for excluded hosts
+    if proxy_config.no_proxy:
+        for host in proxy_config.no_proxy:
+            if host.startswith("."):
+                pattern = f"all://*{host}"
+            else:
+                pattern = f"all://{host}"
+            mounts[pattern] = httpx.AsyncHTTPTransport()
+
+    return mounts
 
 
 def build_network_client_kwargs(network_config: NetworkConfig | None) -> dict[str, Any]:

--- a/src/ogx/providers/utils/inference/model_registry.py
+++ b/src/ogx/providers/utils/inference/model_registry.py
@@ -203,7 +203,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         model_entries: list[ProviderModelEntry] | None = None,
         allowed_models: list[str] | None = None,
     ):
-        self.allowed_models = allowed_models if allowed_models else []
+        self.allowed_models = allowed_models
 
         self.alias_to_provider_id_map = {}
         self.provider_id_to_llama_model_map = {}
@@ -224,7 +224,7 @@ class ModelRegistryHelper(ModelsProtocolPrivate):
         for entry in self.model_entries:
             ids = [entry.provider_model_id] + entry.aliases
             for id in ids:
-                if self.allowed_models and id not in self.allowed_models:
+                if self.allowed_models is not None and id not in self.allowed_models:
                     continue
                 models.append(
                     Model(

--- a/src/ogx_api/conversations/fastapi_routes.py
+++ b/src/ogx_api/conversations/fastapi_routes.py
@@ -13,7 +13,7 @@ FastAPI route decorators.
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Body, Depends, Path
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ogx_api.router_utils import (
     ExceptionTranslatingRoute,
@@ -50,7 +50,7 @@ class _ListItemsQueryParams(BaseModel):
 
     after: str | None = None
     include: list[ConversationItemInclude] | None = None
-    limit: int | None = None
+    limit: int | None = Field(default=None, ge=1, le=100)
     order: Literal["asc", "desc"] | None = None
 
 

--- a/src/ogx_api/conversations/models.py
+++ b/src/ogx_api/conversations/models.py
@@ -233,6 +233,8 @@ class ListItemsRequest(BaseModel):
     )
     limit: int | None = Field(
         default=None,
+        ge=1,
+        le=100,
         description="A limit on the number of objects to be returned (1-100, default 20).",
     )
     order: Literal["asc", "desc"] | None = Field(

--- a/src/ogx_api/provider/__init__.py
+++ b/src/ogx_api/provider/__init__.py
@@ -9,7 +9,7 @@ Provider SDK surface for OGX.
 
 This namespace contains the symbols an out-of-tree provider needs to register
 itself with the OGX server: protocol classes, provider specs, the `Api` enum,
-the `webmethod` decorator, schema utilities, and shared resource/value types.
+schema utilities, and shared resource/value types.
 
 The Provider SDK surface is levelled as a single cohesive contract — see
 `docs/docs/concepts/apis/api_leveling.mdx` for the stability rules. The whole

--- a/src/ogx_api/vector_io/models.py
+++ b/src/ogx_api/vector_io/models.py
@@ -758,6 +758,16 @@ class OpenAICreateVectorStoreFileBatchRequestWithExtraBody(BaseModel, extra="all
     attributes: VectorStoreFileAttributes | None = None
     chunking_strategy: VectorStoreChunkingStrategy | None = None
 
+    @model_validator(mode="after")
+    def validate_file_ids_or_files(self) -> "OpenAICreateVectorStoreFileBatchRequestWithExtraBody":
+        has_file_ids = len(self.file_ids) > 0
+        has_files = self.files is not None and len(self.files) > 0
+        if has_file_ids and has_files:
+            raise ValueError("Only one of 'file_ids' or 'files' may be provided, not both")
+        if not has_file_ids and not has_files:
+            raise ValueError("Either 'file_ids' or 'files' must be provided")
+        return self
+
 
 @json_schema_type
 class ChunkForDeletion(BaseModel):

--- a/tests/common/mcp.py
+++ b/tests/common/mcp.py
@@ -180,11 +180,12 @@ def make_mcp_server(
 
     logging.getLogger("mcp.server.lowlevel.server").setLevel(logging.WARNING)
 
-    tools = tools or default_tools()
+    if tools is None:
+        tools = default_tools()
 
     # Register all tools with the server
-    for tool_func in tools.values():
-        server.tool()(tool_func)
+    for tool_name, tool_func in tools.items():
+        server.tool(name=tool_name)(tool_func)
 
     sse = SseServerTransport("/messages/")
 


### PR DESCRIPTION
# What does this PR do?

Fixes 6 medium-severity findings from a Clawpatch code review where documented behavior diverged from implementation. Each fix aligns the code with its documented contract rather than weakening the documentation.

**Changes:**
1. **Provider SDK docstring** — removed stale `webmethod` decorator reference (removed in #5248)
2. **Vector store file batch** — added `model_validator` enforcing `file_ids`/`files` mutual exclusivity as documented
3. **`allowed_models` filtering** — preserved `None` vs `[]` distinction so `None` means "all allowed" and `[]` means "none allowed"
4. **`no_proxy` support** — implemented proxy bypass mounts in `_build_proxy_mounts` so the documented `ProxyConfig.no_proxy` field actually works
5. **MCP test helper** — changed to `if tools is None:` for default fallback and registers tools with the mapping key name
6. **Conversation list-items `limit`** — added `ge=1, le=100` validation to match the documented bounds

## Test Plan

1. Pre-commit checks pass (all 40 hooks including mypy, API spec breaking changes check, ruff):
```
uv run pre-commit run --all-files
# All passed
```

2. Unit tests pass (2341 passed, 3 skipped):
```
uv run pytest tests/unit/ -x --tb=short --ignore=tests/unit/providers/vector_io
# 2341 passed, 3 skipped, 3 xfailed
```

3. OpenAPI specs regenerated successfully with no breaking changes detected.