### PR TITLE
fix(ci): strip quotes from parsed dependency version in workflow

### DIFF
--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -52,8 +52,8 @@ jobs:
 
           # Extract dependency-name and dependency-version from the structured
           # updated-dependencies block in the Dependabot commit message
-          dep_name=$(echo "$commit_msg" | grep -oP '(?<=dependency-name: ).+' | head -1 | tr -d '[:space:]')
-          dep_version=$(echo "$commit_msg" | grep -oP '(?<=dependency-version: ).+' | head -1 | tr -d '[:space:]')
+          dep_name=$(echo "$commit_msg" | grep -oP '(?<=dependency-name: ).+' | head -1 | tr -d "[:space:]'\"")
+          dep_version=$(echo "$commit_msg" | grep -oP '(?<=dependency-version: ).+' | head -1 | tr -d "[:space:]'\"")
 
           if [ -z "$dep_name" ] || [ -z "$dep_version" ]; then
             echo "Could not parse dependency info from commit message"


### PR DESCRIPTION
# What does this PR do?

Fixes `uv lock` failure in the Dependabot constraint workflow when the dependency version in the commit message is single-quoted (e.g., `dependency-version: '3.15'`).

The parse step used `tr -d '[:space:]'` which only strips whitespace. Versions like `'3.15'` kept their quotes, producing invalid PEP 440 specifiers like `"idna>='3.15'"` that cause `uv lock` to fail.

Fix: `tr -d "[:space:]'\""` — also strips single and double quotes.

Failure: https://github.com/ogx-ai/ogx/actions/runs/26168453975/job/76979099490

## Test Plan

The fix is a one-line shell change. Verified by inspecting the Dependabot commit message format for `idna` which includes `dependency-version: '3.15'`.