### PR TITLE
fix(ci): use PAT for constraint update commits to trigger CI

### DIFF
--- a/.github/workflows/commit-constraint-updates.yml
+++ b/.github/workflows/commit-constraint-updates.yml
@@ -187,7 +187,7 @@ jobs:
           repository: ${{ steps.pr-info.outputs.head_repo }}
           ref: ${{ steps.pr-info.outputs.head_ref }}
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Restore artifacts after checkout
         if: steps.download-update.outputs.skip != 'true' && steps.changes.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true' && steps.pr-info.outputs.is_fork_pr != 'true'
@@ -222,7 +222,7 @@ jobs:
         id: commit
         if: steps.download-update.outputs.skip != 'true' && steps.changes.outputs.skip != 'true' && steps.pr-info.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ steps.pr-info.outputs.is_fork_pr == 'true' && secrets.RELEASE_PAT || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           HEAD_REPO: ${{ steps.pr-info.outputs.head_repo }}
           HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
@@ -260,7 +260,8 @@ jobs:
             fi
           else
             echo "Pushing to same-repo PR branch: $HEAD_REF"
-            git push origin "HEAD:${HEAD_REF}"
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${BASE_REPO}.git" \
+              "HEAD:${HEAD_REF}"
             echo "Successfully pushed constraint updates"
             echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
# What does this PR do?

Fixes CI not running after the constraint-dependencies update workflow commits changes to Dependabot PRs.

The `commit-constraint-updates.yml` workflow was using `github.token` (the default `GITHUB_TOKEN`) for checking out and pushing to same-repo PR branches. GitHub intentionally prevents commits pushed with `GITHUB_TOKEN` from triggering subsequent workflows to avoid infinite loops. This meant CI never ran on the constraint update commit, leaving PRs like #5859 without status checks.

The fix switches to `RELEASE_PAT` for both the checkout `token:` and the `git push` command on same-repo PRs, matching the fork PR path which already used it correctly.

## Test Plan

- Verify on the next Dependabot PR that constraint updates trigger CI after being committed
- The fork PR path already uses `RELEASE_PAT` and works correctly, so this aligns the same-repo path