### PR TITLE
fix(ci): update constraint deps script to handle missing and regular dependencies

### DIFF
--- a/.github/scripts/update_constraint_deps.py
+++ b/.github/scripts/update_constraint_deps.py
@@ -167,25 +167,29 @@ def main() -> int:
     # 2. Try updating >= floors in regular dependency arrays
     if dep_indices:
         any_changed = False
-        skip_reasons = []
+        has_floor = False
         for idx in dep_indices:
             new_line, changed, reason = update_constraint(lines[idx], args.dependency_name, args.dependency_version)
             if changed:
                 lines[idx] = new_line
                 any_changed = True
+                has_floor = True
                 print(f"UPDATED (dependencies): {reason}")
-            else:
-                skip_reasons.append(reason)
+            elif "no >= lower bound" not in reason:
+                has_floor = True
+                print(f"SKIP (dependencies): {reason}")
         if any_changed:
             pyproject_path.write_text("".join(lines))
             print("updated=true")
-        else:
-            for r in skip_reasons:
-                print(f"SKIP (dependencies): {r}")
+            return 0
+        if has_floor:
             print("updated=false")
-        return 0
+            return 0
+        # Found in dependencies but no >= floor anywhere — fall through to
+        # add to constraint-dependencies so the version floor is tracked somewhere
 
-    # 3. Not found anywhere — add to constraint-dependencies
+    # 3. Not found in constraint-dependencies, and either not in regular deps
+    #    or present without a >= floor — add to constraint-dependencies
     lines, changed, reason = insert_constraint(lines, args.dependency_name, args.dependency_version)
     if not changed:
         print(f"SKIP: {reason}")

--- a/tests/unit/test_update_constraint_deps.py
+++ b/tests/unit/test_update_constraint_deps.py
@@ -54,6 +54,10 @@ SAMPLE_PYPROJECT = textwrap.dedent("""\
     ]
 
     [dependency-groups]
+    dev = [
+        "ruff",
+        "black",
+    ]
     test = [
         "google-genai>=1.69.0",
     ]
@@ -454,6 +458,34 @@ class TestMainCli:
         content = pyproject.read_text()
         assert "aiohttp>=3.14.0" in content
         assert "CVE-2026-34514" in content
+
+    def test_bare_dep_no_constraint_adds_to_constraints(self, tmp_path):
+        """A dep without a >= floor in dependencies and not in constraint-dependencies
+        gets added to constraint-dependencies."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(SAMPLE_PYPROJECT)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(_script_path),
+                "--dependency-name",
+                "ruff",
+                "--dependency-version",
+                "0.12.0",
+                "--pyproject",
+                str(pyproject),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "updated=true" in result.stdout
+        assert "ADDED" in result.stdout
+        content = pyproject.read_text()
+        assert '"ruff>=0.12.0"' in content
+        # Original bare "ruff" in dev deps should be untouched
+        assert '    "ruff",\n' in content
 
     def test_missing_pyproject_returns_error(self, tmp_path):
         result = subprocess.run(


### PR DESCRIPTION
# What does this PR do?

Extends the Dependabot constraint-dependencies update script to handle three cases instead of just one:

1. **Dependency in `constraint-dependencies`** — update the `>=` floor in place (existing behavior)
2. **Dependency in regular dependency arrays** (`[project] dependencies`, `[project.optional-dependencies]`, `[dependency-groups]`) — update the `>=` floor in place across all occurrences
3. **Dependency not found anywhere** (or found without a `>=` specifier) — add a new entry to `constraint-dependencies` in alphabetical order

Previously, the script would skip with "not found in constraint-dependencies" for deps like `google-genai` (which lives in `starter` and `test` groups) or `ruff` (which has no version specifier in `dev`). This caused Dependabot PRs to silently skip version floor updates.

Key fix: when a dependency exists in regular deps without a `>=` floor (e.g., bare `"ruff"`), the script falls through to add it to `constraint-dependencies`. But when it has a `>=` floor and the new version isn't newer, it correctly stops without falling through.

## Test Plan

Unit tests covering all paths:

```bash
uv run pytest tests/unit/test_update_constraint_deps.py -x --tb=short
```

```
43 passed in 2.14s
```

Pre-commit checks pass:
```bash
uv run pre-commit run --files .github/scripts/update_constraint_deps.py tests/unit/test_update_constraint_deps.py
```