### PR TITLE
fix(cli): stop ogx run --port argparse default from overriding config

### DIFF
--- a/src/ogx/cli/stack/run.py
+++ b/src/ogx/cli/stack/run.py
@@ -39,7 +39,7 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         "--port",
         type=int,
         help="Port to run the server on. It can also be passed via the env var OGX_PORT.",
-        default=int(os.getenv("OGX_PORT", 8321)),
+        default=None,
     )
     parser.add_argument(
         "--enable-ui",
@@ -60,7 +60,9 @@ def run_stack_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
     from ogx.core.configure import parse_and_maybe_upgrade_config
 
     if args.enable_ui:
-        _start_ui_development_server(args.port)
+        env_port = os.getenv("OGX_PORT")
+        ui_port = args.port or (int(env_port) if env_port else None) or 8321
+        _start_ui_development_server(ui_port)
 
     if args.config:
         try:
@@ -120,7 +122,8 @@ def _uvicorn_run(config_file: Path | None, args: argparse.Namespace, parser: arg
         config_contents = yaml.safe_load(fp)
         config = parse_and_maybe_upgrade_config(config_contents)
 
-    port = args.port or config.server.port
+    env_port = os.getenv("OGX_PORT")
+    port = args.port or (int(env_port) if env_port else None) or config.server.port
     workers = config.server.workers
 
     host = ""


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where `ogx run` always ignores the `server.port` value from config files. The argparse `--port` default was hardcoded to `8321` (or `OGX_PORT`), so `args.port` was never `None` and the `args.port or config.server.port` expression always picked the argparse default.

The fix changes the argparse default to `None` and resolves the port with explicit precedence:
1. CLI `--port` flag (explicit user intent)
2. `OGX_PORT` environment variable
3. Config file `server.port`
4. Hardcoded default `8321`

## Test Plan

1. Pre-commit checks pass on modified file
2. Unit tests pass (287 relevant tests including `test_stack_run.py`):
```
uv run pytest tests/unit/ -x --tb=short -q -k "run or cli or port"
# 287 passed, 2060 deselected
```

3. Manual verification of precedence logic:
   - Without `--port` and without `OGX_PORT`: config file port is now respected
   - With `--port 9000`: CLI flag wins over config
   - With `OGX_PORT=9000` (no `--port`): env var wins over config