### PR TITLE
feat(vllm): populate embedding metadata from models.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.41",                    # server - for conversations
     "mcp>=1.23.0",                                    # for connectors
     "zstandard>=0.23.0",                              # server - zstd request decompression
+    "models-dev>=1.0.398",
 ]
 
 [project.optional-dependencies]

--- a/src/ogx/providers/remote/inference/vllm/vllm.py
+++ b/src/ogx/providers/remote/inference/vllm/vllm.py
@@ -4,9 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 from collections.abc import AsyncIterator
+from functools import cache
 from urllib.parse import urljoin
 
 import httpx
+import models_dev as _models_dev
 from pydantic import ConfigDict
 
 from ogx.core.request_headers import get_authenticated_user
@@ -38,6 +40,26 @@ from ogx_api.inference import RerankRequest
 from .config import VLLMInferenceAdapterConfig
 
 log = get_logger(name=__name__, category="inference::vllm")
+
+
+def _is_embedding_model(model_id: str, model: _models_dev.Model) -> bool:
+    return (model.family is not None and "embed" in model.family) or "embed" in model_id.lower()
+
+
+@cache
+def _models_dev_index() -> dict[str, _models_dev.Model]:
+    index: dict[str, _models_dev.Model] = {}
+    # Sort so huggingface is processed last: vLLM serves HF model IDs and the
+    # huggingface provider entry is the most authoritative source for them.
+    for provider in sorted(_models_dev.providers(), key=lambda p: p.id == "huggingface"):
+        for model_id, model in provider.models.items():
+            if _is_embedding_model(model_id, model):
+                index[model_id] = model
+    return index
+
+
+def _lookup_models_dev(identifier: str) -> _models_dev.Model | None:
+    return _models_dev_index().get(identifier)
 
 
 class VLLMInferenceAdapter(OpenAIMixin):
@@ -184,14 +206,35 @@ class VLLMInferenceAdapter(OpenAIMixin):
         return _wrap_chunks()
 
     def construct_model_from_identifier(self, identifier: str) -> Model:
-        # vLLM's /v1/models response does not expose a model task/type field, so classify by name.
-        if "embed" in identifier.lower():
+        # vLLM's /v1/models response does not expose a model task/type field,
+        # so we classify with models.dev with a name fallback.
+        md = _lookup_models_dev(identifier)
+        is_embedding = md is not None or "embed" in identifier.lower()
+
+        if is_embedding:
+            metadata: dict[str, int] = {}
+            if md is not None:
+                if md.limit.output:
+                    metadata["embedding_dimension"] = md.limit.output
+                if md.limit.context:
+                    metadata["context_length"] = md.limit.context
+                log.debug(
+                    "Classified embedding model via models.dev",
+                    identifier=identifier,
+                    family=md.family,
+                    metadata=metadata,
+                )
+            else:
+                log.debug(
+                    "Classified embedding model via name heuristic (not in models.dev)",
+                    identifier=identifier,
+                )
             return Model(
                 provider_id=self.__provider_id__,  # type: ignore[attr-defined]
                 provider_resource_id=identifier,
                 identifier=identifier,
                 model_type=ModelType.embedding,
-                metadata={},
+                metadata=metadata,
             )
         if "rerank" in identifier.lower():
             return Model(

--- a/tests/unit/providers/inference/test_remote_vllm.py
+++ b/tests/unit/providers/inference/test_remote_vllm.py
@@ -21,6 +21,7 @@ from ogx.providers.remote.inference.vllm.vllm import VLLMInferenceAdapter
 from ogx_api import (
     HealthStatus,
     Model,
+    ModelType,
     OpenAIChatCompletion,
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAIChatCompletionResponseMessage,
@@ -317,7 +318,57 @@ async def test_vllm_chat_completion_extra_body():
         assert call_kwargs["extra_body"]["chat_template_kwargs"] == {"thinking": True}
 
 
-class TestHealthTLSConfig:
+class TestConstructModelFromIdentifier:
+    def _make_adapter(self) -> VLLMInferenceAdapter:
+        config = VLLMInferenceAdapterConfig(base_url="http://mocked.localhost:12345")
+        adapter = VLLMInferenceAdapter(config=config)
+        adapter.__provider_id__ = "vllm"
+        return adapter
+
+    def test_family_check_classifies_embedding_without_embed_in_identifier(self):
+        # intfloat/multilingual-e5-large-instruct has no "embed" in its identifier
+        # but its models.dev family is "text-embedding", so it must be classified
+        # as an embedding model with metadata populated from models.dev.
+        adapter = self._make_adapter()
+        model = adapter.construct_model_from_identifier("intfloat/multilingual-e5-large-instruct")
+
+        assert model.model_type == ModelType.embedding
+        assert model.metadata.get("embedding_dimension") == 512
+
+    def test_known_embedding_model_populates_metadata_from_models_dev(self):
+        # text-embedding-3-large is in models_dev (openai provider) with
+        # limit.output=3072 (embedding dimension) and limit.context=8191.
+        adapter = self._make_adapter()
+        model = adapter.construct_model_from_identifier("text-embedding-3-large")
+
+        assert model.model_type == ModelType.embedding
+        assert model.metadata.get("embedding_dimension") == 3072
+        assert model.metadata.get("context_length") == 8191
+
+    def test_unknown_embedding_model_falls_back_to_name_heuristic(self):
+        adapter = self._make_adapter()
+        model = adapter.construct_model_from_identifier("acme/custom-embed-v1")
+
+        assert model.model_type == ModelType.embedding
+        assert model.metadata == {}
+
+    def test_rerank_model_classified_correctly(self):
+        adapter = self._make_adapter()
+        model = adapter.construct_model_from_identifier("Qwen/Qwen3-Reranker-0.6B")
+
+        assert model.model_type == ModelType.rerank
+
+    def test_huggingface_provider_wins_over_other_providers(self):
+        # Qwen/Qwen3-Embedding-8B exists in multiple providers. evroc records
+        # output=40960 (the context window, not the embedding dimension).
+        # huggingface correctly records output=4096. The index must prefer
+        # huggingface so callers see the right embedding_dimension.
+        adapter = self._make_adapter()
+        model = adapter.construct_model_from_identifier("Qwen/Qwen3-Embedding-8B")
+
+        assert model.model_type == ModelType.embedding
+        assert model.metadata.get("embedding_dimension") == 4096
+
     """Tests that health() honours TLS/network configuration."""
 
     async def test_health_uses_shared_ssl_context_by_default(self):

--- a/uv.lock
+++ b/uv.lock
@@ -3532,6 +3532,15 @@ wheels = [
 ]
 
 [[package]]
+name = "models-dev"
+version = "1.0.398"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/c8/5702047a574dc8fcba1638bd6deb910910c57afea7e85bce176799566f4e/models_dev-1.0.398.tar.gz", hash = "sha256:6c087e8308e3be9f8e3b17ba96e00c2453504a5c674914220ef621f7fe53abd2", size = 193300, upload-time = "2026-05-21T13:55:58.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/0a/8cb8bb5e22a4f09565bfea38c8c280c791ae8d09303b8624a8c70fc3cedc/models_dev-1.0.398-py3-none-any.whl", hash = "sha256:86155586aed904094facaf1d19d87a0beeb9b0635804c831540892c97708263a", size = 178535, upload-time = "2026-05-21T13:55:57.017Z" },
+]
+
+[[package]]
 name = "moto"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3992,6 +4001,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "mcp" },
+    { name = "models-dev" },
     { name = "ogx-api" },
     { name = "openai" },
     { name = "opentelemetry-distro" },
@@ -4251,6 +4261,7 @@ requires-dist = [
     { name = "markitdown", extras = ["all"], marker = "extra == 'starter'" },
     { name = "matplotlib", marker = "extra == 'starter'" },
     { name = "mcp", specifier = ">=1.23.0" },
+    { name = "models-dev", specifier = ">=1.0.398" },
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },


### PR DESCRIPTION
vLLM's /v1/models response does not include a model type field, so embedding models previously had to be detected purely by name and were returned with an empty metadata dict.

Integrate the models-dev package to address both problems. Build a @cache-backed index over the models.dev catalog, filtered to embedding models only (family contains "embed" or model ID contains "embed"), with the huggingface provider sorted last so its entries win when the same model ID appears in multiple providers. Use the index to:

- classify models as embedding via family rather than name alone, catching models like intfloat/multilingual-e5-large-instruct whose identifier does not contain "embed"
- populate embedding_dimension and context_length from limit.output / limit.context when available

Fall back to the identifier heuristic for models not present in the catalog. Log at DEBUG level to distinguish which path was taken and what values were sourced.
