### PR TITLE
fix(deps): add missing chardet dependency to file processor provider specs

### DIFF
--- a/src/ogx/providers/registry/file_processors.py
+++ b/src/ogx/providers/registry/file_processors.py
@@ -22,7 +22,7 @@ def available_providers() -> list[ProviderSpec]:
         InlineProviderSpec(
             api=Api.file_processors,
             provider_type="inline::auto",
-            pip_packages=["pypdf>=6.7.2", "markitdown[all]"],
+            pip_packages=["chardet", "pypdf>=6.7.2", "markitdown[all]"],
             module="ogx.providers.inline.file_processor.auto",
             config_class="ogx.providers.inline.file_processor.auto.AutoFileProcessorConfig",
             api_dependencies=[Api.files],
@@ -36,7 +36,7 @@ def available_providers() -> list[ProviderSpec]:
         InlineProviderSpec(
             api=Api.file_processors,
             provider_type="inline::pypdf",
-            pip_packages=["pypdf>=6.7.2"],
+            pip_packages=["chardet", "pypdf>=6.7.2"],
             module="ogx.providers.inline.file_processor.pypdf",
             config_class="ogx.providers.inline.file_processor.pypdf.PyPDFFileProcessorConfig",
             api_dependencies=[Api.files],


### PR DESCRIPTION
# What does this PR do?

The `inline::pypdf` and `inline::auto` file processor provider specs import `chardet` at module load for encoding detection, but neither spec declared it in `pip_packages`. This causes `ModuleNotFoundError` on clean installs driven by registry metadata. This PR adds `chardet` to both specs' `pip_packages` lists, matching the pattern already used in `vector_io.py` where `chardet` is included in `DEFAULT_VECTOR_IO_DEPS`.

## Test Plan

1. Verified `chardet` is already declared in `DEFAULT_VECTOR_IO_DEPS` in `vector_io.py`, confirming the omission in `file_processors.py` was accidental.
2. Ran provider codegen (`provider_codegen.py`) — no additional generated files changed.
3. Pre-commit checks pass on the changed file.