### PR TITLE
fix(ci): do not add deps to constraint-dependencies when already declared

### DIFF
--- a/.github/scripts/update_constraint_deps.py
+++ b/.github/scripts/update_constraint_deps.py
@@ -164,32 +164,30 @@ def main() -> int:
         print("updated=true")
         return 0
 
-    # 2. Try updating >= floors in regular dependency arrays
+    # 2. Try updating >= floors in regular dependency arrays.
+    #    If the dep is declared here (even without a >= floor), stop — don't
+    #    add a redundant entry to constraint-dependencies.
     if dep_indices:
         any_changed = False
-        has_floor = False
+        skip_reasons = []
         for idx in dep_indices:
             new_line, changed, reason = update_constraint(lines[idx], args.dependency_name, args.dependency_version)
             if changed:
                 lines[idx] = new_line
                 any_changed = True
-                has_floor = True
                 print(f"UPDATED (dependencies): {reason}")
-            elif "no >= lower bound" not in reason:
-                has_floor = True
-                print(f"SKIP (dependencies): {reason}")
+            else:
+                skip_reasons.append(reason)
         if any_changed:
             pyproject_path.write_text("".join(lines))
             print("updated=true")
-            return 0
-        if has_floor:
+        else:
+            for r in skip_reasons:
+                print(f"SKIP (dependencies): {r}")
             print("updated=false")
-            return 0
-        # Found in dependencies but no >= floor anywhere — fall through to
-        # add to constraint-dependencies so the version floor is tracked somewhere
+        return 0
 
-    # 3. Not found in constraint-dependencies, and either not in regular deps
-    #    or present without a >= floor — add to constraint-dependencies
+    # 3. Not found anywhere — add to constraint-dependencies
     lines, changed, reason = insert_constraint(lines, args.dependency_name, args.dependency_version)
     if not changed:
         print(f"SKIP: {reason}")

--- a/tests/unit/test_update_constraint_deps.py
+++ b/tests/unit/test_update_constraint_deps.py
@@ -459,11 +459,12 @@ class TestMainCli:
         assert "aiohttp>=3.14.0" in content
         assert "CVE-2026-34514" in content
 
-    def test_bare_dep_no_constraint_adds_to_constraints(self, tmp_path):
-        """A dep without a >= floor in dependencies and not in constraint-dependencies
-        gets added to constraint-dependencies."""
+    def test_bare_dep_skips_without_adding_to_constraints(self, tmp_path):
+        """A dep without a >= floor in dependencies must NOT be added to
+        constraint-dependencies — it is already declared elsewhere."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(SAMPLE_PYPROJECT)
+        original = pyproject.read_text()
 
         result = subprocess.run(
             [
@@ -480,12 +481,9 @@ class TestMainCli:
             text=True,
         )
         assert result.returncode == 0
-        assert "updated=true" in result.stdout
-        assert "ADDED" in result.stdout
-        content = pyproject.read_text()
-        assert '"ruff>=0.12.0"' in content
-        # Original bare "ruff" in dev deps should be untouched
-        assert '    "ruff",\n' in content
+        assert "updated=false" in result.stdout
+        assert "SKIP (dependencies)" in result.stdout
+        assert pyproject.read_text() == original
 
     def test_missing_pyproject_returns_error(self, tmp_path):
         result = subprocess.run(


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in the constraint deps update script (#5888) where dependencies found in regular dependency arrays (e.g., `"ruff"` in `[dependency-groups] dev`) without a `>=` version floor were incorrectly falling through and getting added to `constraint-dependencies`.

This caused PR #5855 (ruff bump) to add a redundant `"ruff>=0.15.13"` entry to `constraint-dependencies` even though `ruff` is already declared in `[dependency-groups] dev`.

The fix: when a dependency is found in any regular dependency array, always stop processing — regardless of whether it has a `>=` floor. Only add to `constraint-dependencies` when the dep is truly not found anywhere in pyproject.toml.

## Test Plan

```bash
uv run pytest tests/unit/test_update_constraint_deps.py -x --tb=short
```

```
43 passed in 0.37s
```

The `test_bare_dep_skips_without_adding_to_constraints` test verifies that `ruff` (bare dep in `dev`) is skipped with `updated=false` and the file is not modified.