### PR TITLE
feat(cli/letsgo): add VLLM_API_TOKEN support to provider autodetection

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -84,6 +84,7 @@ class _ProbeStatus(enum.Enum):
     NO_KEY = "no_key"
     AUTH = "auth"
     UNREACHABLE = "unreachable"
+    NEEDS_KEY = "needs_key"  # reachable but optional auth token not configured
 
 
 def add_letsgo_arguments(parser: argparse.ArgumentParser) -> None:
@@ -208,7 +209,7 @@ def _autodetect_providers() -> str:
     candidates = [
         # provider_type, env_for_base_url, default_base_url, probe_path, requires_api_key, api_key_env, extra_headers, api_key_header
         ("remote::ollama", "OLLAMA_URL", "http://localhost:11434/v1", "models", False, None, {}, None),
-        ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", "health", False, None, {}, None),
+        ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN", {}, None),
         (
             "remote::llama-cpp-server",
             "LLAMA_CPP_SERVER_URL",
@@ -286,7 +287,7 @@ def _autodetect_providers() -> str:
 
         # Build annotation parts
         parts = [f"{base}, {base_source}"]
-        if requires_key and key_env:
+        if key_env:
             parts.append(f"{key_env} {'set' if os.getenv(key_env) else 'not set'}")
 
         annotation = ", ".join(parts)
@@ -296,6 +297,8 @@ def _autodetect_providers() -> str:
             cprint(f"  ✓ {provider_type} ({annotation})", color="green")
         elif status == _ProbeStatus.NO_KEY:
             cprint(f"  ✗ {provider_type} ({annotation})", color="yellow")
+        elif status == _ProbeStatus.NEEDS_KEY:
+            cprint(f"  ✗ {provider_type} ({annotation}) — set {key_env} to authenticate", color="yellow")
         elif status == _ProbeStatus.AUTH:
             cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
         else:
@@ -347,10 +350,16 @@ def _probe_endpoint(
             headers[api_key_header] = key
         else:
             headers["Authorization"] = f"Bearer {key}"
+    elif key_env:
+        key = os.getenv(key_env, "")
+        if key:
+            headers["Authorization"] = f"Bearer {key}"
 
     try:
         resp = cast(httpx.Response, httpx.get(url, headers=headers, timeout=2.0))
         if resp.status_code in (401, 403):
+            if not requires_key and key_env and not os.getenv(key_env):
+                return _ProbeStatus.NEEDS_KEY
             return _ProbeStatus.AUTH
         if resp.status_code < 400:
             return _ProbeStatus.OK

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -198,6 +198,42 @@ class TestProbeEndpoint:
         assert headers["Authorization"] == "Bearer sk-secret"
         assert "x-api-key" not in headers
 
+    def test_optional_key_included_when_env_var_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("VLLM_API_TOKEN", "vllm-token-123")
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
+            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
+        assert result == _ProbeStatus.OK
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer vllm-token-123"
+
+    def test_optional_key_omitted_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 200
+        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
+            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
+        assert result == _ProbeStatus.OK
+        headers = mock_get.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    def test_needs_key_when_optional_token_unset_and_server_returns_401(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 401
+        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
+        assert result == _ProbeStatus.NEEDS_KEY
+
+    def test_auth_when_optional_token_set_and_server_returns_401(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("VLLM_API_TOKEN", "wrong-token")
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 401
+        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
+            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
+        assert result == _ProbeStatus.AUTH
+
 
 class TestAutodetect:
     @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.UNREACHABLE)
@@ -300,6 +336,28 @@ class TestAutodetect:
         mock_probe.side_effect = side_effect
         parts = _autodetect_providers().split(",")
         assert parts.index("inference=remote::ollama") < parts.index("inference=remote::openai")
+
+    @patch("ogx.cli.stack.lets_go._probe_endpoint")
+    def test_autodetect_includes_vllm_on_needs_key(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
+        from ogx.cli.stack.lets_go import _autodetect_providers
+
+        monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
+
+        def side_effect(
+            base_url: str,
+            probe_path: str,
+            requires_key: bool,
+            key_env: object,
+            extra_headers: object = None,
+            api_key_header: object = None,
+        ) -> _ProbeStatus:
+            if "8000" in base_url:
+                return _ProbeStatus.NEEDS_KEY
+            return _ProbeStatus.UNREACHABLE
+
+        mock_probe.side_effect = side_effect
+        parts = _autodetect_providers().split(",")
+        assert "inference=remote::vllm" not in parts
 
 
 class TestRunCommand:


### PR DESCRIPTION
When VLLM_API_TOKEN is set, letsgo now sends it as a Bearer token on the vLLM probe request so that auth-protected deployments are detected correctly. When the token is absent and the server returns 401/403, a new NEEDS_KEY probe status is emitted with a targeted message directing the user to set VLLM_API_TOKEN, rather than reporting a generic auth error.

The vLLM probe path is changed from "health" to "models" because the /health endpoint sits at the server root, not under /v1/, and is often unreachable when the base URL already includes the /v1 path prefix. The /v1/models endpoint is the standard OpenAI-compatible path and behaves consistently whether or not authentication is required.

The annotation printed during scanning now shows the key status for any provider that has an optional key configured, not only required-key providers.
