### PR TITLE
fix: bounded chunked reads before unbounded fallback in upload reader

### DIFF
--- a/src/ogx_api/common/upload_limits.py
+++ b/src/ogx_api/common/upload_limits.py
@@ -69,7 +69,26 @@ async def read_upload_with_size_limit(
                 raise FileTooLargeError(file_size=total_bytes, max_size=max_upload_bytes)
             chunks.append(chunk)
     except TypeError:
-        # file.read() doesn't accept a size argument — read all at once
+        # file.read() doesn't accept a size argument — try the underlying
+        # synchronous file object for bounded chunked reads before resorting
+        # to an unbounded read.
+        underlying = getattr(file, "_buf", None) or getattr(file, "file", None)
+        if underlying is not None and callable(getattr(underlying, "read", None)):
+            try:
+                while True:
+                    chunk = underlying.read(_READ_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    total_bytes += len(chunk)
+                    if total_bytes > max_upload_bytes:
+                        raise FileTooLargeError(file_size=total_bytes, max_size=max_upload_bytes) from None
+                    chunks.append(chunk)
+                return b"".join(chunks)
+            except TypeError:
+                pass
+
+        # Last resort: declared_size was already validated above so if it was
+        # set the read is bounded; otherwise we have no way to chunk.
         content: bytes = await file.read()
         if len(content) > max_upload_bytes:
             raise FileTooLargeError(file_size=len(content), max_size=max_upload_bytes) from None


### PR DESCRIPTION
# What does this PR do?

When `file.read(size)` raises `TypeError` (file objects that don't support sized reads), `read_upload_with_size_limit` fell back to `await file.read()` without a size argument, buffering the entire payload into memory before checking `max_upload_bytes`. A sufficiently large upload could consume arbitrary memory before `FileTooLargeError` is raised.

This fix attempts bounded chunked reads from the underlying synchronous file object (accessed via `_buf` or `file` attributes) before falling back to the unbounded read, reducing memory exposure for large uploads without a declared size.

## Test Plan

```bash
uv run pytest tests/unit/files/test_upload_limits.py -x --tb=short  # 17 passed
uv run pre-commit run --files src/ogx_api/common/upload_limits.py    # all passed
```