### PR TITLE
feat(messages): add URL image source and fix vision support in Messages API

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -10284,6 +10284,32 @@ components:
       type: object
       title: AllowedToolsFilter
       description: Filter configuration for restricting which MCP tools can be used.
+    AnthropicBase64ImageSource:
+      properties:
+        type:
+          type: string
+          title: Type
+          enum:
+          - base64
+        media_type:
+          type: string
+          enum:
+          - image/jpeg
+          - image/png
+          - image/gif
+          - image/webp
+          title: Media Type
+          description: MIME type of the image.
+        data:
+          type: string
+          title: Data
+          description: Base64-encoded image data.
+      type: object
+      required:
+      - media_type
+      - data
+      title: AnthropicBase64ImageSource
+      description: Base64-encoded image source.
     AnthropicCountTokensRequest:
       properties:
         model:
@@ -10422,33 +10448,22 @@ components:
           enum:
           - image
         source:
-          $ref: '#/components/schemas/AnthropicImageSource'
+          oneOf:
+          - $ref: '#/components/schemas/AnthropicBase64ImageSource'
+            title: AnthropicBase64ImageSource
+          - $ref: '#/components/schemas/AnthropicURLImageSource'
+            title: AnthropicURLImageSource
+          title: AnthropicBase64ImageSource | AnthropicURLImageSource
+          discriminator:
+            propertyName: type
+            mapping:
+              base64: '#/components/schemas/AnthropicBase64ImageSource'
+              url: '#/components/schemas/AnthropicURLImageSource'
       type: object
       required:
       - source
       title: AnthropicImageBlock
       description: An image content block.
-    AnthropicImageSource:
-      properties:
-        type:
-          type: string
-          title: Type
-          enum:
-          - base64
-        media_type:
-          type: string
-          title: Media Type
-          description: MIME type of the image (e.g. image/png).
-        data:
-          type: string
-          title: Data
-          description: Base64-encoded image data.
-      type: object
-      required:
-      - media_type
-      - data
-      title: AnthropicImageSource
-      description: Source for an image content block.
     AnthropicMessage:
       properties:
         role:
@@ -10727,6 +10742,22 @@ components:
       - input
       title: AnthropicToolUseBlock
       description: A tool use content block in an assistant message.
+    AnthropicURLImageSource:
+      properties:
+        type:
+          type: string
+          title: Type
+          enum:
+          - url
+        url:
+          type: string
+          title: Url
+          description: URL of the image.
+      type: object
+      required:
+      - url
+      title: AnthropicURLImageSource
+      description: URL image source.
     AnthropicUsage:
       properties:
         input_tokens:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -9837,6 +9837,32 @@ components:
       type: object
       title: AllowedToolsFilter
       description: Filter configuration for restricting which MCP tools can be used.
+    AnthropicBase64ImageSource:
+      properties:
+        type:
+          type: string
+          title: Type
+          enum:
+          - base64
+        media_type:
+          type: string
+          enum:
+          - image/jpeg
+          - image/png
+          - image/gif
+          - image/webp
+          title: Media Type
+          description: MIME type of the image.
+        data:
+          type: string
+          title: Data
+          description: Base64-encoded image data.
+      type: object
+      required:
+      - media_type
+      - data
+      title: AnthropicBase64ImageSource
+      description: Base64-encoded image source.
     AnthropicCountTokensRequest:
       properties:
         model:
@@ -9975,33 +10001,22 @@ components:
           enum:
           - image
         source:
-          $ref: '#/components/schemas/AnthropicImageSource'
+          oneOf:
+          - $ref: '#/components/schemas/AnthropicBase64ImageSource'
+            title: AnthropicBase64ImageSource
+          - $ref: '#/components/schemas/AnthropicURLImageSource'
+            title: AnthropicURLImageSource
+          title: AnthropicBase64ImageSource | AnthropicURLImageSource
+          discriminator:
+            propertyName: type
+            mapping:
+              base64: '#/components/schemas/AnthropicBase64ImageSource'
+              url: '#/components/schemas/AnthropicURLImageSource'
       type: object
       required:
       - source
       title: AnthropicImageBlock
       description: An image content block.
-    AnthropicImageSource:
-      properties:
-        type:
-          type: string
-          title: Type
-          enum:
-          - base64
-        media_type:
-          type: string
-          title: Media Type
-          description: MIME type of the image (e.g. image/png).
-        data:
-          type: string
-          title: Data
-          description: Base64-encoded image data.
-      type: object
-      required:
-      - media_type
-      - data
-      title: AnthropicImageSource
-      description: Source for an image content block.
     AnthropicMessage:
       properties:
         role:
@@ -10280,6 +10295,22 @@ components:
       - input
       title: AnthropicToolUseBlock
       description: A tool use content block in an assistant message.
+    AnthropicURLImageSource:
+      properties:
+        type:
+          type: string
+          title: Type
+          enum:
+          - url
+        url:
+          type: string
+          title: Url
+          description: URL of the image.
+      type: object
+      required:
+      - url
+      title: AnthropicURLImageSource
+      description: URL image source.
     AnthropicUsage:
       properties:
         input_tokens:

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -10284,6 +10284,32 @@ components:
       type: object
       title: AllowedToolsFilter
       description: Filter configuration for restricting which MCP tools can be used.
+    AnthropicBase64ImageSource:
+      properties:
+        type:
+          type: string
+          title: Type
+          enum:
+          - base64
+        media_type:
+          type: string
+          enum:
+          - image/jpeg
+          - image/png
+          - image/gif
+          - image/webp
+          title: Media Type
+          description: MIME type of the image.
+        data:
+          type: string
+          title: Data
+          description: Base64-encoded image data.
+      type: object
+      required:
+      - media_type
+      - data
+      title: AnthropicBase64ImageSource
+      description: Base64-encoded image source.
     AnthropicCountTokensRequest:
       properties:
         model:
@@ -10422,33 +10448,22 @@ components:
           enum:
           - image
         source:
-          $ref: '#/components/schemas/AnthropicImageSource'
+          oneOf:
+          - $ref: '#/components/schemas/AnthropicBase64ImageSource'
+            title: AnthropicBase64ImageSource
+          - $ref: '#/components/schemas/AnthropicURLImageSource'
+            title: AnthropicURLImageSource
+          title: AnthropicBase64ImageSource | AnthropicURLImageSource
+          discriminator:
+            propertyName: type
+            mapping:
+              base64: '#/components/schemas/AnthropicBase64ImageSource'
+              url: '#/components/schemas/AnthropicURLImageSource'
       type: object
       required:
       - source
       title: AnthropicImageBlock
       description: An image content block.
-    AnthropicImageSource:
-      properties:
-        type:
-          type: string
-          title: Type
-          enum:
-          - base64
-        media_type:
-          type: string
-          title: Media Type
-          description: MIME type of the image (e.g. image/png).
-        data:
-          type: string
-          title: Data
-          description: Base64-encoded image data.
-      type: object
-      required:
-      - media_type
-      - data
-      title: AnthropicImageSource
-      description: Source for an image content block.
     AnthropicMessage:
       properties:
         role:
@@ -10727,6 +10742,22 @@ components:
       - input
       title: AnthropicToolUseBlock
       description: A tool use content block in an assistant message.
+    AnthropicURLImageSource:
+      properties:
+        type:
+          type: string
+          title: Type
+          enum:
+          - url
+        url:
+          type: string
+          title: Url
+          description: URL of the image.
+      type: object
+      required:
+      - url
+      title: AnthropicURLImageSource
+      description: URL image source.
     AnthropicUsage:
       properties:
         input_tokens:

--- a/src/ogx/providers/inline/messages/impl.py
+++ b/src/ogx/providers/inline/messages/impl.py
@@ -37,6 +37,7 @@ from ogx_api.messages import (
 )
 from ogx_api.messages.models import (
     ANTHROPIC_VERSION,
+    AnthropicBase64ImageSource,
     AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
@@ -50,6 +51,7 @@ from ogx_api.messages.models import (
     AnthropicToolDef,
     AnthropicToolResultBlock,
     AnthropicToolUseBlock,
+    AnthropicURLImageSource,
     AnthropicUsage,
     CancelMessageBatchRequest,
     ContentBlockDeltaEvent,
@@ -120,6 +122,12 @@ _FINISH_TO_STOP_REASON = {
     "length": "max_tokens",
     "content_filter": "end_turn",
 }
+
+
+def _image_source_to_url(source: AnthropicBase64ImageSource | AnthropicURLImageSource) -> str:
+    if isinstance(source, AnthropicBase64ImageSource):
+        return f"data:{source.media_type};base64,{source.data}"
+    return source.url
 
 
 class BuiltinMessagesImpl(Messages):
@@ -647,10 +655,21 @@ class BuiltinMessagesImpl(Messages):
                         flush_content = text_parts
                     result.append({"role": "user", "content": flush_content})
                     text_parts = []
-                # Tool results become separate tool messages
+                # Tool results become separate tool messages.
+                # OpenAI tool messages only support text content, so image blocks
+                # from tool results are promoted to a follow-up user message.
                 tool_content = block.content
+                image_parts: list[dict[str, Any]] = []
                 if isinstance(tool_content, list):
-                    tool_content = "\n".join(b.text for b in tool_content if isinstance(b, AnthropicTextBlock))
+                    text_pieces = []
+                    for b in tool_content:
+                        if isinstance(b, AnthropicTextBlock):
+                            text_pieces.append(b.text)
+                        elif isinstance(b, AnthropicImageBlock):
+                            image_parts.append(
+                                {"type": "image_url", "image_url": {"url": _image_source_to_url(b.source)}}
+                            )
+                    tool_content = "\n".join(text_pieces)
                 result.append(
                     {
                         "role": "tool",
@@ -658,17 +677,12 @@ class BuiltinMessagesImpl(Messages):
                         "content": tool_content,
                     }
                 )
+                if image_parts:
+                    result.append({"role": "user", "content": image_parts})
             elif isinstance(block, AnthropicTextBlock):
                 text_parts.append({"type": "text", "text": block.text})
             elif isinstance(block, AnthropicImageBlock):
-                text_parts.append(
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:{block.source.media_type};base64,{block.source.data}",
-                        },
-                    }
-                )
+                text_parts.append({"type": "image_url", "image_url": {"url": _image_source_to_url(block.source)}})
 
         if text_parts:
             # OpenAI content must be a string or a list, never a single dict

--- a/src/ogx_api/__init__.py
+++ b/src/ogx_api/__init__.py
@@ -282,6 +282,7 @@ from .interactions import (
 )
 from .messages import (
     Messages,
+    AnthropicBase64ImageSource,
     AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
@@ -290,6 +291,7 @@ from .messages import (
     AnthropicImageBlock,
     AnthropicImageSource,
     AnthropicMessage,
+    AnthropicURLImageSource,
     AnthropicMessageResponse,
     AnthropicTextBlock,
     AnthropicThinkingBlock,
@@ -965,6 +967,7 @@ __all__ = [
     "GoogleUsage",
     # Messages API
     "Messages",
+    "AnthropicBase64ImageSource",
     "AnthropicContentBlock",
     "AnthropicCountTokensRequest",
     "AnthropicCountTokensResponse",
@@ -973,6 +976,7 @@ __all__ = [
     "AnthropicImageBlock",
     "AnthropicImageSource",
     "AnthropicMessage",
+    "AnthropicURLImageSource",
     "AnthropicMessageResponse",
     "AnthropicTextBlock",
     "AnthropicThinkingBlock",

--- a/src/ogx_api/messages/__init__.py
+++ b/src/ogx_api/messages/__init__.py
@@ -14,6 +14,7 @@ The FastAPI router is defined in ogx_api.messages.fastapi_routes.
 from . import fastapi_routes
 from .api import Messages
 from .models import (
+    AnthropicBase64ImageSource,
     AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
@@ -29,6 +30,7 @@ from .models import (
     AnthropicToolDef,
     AnthropicToolResultBlock,
     AnthropicToolUseBlock,
+    AnthropicURLImageSource,
     AnthropicUsage,
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
@@ -50,6 +52,7 @@ from .models import (
 
 __all__ = [
     "Messages",
+    "AnthropicBase64ImageSource",
     "AnthropicContentBlock",
     "AnthropicCountTokensRequest",
     "AnthropicCountTokensResponse",
@@ -58,6 +61,7 @@ __all__ = [
     "AnthropicImageBlock",
     "AnthropicImageSource",
     "AnthropicMessage",
+    "AnthropicURLImageSource",
     "AnthropicMessageResponse",
     "AnthropicTextBlock",
     "AnthropicThinkingBlock",

--- a/src/ogx_api/messages/models.py
+++ b/src/ogx_api/messages/models.py
@@ -31,12 +31,27 @@ class AnthropicTextBlock(BaseModel):
     text: str
 
 
-class AnthropicImageSource(BaseModel):
-    """Source for an image content block."""
+class AnthropicBase64ImageSource(BaseModel):
+    """Base64-encoded image source."""
 
     type: Literal["base64"] = "base64"
-    media_type: str = Field(..., description="MIME type of the image (e.g. image/png).")
+    media_type: Literal["image/jpeg", "image/png", "image/gif", "image/webp"] = Field(
+        ..., description="MIME type of the image."
+    )
     data: str = Field(..., description="Base64-encoded image data.")
+
+
+class AnthropicURLImageSource(BaseModel):
+    """URL image source."""
+
+    type: Literal["url"] = "url"
+    url: str = Field(..., description="URL of the image.")
+
+
+AnthropicImageSource = Annotated[
+    AnthropicBase64ImageSource | AnthropicURLImageSource,
+    Field(discriminator="type"),
+]
 
 
 class AnthropicImageBlock(BaseModel):

--- a/src/ogx_api/types/__init__.py
+++ b/src/ogx_api/types/__init__.py
@@ -247,6 +247,7 @@ from ogx_api.interactions import (
 
 # Messages
 from ogx_api.messages import (
+    AnthropicBase64ImageSource,
     AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
@@ -262,6 +263,7 @@ from ogx_api.messages import (
     AnthropicToolDef,
     AnthropicToolResultBlock,
     AnthropicToolUseBlock,
+    AnthropicURLImageSource,
     AnthropicUsage,
 )
 
@@ -691,6 +693,7 @@ __all__ = [
     "GoogleInteractionResponse",
     "GoogleUsage",
     # Messages (Anthropic)
+    "AnthropicBase64ImageSource",
     "AnthropicContentBlock",
     "AnthropicCountTokensRequest",
     "AnthropicCountTokensResponse",
@@ -699,6 +702,7 @@ __all__ = [
     "AnthropicImageBlock",
     "AnthropicImageSource",
     "AnthropicMessage",
+    "AnthropicURLImageSource",
     "AnthropicMessageResponse",
     "AnthropicTextBlock",
     "AnthropicThinkingBlock",

--- a/tests/unit/providers/inline/messages/test_impl.py
+++ b/tests/unit/providers/inline/messages/test_impl.py
@@ -15,12 +15,15 @@ from ogx.core.storage.datatypes import KVStoreReference
 from ogx.providers.inline.messages.config import MessagesConfig
 from ogx.providers.inline.messages.impl import BuiltinMessagesImpl
 from ogx_api.messages.models import (
+    AnthropicBase64ImageSource,
     AnthropicCreateMessageRequest,
+    AnthropicImageBlock,
     AnthropicMessage,
     AnthropicTextBlock,
     AnthropicToolDef,
     AnthropicToolResultBlock,
     AnthropicToolUseBlock,
+    AnthropicURLImageSource,
 )
 
 
@@ -180,6 +183,95 @@ class TestRequestTranslation:
         assert msg["role"] == "tool"
         assert msg["tool_call_id"] == "toolu_123"
         assert msg["content"] == "72F and sunny"
+
+    def test_base64_image_in_user_message(self, impl):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicTextBlock(text="What is in this image?"),
+                        AnthropicImageBlock(
+                            source=AnthropicBase64ImageSource(
+                                media_type="image/png",
+                                data="abc123",
+                            )
+                        ),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = impl._anthropic_to_openai(request)
+
+        assert len(result.messages) == 1
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], list)
+        assert msg["content"][0] == {"type": "text", "text": "What is in this image?"}
+        assert msg["content"][1] == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,abc123"},
+        }
+
+    def test_url_image_in_user_message(self, impl):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicImageBlock(source=AnthropicURLImageSource(url="https://example.com/img.jpg")),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = impl._anthropic_to_openai(request)
+
+        assert len(result.messages) == 1
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["content"] == [{"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}]
+
+    def test_image_in_tool_result_promoted_to_user_message(self, impl):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicToolResultBlock(
+                            tool_use_id="toolu_abc",
+                            content=[
+                                AnthropicTextBlock(text="Screenshot taken"),
+                                AnthropicImageBlock(
+                                    source=AnthropicBase64ImageSource(
+                                        media_type="image/png",
+                                        data="screenshotdata",
+                                    )
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = impl._anthropic_to_openai(request)
+
+        # First message: tool result with text only
+        assert len(result.messages) == 2
+        tool_msg = _msg_to_dict(result.messages[0])
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "toolu_abc"
+        assert tool_msg["content"] == "Screenshot taken"
+        # Second message: image promoted to user message
+        image_msg = _msg_to_dict(result.messages[1])
+        assert image_msg["role"] == "user"
+        assert image_msg["content"] == [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,screenshotdata"}}
+        ]
 
     def test_top_k_passed_as_extra(self, impl):
         request = AnthropicCreateMessageRequest(


### PR DESCRIPTION
## Summary

- Split `AnthropicImageSource` into `AnthropicBase64ImageSource` and `AnthropicURLImageSource` as a Pydantic discriminated union — URL image sources previously failed validation entirely
- Constrained `media_type` to the four valid MIME types (`image/jpeg`, `image/png`, `image/gif`, `image/webp`)
- Updated the translator to handle both source types: base64 → data URI, URL → forwarded directly as `image_url`
- Fixed images in `tool_result` content blocks being silently dropped; they are now promoted to a follow-up `user` message (OpenAI tool messages do not support image content parts)

## Test plan

- [ ] `uv run pytest tests/unit/providers/inline/messages/ -x --tb=short` — 22 tests pass (3 new: base64 image in user message, URL image in user message, image in tool_result promoted to user message)
- [ ] Manual test with a vision-capable model via `POST /v1/messages` with an `image` content block