### PR TITLE
fix(embedding): include trust_remote_code in embedding model cache key

### DIFF
--- a/src/ogx/providers/utils/inference/embedding_mixin.py
+++ b/src/ogx/providers/utils/inference/embedding_mixin.py
@@ -24,7 +24,7 @@ from ogx_api import (
     validate_embeddings_input_is_text,
 )
 
-EMBEDDING_MODELS: dict[str, "SentenceTransformer"] = {}
+EMBEDDING_MODELS: dict[tuple[str, bool], "SentenceTransformer"] = {}
 EMBEDDING_MODELS_LOCK = asyncio.Lock()
 
 DARWIN = "Darwin"
@@ -86,12 +86,13 @@ class SentenceTransformerEmbeddingMixin:
     async def _load_sentence_transformer_model(
         self, model: str, trust_remote_code: bool = False
     ) -> "SentenceTransformer":
-        loaded_model = EMBEDDING_MODELS.get(model)
+        cache_key = (model, trust_remote_code)
+        loaded_model = EMBEDDING_MODELS.get(cache_key)
         if loaded_model is not None:
             return loaded_model
 
         async with EMBEDDING_MODELS_LOCK:
-            loaded_model = EMBEDDING_MODELS.get(model)
+            loaded_model = EMBEDDING_MODELS.get(cache_key)
             if loaded_model is not None:
                 return loaded_model
 
@@ -111,5 +112,5 @@ class SentenceTransformerEmbeddingMixin:
                 return SentenceTransformer(model, trust_remote_code=trust_remote_code)
 
             loaded_model = await asyncio.to_thread(_load_model)
-            EMBEDDING_MODELS[model] = loaded_model
+            EMBEDDING_MODELS[cache_key] = loaded_model
             return loaded_model

--- a/tests/unit/providers/utils/inference/test_embedding_validation.py
+++ b/tests/unit/providers/utils/inference/test_embedding_validation.py
@@ -4,8 +4,16 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
 import pytest
 
+from ogx.providers.utils.inference.embedding_mixin import (
+    EMBEDDING_MODELS,
+    SentenceTransformerEmbeddingMixin,
+)
 from ogx_api import OpenAIEmbeddingsRequestWithExtraBody, validate_embeddings_input_is_text
 
 
@@ -55,3 +63,76 @@ class TestEmbeddingValidation:
 
             error_msg = str(exc_info.value)
             assert model in error_msg
+
+
+class FakeConfig:
+    def __init__(self, trust_remote_code: bool):
+        self.trust_remote_code = trust_remote_code
+
+
+class FakeProvider(SentenceTransformerEmbeddingMixin):
+    def __init__(self, trust_remote_code: bool):
+        self.config = FakeConfig(trust_remote_code)
+        self.model_store = MagicMock()
+
+
+@pytest.fixture()
+def clear_embedding_cache():
+    EMBEDDING_MODELS.clear()
+    yield
+    EMBEDDING_MODELS.clear()
+
+
+@pytest.fixture()
+def mock_sentence_transformers():
+    """Inject fake torch and sentence_transformers modules so _load_model() doesn't need real deps."""
+    calls = []
+
+    def fake_constructor(model_name, trust_remote_code=False):
+        m = MagicMock(name=f"ST({model_name}, trust={trust_remote_code})")
+        calls.append({"model": model_name, "trust_remote_code": trust_remote_code, "instance": m})
+        return m
+
+    fake_st_module = ModuleType("sentence_transformers")
+    fake_st_module.SentenceTransformer = fake_constructor
+
+    fake_torch = ModuleType("torch")
+    fake_torch.set_num_threads = MagicMock()
+
+    originals = {}
+    for mod_name, fake in [("sentence_transformers", fake_st_module), ("torch", fake_torch)]:
+        originals[mod_name] = sys.modules.get(mod_name)
+        sys.modules[mod_name] = fake
+
+    yield calls
+
+    for mod_name, orig in originals.items():
+        if orig is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = orig
+
+
+class TestEmbeddingCacheTrustRemoteCode:
+    async def test_different_trust_remote_code_values_get_separate_cache_entries(
+        self, clear_embedding_cache, mock_sentence_transformers
+    ):
+        provider_trusted = FakeProvider(trust_remote_code=True)
+        provider_untrusted = FakeProvider(trust_remote_code=False)
+
+        model_a = await provider_trusted._load_sentence_transformer_model("test-model", trust_remote_code=True)
+        model_b = await provider_untrusted._load_sentence_transformer_model("test-model", trust_remote_code=False)
+
+        assert len(mock_sentence_transformers) == 2
+        assert mock_sentence_transformers[0]["trust_remote_code"] is True
+        assert mock_sentence_transformers[1]["trust_remote_code"] is False
+        assert model_a is not model_b
+
+    async def test_same_trust_remote_code_uses_cache(self, clear_embedding_cache, mock_sentence_transformers):
+        provider = FakeProvider(trust_remote_code=True)
+
+        model_a = await provider._load_sentence_transformer_model("test-model", trust_remote_code=True)
+        model_b = await provider._load_sentence_transformer_model("test-model", trust_remote_code=True)
+
+        assert len(mock_sentence_transformers) == 1
+        assert model_a is model_b


### PR DESCRIPTION
## Summary

- The process-global `SentenceTransformer` cache in `embedding_mixin.py` was keyed only by model name, ignoring the `trust_remote_code` parameter. A model loaded with one `trust_remote_code` value would be silently reused for requests with a different value, bypassing the intended security setting.
- Changed the cache key from `model` (str) to `(model, trust_remote_code)` (tuple) so different security configurations get separate cache entries.
- Added regression tests to `test_embedding_validation.py`.

Closes: #5929 

## Test plan

- [x] Unit tests pass: `uv run pytest tests/unit/providers/utils/inference/test_embedding_validation.py`
- [x] `test_different_trust_remote_code_values_get_separate_cache_entries` - loads same model with opposite `trust_remote_code` values and asserts the constructor is called twice with separate results
- [x] `test_same_trust_remote_code_uses_cache` - loads same model with identical config and asserts the constructor is called only once

```
$ uv run pytest tests/unit/providers/utils/inference/test_embedding_validation.py -v
collected 7 items

tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingValidation::test_valid_string_input PASSED
tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingValidation::test_valid_list_of_strings_input PASSED
tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingValidation::test_invalid_list_of_ints_input PASSED
tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingValidation::test_invalid_list_of_list_of_ints_input PASSED
tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingValidation::test_error_message_includes_model_name PASSED
tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingCacheTrustRemoteCode::test_different_trust_remote_code_values_get_separate_cache_entries PASSED
tests/unit/providers/utils/inference/test_embedding_validation.py::TestEmbeddingCacheTrustRemoteCode::test_same_trust_remote_code_uses_cache PASSED

============================== 7 passed =======================================
```