### PR TITLE
fix: reuse cached local Weaviate client instead of leaking instances

### DIFF
--- a/src/ogx/providers/remote/vector_io/weaviate/weaviate.py
+++ b/src/ogx/providers/remote/vector_io/weaviate/weaviate.py
@@ -312,15 +312,17 @@ class WeaviateVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
 
     def _get_client(self) -> weaviate.WeaviateClient:
         if "localhost" in self.config.weaviate_cluster_url:
-            log.info("Using Weaviate locally in container")
             host, port = self.config.weaviate_cluster_url.split(":")
-            key = "local_test"
+            key = f"local::{host}::{port}"
+            if key in self.client_cache:
+                return self.client_cache[key]
+            log.info("Using Weaviate locally in container")
             client = weaviate.connect_to_local(host=host, port=port)
         else:
-            log.info("Using Weaviate remote cluster with URL")
             key = f"{self.config.weaviate_cluster_url}::{self.config.weaviate_api_key}"
             if key in self.client_cache:
                 return self.client_cache[key]
+            log.info("Using Weaviate remote cluster with URL")
             client = weaviate.connect_to_weaviate_cloud(
                 cluster_url=self.config.weaviate_cluster_url,
                 auth_credentials=Auth.api_key(self.config.weaviate_api_key),


### PR DESCRIPTION
# What does this PR do?

The localhost branch of `_get_client()` always created a new `weaviate.connect_to_local()` connection and overwrote the constant `"local_test"` cache entry without checking for an existing client first. This leaked one client per stored vector store during `initialize()`, since `shutdown()` only closes clients still in `client_cache` at that point.

This fix keys the local cache entry by `host::port` (matching the remote branch pattern) and returns early when the key already exists, preventing client leaks.

## Test Plan

```bash
uv run pre-commit run --files src/ogx/providers/remote/vector_io/weaviate/weaviate.py  # all passed
```

Verified by code inspection that the local branch now mirrors the remote branch's cache-check-before-create pattern.