### PR TITLE
fix(ci): update constraint deps script to handle missing and regular dependencies

### DIFF
--- a/.github/scripts/update_constraint_deps.py
+++ b/.github/scripts/update_constraint_deps.py
@@ -101,13 +101,38 @@ def insert_constraint(lines: list[str], pkg_name: str, version: str) -> tuple[li
     return lines, True, f"{pkg_name}: added to constraint-dependencies with >={version}"
 
 
-def update_constraint(line: str, pkg_name: str, new_version: str) -> tuple[str, bool, str]:
-    """Update the >= lower bound in a constraint-dependencies line.
+def add_floor(line: str, pkg_name: str, version: str) -> tuple[str, bool, str]:
+    """Add a >= floor to a dependency line that has no version specifier.
+
+    Transforms  "pkg"  or  "pkg",  into  "pkg>=version"  or  "pkg>=version",
+    preserving extras, whitespace, trailing comma, and inline comments.
 
     Returns (new_line, changed, reason).
     """
     pkg_pattern = normalize_pkg_pattern(pkg_name)
-    lower_bound_pattern = re.compile(rf'("{pkg_pattern}>=)([\d]+(?:\.[\d]+)*)', re.IGNORECASE)
+    bare_pattern = re.compile(
+        rf'(?P<pre>\s*")(?P<name>{pkg_pattern})(?P<extras>\[[^\]]*\])?(?P<post>")',
+        re.IGNORECASE,
+    )
+    match = bare_pattern.search(line)
+    if not match:
+        return line, False, f"could not parse dependency line for {pkg_name}"
+
+    extras = match.group("extras") or ""
+    new_line = bare_pattern.sub(
+        rf"\g<pre>\g<name>{extras}>={version}\g<post>",
+        line,
+    )
+    return new_line, True, f"{pkg_name}: added >= floor {version}"
+
+
+def update_constraint(line: str, pkg_name: str, new_version: str) -> tuple[str, bool, str]:
+    """Update the >= lower bound in a dependency line.
+
+    Returns (new_line, changed, reason).
+    """
+    pkg_pattern = normalize_pkg_pattern(pkg_name)
+    lower_bound_pattern = re.compile(rf'("{pkg_pattern}(?:\[[^\]]*\])?>=)([\d]+(?:\.[\d]+)*)', re.IGNORECASE)
 
     match = lower_bound_pattern.search(line)
     if not match:
@@ -117,7 +142,9 @@ def update_constraint(line: str, pkg_name: str, new_version: str) -> tuple[str, 
     if parse_version(new_version) <= parse_version(old_version):
         return line, False, (f"{pkg_name}: new version {new_version} <= current floor {old_version}")
 
-    upper_bound_match = re.search(rf'"{pkg_pattern}>=[^"]*,<([\d]+(?:\.[\d]+)*)"', line, re.IGNORECASE)
+    upper_bound_match = re.search(
+        rf'"{pkg_pattern}(?:\[[^\]]*\])?>=(?:[^"]*),<([\d]+(?:\.[\d]+)*)"', line, re.IGNORECASE
+    )
     if upper_bound_match:
         upper_version = upper_bound_match.group(1)
         if parse_version(new_version) >= parse_version(upper_version):
@@ -164,14 +191,15 @@ def main() -> int:
         print("updated=true")
         return 0
 
-    # 2. Try updating >= floors in regular dependency arrays.
-    #    If the dep is declared here (even without a >= floor), stop — don't
-    #    add a redundant entry to constraint-dependencies.
+    # 2. Update in place in regular dependency arrays — either bump an existing
+    #    >= floor or add one when the dep is bare (no version specifier).
     if dep_indices:
         any_changed = False
         skip_reasons = []
         for idx in dep_indices:
             new_line, changed, reason = update_constraint(lines[idx], args.dependency_name, args.dependency_version)
+            if not changed and "no >= lower bound" in reason:
+                new_line, changed, reason = add_floor(lines[idx], args.dependency_name, args.dependency_version)
             if changed:
                 lines[idx] = new_line
                 any_changed = True

--- a/tests/unit/test_update_constraint_deps.py
+++ b/tests/unit/test_update_constraint_deps.py
@@ -22,6 +22,7 @@ find_constraint_section = _mod.find_constraint_section
 find_constraint_line = _mod.find_constraint_line
 find_dependency_lines = _mod.find_dependency_lines
 insert_constraint = _mod.insert_constraint
+add_floor = _mod.add_floor
 update_constraint = _mod.update_constraint
 main = _mod.main
 
@@ -50,13 +51,14 @@ SAMPLE_PYPROJECT = textwrap.dedent("""\
     [project.optional-dependencies]
     starter = [
         "aiohttp",
+        "boto3",
         "google-genai>=1.69.0",
     ]
 
     [dependency-groups]
     dev = [
         "ruff",
-        "black",
+        "boto3",
     ]
     test = [
         "google-genai>=1.69.0",
@@ -222,6 +224,34 @@ class TestInsertConstraint:
         _, changed, reason = insert_constraint(lines, "pkg", "1.0.0")
         assert changed is False
         assert "not found" in reason
+
+
+class TestAddFloor:
+    def test_adds_floor_to_bare_dep(self):
+        line = '    "boto3",\n'
+        new_line, changed, reason = add_floor(line, "boto3", "1.43.9")
+        assert changed is True
+        assert '"boto3>=1.43.9"' in new_line
+        assert new_line.endswith(",\n")
+
+    def test_preserves_extras(self):
+        line = '    "pyjwt[crypto]",\n'
+        new_line, changed, _ = add_floor(line, "pyjwt", "2.12.0")
+        assert changed is True
+        assert '"pyjwt[crypto]>=2.12.0"' in new_line
+
+    def test_preserves_inline_comment(self):
+        line = '    "ruff",                            # linter\n'
+        new_line, changed, _ = add_floor(line, "ruff", "0.15.13")
+        assert changed is True
+        assert '"ruff>=0.15.13"' in new_line
+        assert "# linter" in new_line
+
+    def test_preserves_whitespace(self):
+        line = '    "boto3",\n'
+        new_line, changed, _ = add_floor(line, "boto3", "1.43.9")
+        assert changed is True
+        assert new_line.startswith("    ")
 
 
 class TestUpdateConstraint:
@@ -459,12 +489,11 @@ class TestMainCli:
         assert "aiohttp>=3.14.0" in content
         assert "CVE-2026-34514" in content
 
-    def test_bare_dep_skips_without_adding_to_constraints(self, tmp_path):
-        """A dep without a >= floor in dependencies must NOT be added to
-        constraint-dependencies — it is already declared elsewhere."""
+    def test_bare_dep_gets_floor_added_in_place(self, tmp_path):
+        """A bare dep (no version specifier) gets a >= floor added in place,
+        not added to constraint-dependencies."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(SAMPLE_PYPROJECT)
-        original = pyproject.read_text()
 
         result = subprocess.run(
             [
@@ -473,7 +502,7 @@ class TestMainCli:
                 "--dependency-name",
                 "ruff",
                 "--dependency-version",
-                "0.12.0",
+                "0.15.13",
                 "--pyproject",
                 str(pyproject),
             ],
@@ -481,9 +510,39 @@ class TestMainCli:
             text=True,
         )
         assert result.returncode == 0
-        assert "updated=false" in result.stdout
-        assert "SKIP (dependencies)" in result.stdout
-        assert pyproject.read_text() == original
+        assert "updated=true" in result.stdout
+        assert "UPDATED (dependencies)" in result.stdout
+        content = pyproject.read_text()
+        assert '"ruff>=0.15.13"' in content
+        assert "constraint-dependencies" in content
+        # Must NOT appear in constraint-dependencies
+        constraint_start = content.index("constraint-dependencies")
+        constraint_end = content.index("]", constraint_start)
+        assert "ruff" not in content[constraint_start:constraint_end]
+
+    def test_bare_dep_multiple_occurrences(self, tmp_path):
+        """A bare dep appearing in multiple sections gets >= floor added everywhere."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(SAMPLE_PYPROJECT)
+
+        result = subprocess.run(
+            [
+                "python3",
+                str(_script_path),
+                "--dependency-name",
+                "boto3",
+                "--dependency-version",
+                "1.43.9",
+                "--pyproject",
+                str(pyproject),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "updated=true" in result.stdout
+        content = pyproject.read_text()
+        assert content.count("boto3>=1.43.9") == 2
 
     def test_missing_pyproject_returns_error(self, tmp_path):
         result = subprocess.run(


### PR DESCRIPTION
# What does this PR do?

Fixes the Dependabot constraint-dependencies update script to properly handle bare deps (no version specifier) in regular dependency arrays.

**Before:** A dep like `"boto3"` or `"ruff"` in `[dependency-groups] dev` would either get incorrectly added to `constraint-dependencies` (fall-through bug from #5888) or silently skipped with `SKIP (dependencies): no >= lower bound`.

**After:** Bare deps get a `>=` floor added in place where they are declared. For example, `"boto3"` in `starter` becomes `"boto3>=1.43.9"`.

The three cases now work correctly:
1. **In constraint-dependencies** — update `>=` floor in place
2. **In regular deps with `>=` floor** — update in place
3. **In regular deps without `>=` floor** (bare like `"boto3"`) — add `>=` floor in place
4. **Not found anywhere** — add new entry to constraint-dependencies

Supersedes #5893.

## Test Plan

```bash
uv run pytest tests/unit/test_update_constraint_deps.py -x --tb=short
```

```
48 passed in 0.41s
```

New tests: `TestAddFloor` (4 unit tests), `test_bare_dep_gets_floor_added_in_place`, `test_bare_dep_multiple_occurrences`.