### PR TITLE
fix(ui): fix sidebar conversations hydration mismatch

### DIFF
--- a/src/ogx_ui/components/layout/app-sidebar.tsx
+++ b/src/ogx_ui/components/layout/app-sidebar.tsx
@@ -139,10 +139,12 @@ export function AppSidebar() {
   const [conversations, setConversations] = useState<
     ConversationHistoryEntry[]
   >([]);
-  const [isConversationsOpen, setIsConversationsOpen] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return sessionStorage.getItem("sidebar-conversations-open") === "true";
-  });
+  const [isConversationsOpen, setIsConversationsOpen] = useState(false);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem("sidebar-conversations-open");
+    if (stored === "true") setIsConversationsOpen(true);
+  }, []);
 
   useEffect(() => {
     sessionStorage.setItem(


### PR DESCRIPTION
## Summary

- Fix SSR hydration mismatch in the sidebar conversations collapsible by moving `sessionStorage` read from `useState` initializer to `useEffect`

The `useState` lazy initializer runs on both server and client. On the server, `sessionStorage` doesn't exist so it returns `false`, but on the client it may return `true` — causing React to detect a hydration mismatch and regenerate the tree. The fix initializes state as `false` and restores from `sessionStorage` in a `useEffect` (client-only, post-hydration).

## Test plan
- [x] Verified no hydration mismatch error in browser console
- [x] Sidebar conversations expand/collapse state still persists across navigations
- [x] `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)