### PR TITLE
chore(letsgo): probe provider availability using actual instantiation and model listing

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -223,10 +223,10 @@ def _autodetect_providers() -> str:
     ]
 
     passed: list[str] = []
-    has_missing_deps = False
+    missing_deps_providers: dict[str, list[str]] = {}  # provider_type -> pip_packages
     cprint("Scanning for available providers...", color="cyan")
     for provider_type, base_url_env, default_base_url, api_key_env in candidates:
-        status, model_count, base_url, base_source = _probe_provider_availability(
+        status, model_count, base_url, base_source, pip_packages = _probe_provider_availability(
             provider_type, base_url_env, default_base_url, api_key_env
         )
 
@@ -238,8 +238,8 @@ def _autodetect_providers() -> str:
             parts.append(f"{api_key_env} {'set' if os.getenv(api_key_env) else 'not set'}")
         annotation = ", ".join(parts) if parts else ""
 
-        if status == _ProbeStatus.MISSING_DEPS:
-            has_missing_deps = True
+        if status == _ProbeStatus.MISSING_DEPS and pip_packages:
+            missing_deps_providers[provider_type] = pip_packages
 
         if status == _ProbeStatus.OK:
             passed.append(f"inference={provider_type}")
@@ -286,13 +286,18 @@ def _autodetect_providers() -> str:
 
     if passed:
         cprint(f"\nDetected {len(passed)} inference provider(s). Starting stack...", color="cyan")
+        if missing_deps_providers:
+            cprint("Available providers with missing dependencies:", color="cyan")
+            for provider_type, pip_packages in missing_deps_providers.items():
+                packages_str = " ".join(f"'{pkg}'" for pkg in pip_packages)
+                cprint(f"  {provider_type}: uv pip install {packages_str}", color="cyan")
     else:
         cprint("\nDetected no inference providers, not starting stack.", color="red")
-        if has_missing_deps:
-            cprint(
-                "Hint: Some providers had missing dependencies. Run without --skip-install-deps to auto-install them.",
-                color="cyan",
-            )
+        if missing_deps_providers:
+            cprint("Install missing dependencies:", color="cyan")
+            for provider_type, pip_packages in missing_deps_providers.items():
+                packages_str = " ".join(f"'{pkg}'" for pkg in pip_packages)
+                cprint(f"  {provider_type}: uv pip install {packages_str}", color="cyan")
     return ",".join(passed + inline_providers)
 
 
@@ -340,7 +345,7 @@ async def _instantiate_with_timeout(factory_fn: Any, config: Any) -> Any:
 
 def _probe_provider_availability(
     provider_type: str, base_url_env: str | None, default_base_url: str, api_key_env: str | None
-) -> tuple[_ProbeStatus, int, str, str]:
+) -> tuple[_ProbeStatus, int, str, str, list[str] | None]:
     """Instantiate a provider and probe availability by listing models.
 
     Args:
@@ -350,8 +355,9 @@ def _probe_provider_availability(
         api_key_env: Environment variable name for API key, or None if not required
 
     Returns:
-        Tuple of (status, model_count, base_url, base_source).
+        Tuple of (status, model_count, base_url, base_source, pip_packages).
         base_source is "default" or the env var name. base_url is empty string if not applicable.
+        pip_packages is a list of packages to install for MISSING_DEPS, None otherwise.
     """
     # Determine base URL and source
     base_url = ""
@@ -370,14 +376,14 @@ def _probe_provider_availability(
 
     # Check if required API key is available
     if api_key_env and not os.getenv(api_key_env):
-        return _ProbeStatus.NO_KEY, 0, base_url, base_source
+        return _ProbeStatus.NO_KEY, 0, base_url, base_source, None
 
     try:
         # Load provider registry and look up the spec
         registry = get_provider_registry()
         if Api.inference not in registry or provider_type not in registry[Api.inference]:
             logger.debug("Provider not found in registry", provider_type=provider_type)
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
         provider_spec = registry[Api.inference][provider_type]
         logger.debug("Found provider in registry", provider_type=provider_type, module=provider_spec.module)
@@ -392,10 +398,10 @@ def _probe_provider_availability(
             config_defaults = _substitute_env_vars(config_defaults)
         except ModuleNotFoundError as e:
             logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
-            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source, provider_spec.pip_packages
         except Exception as e:
             logger.debug("Failed to get config defaults", provider_type=provider_type, error=str(e)[:200])
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
         # Instantiate config object
         try:
@@ -403,25 +409,25 @@ def _probe_provider_availability(
             logger.debug("Instantiated config", provider_type=provider_type)
         except ModuleNotFoundError as e:
             logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
-            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source, provider_spec.pip_packages
         except Exception as e:
             logger.debug("Failed to instantiate config", provider_type=provider_type, error=str(e)[:200])
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
         # Import provider module and instantiate
         if not provider_spec.module:
             logger.debug("Provider spec missing module", provider_type=provider_type)
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
         try:
             module = importlib.import_module(provider_spec.module)
             logger.debug("Imported provider module", provider_type=provider_type, module=provider_spec.module)
         except ModuleNotFoundError as e:
             logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
-            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source, provider_spec.pip_packages
         except Exception as e:
             logger.debug("Failed to import provider module", module=provider_spec.module, error=str(e)[:200])
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
         try:
             # Call appropriate factory function
@@ -442,7 +448,7 @@ def _probe_provider_availability(
             provider.__provider_config__ = config
         except ModuleNotFoundError as e:
             logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
-            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source, provider_spec.pip_packages
         except Exception as e:
             error_str = str(e).lower()
             logger.debug("Failed to instantiate provider", provider_type=provider_type, error=str(e)[:300])
@@ -458,8 +464,8 @@ def _probe_provider_availability(
                 logger.warning(
                     "Provider auth failed", provider_type=provider_type, base_url=base_url, error=str(e)[:200]
                 )
-                return _ProbeStatus.AUTH, 0, base_url, base_source
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+                return _ProbeStatus.AUTH, 0, base_url, base_source, None
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
         # List models with timeout
         try:
@@ -477,11 +483,11 @@ def _probe_provider_availability(
 
             if model_count == 0:
                 logger.debug("Provider returned zero models", provider_type=provider_type)
-                return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
-            return _ProbeStatus.OK, model_count, base_url, base_source
+                return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
+            return _ProbeStatus.OK, model_count, base_url, base_source, None
         except TimeoutError:
             logger.debug("Model listing timed out", provider_type=provider_type)
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
         except Exception as e:
             error_str = str(e).lower()
             logger.debug("Failed to list models", provider_type=provider_type, error=str(e)[:300])
@@ -500,11 +506,11 @@ def _probe_provider_availability(
                     base_url=base_url,
                     error=str(e)[:200],
                 )
-                return _ProbeStatus.AUTH, 0, base_url, base_source
-            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+                return _ProbeStatus.AUTH, 0, base_url, base_source, None
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
     except Exception as e:
         logger.debug("Unexpected error during provider probing", provider_type=provider_type, error=str(e)[:300])
-        return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+        return _ProbeStatus.UNREACHABLE, 0, base_url, base_source, None
 
 
 class StackLetsGo(Subcommand):

--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -5,27 +5,31 @@
 # the root directory of this source tree.
 
 import argparse
+import asyncio
 import enum
+import importlib
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any, cast
-from urllib.parse import urljoin
+from typing import Any
 
-import httpx
 import yaml
 from termcolor import cprint
 
 from ogx.cli.stack.run import _start_ui_development_server, _uvicorn_run
 from ogx.cli.subcommand import Subcommand
 from ogx.core.build import get_provider_dependencies
+from ogx.core.distribution import get_provider_registry
 from ogx.core.stack import run_config_from_dynamic_config_spec
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR
+from ogx.core.utils.dynamic import instantiate_class_type
 from ogx.log import get_logger
+from ogx_api import Api, RemoteProviderSpec
 from ogx_api.models.models import ModelInput
 
 logger = get_logger(name=__name__, category="cli")
@@ -201,105 +205,58 @@ def _install_provider_deps(normal_deps: list[str], special_deps: list[str]) -> N
 def _autodetect_providers() -> str:
     """Probe all candidate providers and return a comma-separated providers spec string.
 
-    Each provider is probed independently; all that pass are included in the
-    result. Providers that require an API key skip the network probe entirely
+    Each provider is probed by instantiating it and calling list_models() to confirm
+    availability and model access. Providers that require an API key skip probing
     when the key environment variable is not set.
     """
     candidates = [
-        # provider_type, env_for_base_url, default_base_url, probe_path, requires_api_key, api_key_env, extra_headers, api_key_header
-        ("remote::ollama", "OLLAMA_URL", "http://localhost:11434/v1", "models", False, None, {}, None),
-        ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", "health", False, None, {}, None),
-        (
-            "remote::llama-cpp-server",
-            "LLAMA_CPP_SERVER_URL",
-            "http://localhost:8080/v1",
-            "models",
-            False,
-            None,
-            {},
-            None,
-        ),
-        ("remote::openai", "OPENAI_BASE_URL", "https://api.openai.com/v1", "models", True, "OPENAI_API_KEY", {}, None),
-        (
-            "remote::llama-openai-compat",
-            "LLAMA_API_BASE_URL",
-            "https://api.llama.com/compat/v1/",
-            "models",
-            True,
-            "LLAMA_API_KEY",
-            {},
-            None,
-        ),
-        (
-            "remote::anthropic",
-            None,
-            "https://api.anthropic.com/v1",
-            "models",
-            True,
-            "ANTHROPIC_API_KEY",
-            {"anthropic-version": "2023-06-01"},
-            "x-api-key",
-        ),
-        (
-            "remote::gemini",
-            None,
-            "https://generativelanguage.googleapis.com/v1beta/openai",
-            "models",
-            True,
-            "GEMINI_API_KEY",
-            {},
-            None,
-        ),
-        (
-            "remote::azure",
-            "AZURE_API_BASE",
-            "",
-            "openai/models?api-version=2024-12-01-preview",
-            True,
-            "AZURE_API_KEY",
-            {},
-            "api-key",
-        ),
+        # provider_type, base_url_env, default_base_url, api_key_env
+        ("remote::ollama", "OLLAMA_URL", "http://localhost:11434/v1", None),
+        ("remote::vllm", "VLLM_URL", "http://localhost:8000/v1", None),
+        ("remote::llama-cpp-server", "LLAMA_CPP_SERVER_URL", "http://localhost:8080/v1", None),
+        ("remote::openai", "OPENAI_BASE_URL", "https://api.openai.com/v1", "OPENAI_API_KEY"),
+        ("remote::llama-openai-compat", "LLAMA_API_BASE_URL", "https://api.llama.com/compat/v1/", "LLAMA_API_KEY"),
+        ("remote::anthropic", None, "https://api.anthropic.com/v1", "ANTHROPIC_API_KEY"),
+        ("remote::gemini", None, "https://generativelanguage.googleapis.com/v1beta/openai", "GEMINI_API_KEY"),
+        ("remote::azure", "AZURE_API_BASE", "", "AZURE_API_KEY"),
     ]
 
     passed: list[str] = []
     cprint("Scanning for available providers...", color="cyan")
-    for (
-        provider_type,
-        base_env,
-        default_base,
-        probe_path,
-        requires_key,
-        key_env,
-        extra_headers,
-        api_key_header,
-    ) in candidates:
-        env_val: str | None = os.getenv(base_env) if base_env else None
-        if env_val:
-            base = env_val
-            base_source = f"from {base_env}"
-        else:
-            base = default_base
-            base_source = "default"
-
-        status = _probe_endpoint(base, probe_path, requires_key, key_env, extra_headers, api_key_header)
+    for provider_type, base_url_env, default_base_url, api_key_env in candidates:
+        status, model_count, base_url, base_source = _probe_provider_availability(
+            provider_type, base_url_env, default_base_url, api_key_env
+        )
 
         # Build annotation parts
-        parts = [f"{base}, {base_source}"]
-        if requires_key and key_env:
-            parts.append(f"{key_env} {'set' if os.getenv(key_env) else 'not set'}")
-
-        annotation = ", ".join(parts)
+        parts = []
+        if base_url:
+            parts.append(f"{base_url}, {base_source}")
+        if api_key_env:
+            parts.append(f"{api_key_env} {'set' if os.getenv(api_key_env) else 'not set'}")
+        annotation = ", ".join(parts) if parts else ""
 
         if status == _ProbeStatus.OK:
             passed.append(f"inference={provider_type}")
-            cprint(f"  ✓ {provider_type} ({annotation})", color="green")
+            if annotation:
+                cprint(f"  ✓ {provider_type} ({annotation}) — {model_count} models", color="green")
+            else:
+                cprint(f"  ✓ {provider_type} ({model_count} models)", color="green")
         elif status == _ProbeStatus.NO_KEY:
-            cprint(f"  ✗ {provider_type} ({annotation})", color="yellow")
+            if annotation:
+                cprint(f"  ✗ {provider_type} ({annotation})", color="yellow")
+            else:
+                cprint(f"  ✗ {provider_type}", color="yellow")
         elif status == _ProbeStatus.AUTH:
-            cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
+            if annotation:
+                cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
+            else:
+                cprint(f"  ✗ {provider_type} — auth error", color="yellow")
         else:
-            cprint(f"  ✗ {provider_type} ({annotation}) — unreachable", color="yellow")
+            if annotation:
+                cprint(f"  ✗ {provider_type} ({annotation}) — unreachable", color="yellow")
+            else:
+                cprint(f"  ✗ {provider_type} — unreachable", color="yellow")
 
     # Inline providers require no external service — always include them.
     inline_providers = [
@@ -324,39 +281,203 @@ def _autodetect_providers() -> str:
     return ",".join(passed + inline_providers)
 
 
-def _probe_endpoint(
-    base_url: str,
-    probe_path: str,
-    requires_key: bool,
-    key_env: str | None,
-    extra_headers: dict[str, str] | None = None,
-    api_key_header: str | None = None,
-) -> _ProbeStatus:
-    """Perform a lightweight HTTP probe for a provider."""
-    if not base_url:
-        return _ProbeStatus.UNREACHABLE
+async def _list_models_with_timeout(provider: Any, timeout_seconds: float = 5) -> list[Any] | None:
+    """Call list_models with timeout and proper error handling."""
+    if not hasattr(provider, "list_models"):
+        return None
+    try:
+        models = await asyncio.wait_for(provider.list_models(), timeout=timeout_seconds)
+        return list(models) if models else []
+    except TimeoutError:
+        raise
 
-    url = urljoin(base_url.rstrip("/") + "/", probe_path)
 
-    headers: dict[str, str] = dict(extra_headers or {})
-    if requires_key:
-        if not key_env or not os.getenv(key_env):
-            return _ProbeStatus.NO_KEY
-        key: str = os.getenv(key_env, "")
-        if api_key_header:
-            headers[api_key_header] = key
+def _substitute_env_vars(obj: Any) -> Any:
+    """Recursively substitute ${env.VAR_NAME:=default} patterns with environment variable values."""
+    if isinstance(obj, str):
+        # Pattern: ${env.VAR_NAME:=default_value}
+        pattern = r"\$\{env\.([^}:]+)(?::=([^}]*))?\}"
+
+        def replace_match(match):
+            var_name = match.group(1)
+            default_value = match.group(2) or ""
+            return os.getenv(var_name, default_value)
+
+        return re.sub(pattern, replace_match, obj)
+    elif isinstance(obj, dict):
+        return {k: _substitute_env_vars(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_substitute_env_vars(item) for item in obj]
+    else:
+        return obj
+
+
+async def _instantiate_with_timeout(factory_fn: Any, config: Any) -> Any:
+    """Call factory function with timeout."""
+    try:
+        result = factory_fn(config, {})
+        if asyncio.iscoroutine(result):
+            return await asyncio.wait_for(result, timeout=5.0)
+        return result
+    except TimeoutError:
+        raise
+
+
+def _probe_provider_availability(
+    provider_type: str, base_url_env: str | None, default_base_url: str, api_key_env: str | None
+) -> tuple[_ProbeStatus, int, str, str]:
+    """Instantiate a provider and probe availability by listing models.
+
+    Args:
+        provider_type: Provider type string (e.g., "remote::openai")
+        base_url_env: Environment variable name for base URL override, or None
+        default_base_url: Default base URL if env var not set
+        api_key_env: Environment variable name for API key, or None if not required
+
+    Returns:
+        Tuple of (status, model_count, base_url, base_source).
+        base_source is "default" or the env var name. base_url is empty string if not applicable.
+    """
+    # Determine base URL and source
+    base_url = ""
+    base_source = ""
+    if base_url_env:
+        env_val = os.getenv(base_url_env)
+        if env_val:
+            base_url = env_val
+            base_source = f"from {base_url_env}"
         else:
-            headers["Authorization"] = f"Bearer {key}"
+            base_url = default_base_url
+            base_source = "default"
+    elif default_base_url:
+        base_url = default_base_url
+        base_source = "default"
+
+    # Check if required API key is available
+    if api_key_env and not os.getenv(api_key_env):
+        return _ProbeStatus.NO_KEY, 0, base_url, base_source
 
     try:
-        resp = cast(httpx.Response, httpx.get(url, headers=headers, timeout=2.0))
-        if resp.status_code in (401, 403):
-            return _ProbeStatus.AUTH
-        if resp.status_code < 400:
-            return _ProbeStatus.OK
-        return _ProbeStatus.UNREACHABLE
-    except Exception:
-        return _ProbeStatus.UNREACHABLE
+        # Load provider registry and look up the spec
+        registry = get_provider_registry()
+        if Api.inference not in registry or provider_type not in registry[Api.inference]:
+            logger.debug("Provider not found in registry", provider_type=provider_type)
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+
+        provider_spec = registry[Api.inference][provider_type]
+        logger.debug("Found provider in registry", provider_type=provider_type, module=provider_spec.module)
+
+        # Get config defaults
+        try:
+            config_class = instantiate_class_type(provider_spec.config_class)
+            config_defaults = config_class.sample_run_config(__distro_dir__=tempfile.gettempdir())
+            logger.debug("Got config defaults", provider_type=provider_type)
+
+            # Substitute environment variables in config (e.g., ${env.VAR_NAME:=default})
+            config_defaults = _substitute_env_vars(config_defaults)
+        except Exception as e:
+            logger.debug("Failed to get config defaults", provider_type=provider_type, error=str(e)[:200])
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+
+        # Instantiate config object
+        try:
+            config = config_class(**config_defaults)
+            logger.debug("Instantiated config", provider_type=provider_type)
+        except Exception as e:
+            logger.debug("Failed to instantiate config", provider_type=provider_type, error=str(e)[:200])
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+
+        # Import provider module and instantiate
+        if not provider_spec.module:
+            logger.debug("Provider spec missing module", provider_type=provider_type)
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+
+        try:
+            module = importlib.import_module(provider_spec.module)
+            logger.debug("Imported provider module", provider_type=provider_type, module=provider_spec.module)
+        except Exception as e:
+            logger.debug("Failed to import provider module", module=provider_spec.module, error=str(e)[:200])
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+
+        try:
+            # Call appropriate factory function
+            if isinstance(provider_spec, RemoteProviderSpec):
+                method_name = "get_adapter_impl"
+            else:  # InlineProviderSpec
+                method_name = "get_provider_impl"
+
+            factory_fn = getattr(module, method_name)
+            logger.debug("Calling factory function", provider_type=provider_type, method=method_name)
+            # Pass empty deps dict {} for single-provider probing
+            provider = asyncio.run(_instantiate_with_timeout(factory_fn, config))
+            logger.debug("Provider instantiated successfully", provider_type=provider_type)
+
+            # Set required attributes (normally done by resolver)
+            provider.__provider_id__ = provider_type
+            provider.__provider_spec__ = provider_spec
+            provider.__provider_config__ = config
+        except Exception as e:
+            error_str = str(e).lower()
+            logger.debug("Failed to instantiate provider", provider_type=provider_type, error=str(e)[:300])
+            # Only treat as auth error for specific auth-related keywords
+            if (
+                "401" in error_str
+                or "403" in error_str
+                or "unauthorized" in error_str
+                or "forbidden" in error_str
+                or "invalid_api_key" in error_str
+                or "api_key" in error_str
+            ):
+                logger.warning(
+                    "Provider auth failed", provider_type=provider_type, base_url=base_url, error=str(e)[:200]
+                )
+                return _ProbeStatus.AUTH, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+
+        # List models with timeout
+        try:
+            logger.debug("Calling list_models", provider_type=provider_type)
+            models = asyncio.run(_list_models_with_timeout(provider, timeout_seconds=5))
+            model_count = len(models) if models else 0
+            logger.debug("Listed models successfully", provider_type=provider_type, model_count=model_count)
+
+            # Cleanup provider
+            if hasattr(provider, "aclose"):
+                try:
+                    asyncio.run(provider.aclose())
+                except Exception as e:
+                    logger.debug("Failed to cleanup provider", provider_type=provider_type, error=str(e)[:200])
+
+            if model_count == 0:
+                logger.debug("Provider returned zero models", provider_type=provider_type)
+                return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+            return _ProbeStatus.OK, model_count, base_url, base_source
+        except TimeoutError:
+            logger.debug("Model listing timed out", provider_type=provider_type)
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+        except Exception as e:
+            error_str = str(e).lower()
+            logger.debug("Failed to list models", provider_type=provider_type, error=str(e)[:300])
+            # Only treat as auth error for specific auth-related keywords
+            if (
+                "401" in error_str
+                or "403" in error_str
+                or "unauthorized" in error_str
+                or "forbidden" in error_str
+                or "invalid_api_key" in error_str
+                or "api_key" in error_str
+            ):
+                logger.warning(
+                    "Provider auth failed during model listing",
+                    provider_type=provider_type,
+                    base_url=base_url,
+                    error=str(e)[:200],
+                )
+                return _ProbeStatus.AUTH, 0, base_url, base_source
+            return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
+    except Exception as e:
+        logger.debug("Unexpected error during provider probing", provider_type=provider_type, error=str(e)[:300])
+        return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
 
 
 class StackLetsGo(Subcommand):

--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -9,7 +9,6 @@ import asyncio
 import enum
 import importlib
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -25,7 +24,7 @@ from ogx.cli.stack.run import _start_ui_development_server, _uvicorn_run
 from ogx.cli.subcommand import Subcommand
 from ogx.core.build import get_provider_dependencies
 from ogx.core.distribution import get_provider_registry
-from ogx.core.stack import run_config_from_dynamic_config_spec
+from ogx.core.stack import replace_env_vars, run_config_from_dynamic_config_spec
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR
 from ogx.core.utils.dynamic import instantiate_class_type
 from ogx.log import get_logger
@@ -327,37 +326,6 @@ async def _list_models_with_timeout(provider: Any, timeout_seconds: float = 5) -
         raise
 
 
-def _substitute_env_vars(obj: Any) -> Any:
-    """Recursively substitute ${env.VAR_NAME:=default} patterns with environment variable values."""
-    if isinstance(obj, str):
-        # Pattern: ${env.VAR_NAME:=default_value}
-        pattern = r"\$\{env\.([^}:]+)(?::=([^}]*))?\}"
-
-        def replace_match(match):
-            var_name = match.group(1)
-            default_value = match.group(2) or ""
-            return os.getenv(var_name, default_value)
-
-        result = re.sub(pattern, replace_match, obj)
-        # Coerce boolean strings so Pydantic validators receive proper bool types
-        if result.lower() == "true":
-            return True
-        if result.lower() == "false":
-            return False
-        # Coerce integer strings
-        try:
-            return int(result)
-        except (ValueError, TypeError):
-            pass
-        return result
-    elif isinstance(obj, dict):
-        return {k: _substitute_env_vars(v) for k, v in obj.items()}
-    elif isinstance(obj, list):
-        return [_substitute_env_vars(item) for item in obj]
-    else:
-        return obj
-
-
 async def _instantiate_with_timeout(factory_fn: Any, config: Any) -> Any:
     """Call factory function with timeout."""
     try:
@@ -442,7 +410,7 @@ def _probe_provider_availability(
             logger.debug("Got config defaults", provider_type=provider_type)
 
             # Substitute environment variables in config (e.g., ${env.VAR_NAME:=default})
-            config_defaults = _substitute_env_vars(config_defaults)
+            config_defaults = replace_env_vars(config_defaults)
         except ModuleNotFoundError as e:
             logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
             return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source, provider_spec.pip_packages

--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -87,6 +87,7 @@ class _ProbeStatus(enum.Enum):
     OK = "ok"
     NO_KEY = "no_key"
     AUTH = "auth"
+    MISSING_DEPS = "missing_deps"
     UNREACHABLE = "unreachable"
 
 
@@ -222,6 +223,7 @@ def _autodetect_providers() -> str:
     ]
 
     passed: list[str] = []
+    has_missing_deps = False
     cprint("Scanning for available providers...", color="cyan")
     for provider_type, base_url_env, default_base_url, api_key_env in candidates:
         status, model_count, base_url, base_source = _probe_provider_availability(
@@ -235,6 +237,9 @@ def _autodetect_providers() -> str:
         if api_key_env:
             parts.append(f"{api_key_env} {'set' if os.getenv(api_key_env) else 'not set'}")
         annotation = ", ".join(parts) if parts else ""
+
+        if status == _ProbeStatus.MISSING_DEPS:
+            has_missing_deps = True
 
         if status == _ProbeStatus.OK:
             passed.append(f"inference={provider_type}")
@@ -252,6 +257,11 @@ def _autodetect_providers() -> str:
                 cprint(f"  ✗ {provider_type} ({annotation}) — auth error", color="yellow")
             else:
                 cprint(f"  ✗ {provider_type} — auth error", color="yellow")
+        elif status == _ProbeStatus.MISSING_DEPS:
+            if annotation:
+                cprint(f"  ✗ {provider_type} ({annotation}) — missing dependencies", color="yellow")
+            else:
+                cprint(f"  ✗ {provider_type} — missing dependencies", color="yellow")
         else:
             if annotation:
                 cprint(f"  ✗ {provider_type} ({annotation}) — unreachable", color="yellow")
@@ -278,6 +288,11 @@ def _autodetect_providers() -> str:
         cprint(f"\nDetected {len(passed)} inference provider(s). Starting stack...", color="cyan")
     else:
         cprint("\nDetected no inference providers, not starting stack.", color="red")
+        if has_missing_deps:
+            cprint(
+                "Hint: Some providers had missing dependencies. Run without --skip-install-deps to auto-install them.",
+                color="cyan",
+            )
     return ",".join(passed + inline_providers)
 
 
@@ -375,6 +390,9 @@ def _probe_provider_availability(
 
             # Substitute environment variables in config (e.g., ${env.VAR_NAME:=default})
             config_defaults = _substitute_env_vars(config_defaults)
+        except ModuleNotFoundError as e:
+            logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
         except Exception as e:
             logger.debug("Failed to get config defaults", provider_type=provider_type, error=str(e)[:200])
             return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
@@ -383,6 +401,9 @@ def _probe_provider_availability(
         try:
             config = config_class(**config_defaults)
             logger.debug("Instantiated config", provider_type=provider_type)
+        except ModuleNotFoundError as e:
+            logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
         except Exception as e:
             logger.debug("Failed to instantiate config", provider_type=provider_type, error=str(e)[:200])
             return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
@@ -395,6 +416,9 @@ def _probe_provider_availability(
         try:
             module = importlib.import_module(provider_spec.module)
             logger.debug("Imported provider module", provider_type=provider_type, module=provider_spec.module)
+        except ModuleNotFoundError as e:
+            logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
         except Exception as e:
             logger.debug("Failed to import provider module", module=provider_spec.module, error=str(e)[:200])
             return _ProbeStatus.UNREACHABLE, 0, base_url, base_source
@@ -416,6 +440,9 @@ def _probe_provider_availability(
             provider.__provider_id__ = provider_type
             provider.__provider_spec__ = provider_spec
             provider.__provider_config__ = config
+        except ModuleNotFoundError as e:
+            logger.debug("Provider dependencies not installed", provider_type=provider_type, module=str(e)[:200])
+            return _ProbeStatus.MISSING_DEPS, 0, base_url, base_source
         except Exception as e:
             error_str = str(e).lower()
             logger.debug("Failed to instantiate provider", provider_type=provider_type, error=str(e)[:300])

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -10,7 +10,6 @@ import argparse
 import warnings
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 from ogx.cli.letsgo import LetsGo
@@ -19,8 +18,8 @@ from ogx.cli.stack.lets_go import (
     _CLAUDE_CODE_PROVIDER_PRIORITY,
     StackLetsGo,
     _build_claude_code_aliases,
-    _probe_endpoint,
     _ProbeStatus,
+    _substitute_env_vars,
 )
 
 
@@ -103,140 +102,60 @@ class TestTopLevelLetsGoArguments:
         assert args.skip_install_deps is True
 
 
-class TestProbeEndpoint:
-    def test_empty_base_url_returns_unreachable(self):
-        assert _probe_endpoint("", "models", False, None) == _ProbeStatus.UNREACHABLE
+class TestSubstituteEnvVars:
+    def test_boolean_true_coercion(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MY_VAR", "true")
+        assert _substitute_env_vars("${env.MY_VAR:=false}") is True
 
-    def test_url_construction_preserves_v1_path(self):
-        """Without a trailing slash urljoin strips the last path segment."""
-        captured: list[str] = []
+    def test_boolean_false_coercion(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MY_VAR", "false")
+        assert _substitute_env_vars("${env.MY_VAR:=true}") is False
 
-        def fake_get(url: str, **kwargs: object) -> None:
-            captured.append(url)
-            raise OSError("offline")
+    def test_boolean_default_true_coercion(self):
+        assert _substitute_env_vars("${env.NONEXISTENT_VAR_XYZ:=true}") is True
 
-        with patch("ogx.cli.stack.lets_go.httpx.get", side_effect=fake_get):
-            _probe_endpoint("http://localhost:11434/v1", "models", False, None)
+    def test_boolean_default_false_coercion(self):
+        assert _substitute_env_vars("${env.NONEXISTENT_VAR_XYZ:=false}") is False
 
-        assert captured[0] == "http://localhost:11434/v1/models"
+    def test_integer_coercion(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MY_INT", "4096")
+        result = _substitute_env_vars("${env.MY_INT:=2048}")
+        assert result == 4096
+        assert isinstance(result, int)
 
-    def test_ok_on_200(self):
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 200
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.OK
+    def test_integer_default_coercion(self):
+        result = _substitute_env_vars("${env.NONEXISTENT_INT_XYZ:=2048}")
+        assert result == 2048
+        assert isinstance(result, int)
 
-    def test_ok_on_204(self):
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 204
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert _probe_endpoint("http://localhost:8000/v1", "health", False, None) == _ProbeStatus.OK
+    def test_string_passes_through(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MY_URL", "http://example.com")
+        assert _substitute_env_vars("${env.MY_URL:=http://localhost}") == "http://example.com"
 
-    def test_no_key_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        result = _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
-        assert result == _ProbeStatus.NO_KEY
+    def test_nested_dict_booleans(self):
+        obj = {"tls": {"verify": "${env.NONEXISTENT_TLS_XYZ:=true}"}}
+        result = _substitute_env_vars(obj)
+        assert result["tls"]["verify"] is True
 
-    def test_no_key_when_key_env_is_none(self):
-        result = _probe_endpoint("https://example.com/v1", "models", True, None)
-        assert result == _ProbeStatus.NO_KEY
+    def test_list_items_coerced(self):
+        obj = ["${env.NONEXISTENT_XYZ:=true}", "${env.NONEXISTENT_XYZ:=42}"]
+        result = _substitute_env_vars(obj)
+        assert result[0] is True
+        assert result[1] == 42
 
-    def test_auth_on_401(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 401
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY") == _ProbeStatus.AUTH
+    def test_non_template_string_unchanged(self):
+        assert _substitute_env_vars("http://localhost:8080/v1") == "http://localhost:8080/v1"
 
-    def test_auth_on_403(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 403
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY") == _ProbeStatus.AUTH
-
-    def test_unreachable_on_400(self):
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 400
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-
-    def test_unreachable_on_500(self):
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 500
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-
-    def test_unreachable_on_connection_error(self):
-        with patch("ogx.cli.stack.lets_go.httpx.get", side_effect=OSError("connection refused")):
-            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-
-    def test_unreachable_on_timeout(self):
-        with patch("ogx.cli.stack.lets_go.httpx.get", side_effect=httpx.TimeoutException("timeout")):
-            assert _probe_endpoint("http://localhost:11434/v1", "models", False, None) == _ProbeStatus.UNREACHABLE
-
-    def test_extra_headers_forwarded(self):
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 200
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
-            _probe_endpoint(
-                "https://api.anthropic.com/v1",
-                "models",
-                False,
-                None,
-                {"anthropic-version": "2023-06-01"},
-            )
-        assert mock_get.call_args.kwargs["headers"].get("anthropic-version") == "2023-06-01"
-
-    def test_auth_headers_set_when_key_present(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 200
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
-            _probe_endpoint("https://api.openai.com/v1", "models", True, "OPENAI_API_KEY")
-        headers = mock_get.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer sk-secret"
-        assert "x-api-key" not in headers
-
-    def test_optional_key_included_when_env_var_set(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("VLLM_API_TOKEN", "vllm-token-123")
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 200
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
-            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
-        assert result == _ProbeStatus.OK
-        headers = mock_get.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer vllm-token-123"
-
-    def test_optional_key_omitted_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 200
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp) as mock_get:
-            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
-        assert result == _ProbeStatus.OK
-        headers = mock_get.call_args.kwargs["headers"]
-        assert "Authorization" not in headers
-
-    def test_needs_key_when_optional_token_unset_and_server_returns_401(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 401
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
-        assert result == _ProbeStatus.NEEDS_KEY
-
-    def test_auth_when_optional_token_set_and_server_returns_401(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("VLLM_API_TOKEN", "wrong-token")
-        mock_resp = MagicMock(spec=httpx.Response)
-        mock_resp.status_code = 401
-        with patch("ogx.cli.stack.lets_go.httpx.get", return_value=mock_resp):
-            result = _probe_endpoint("http://localhost:8000/v1", "models", False, "VLLM_API_TOKEN")
-        assert result == _ProbeStatus.AUTH
+    def test_non_string_passthrough(self):
+        assert _substitute_env_vars(123) == 123
+        assert _substitute_env_vars(True) is True
 
 
 class TestAutodetect:
-    @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.UNREACHABLE)
+    @patch(
+        "ogx.cli.stack.lets_go._probe_provider_availability",
+        return_value=(_ProbeStatus.UNREACHABLE, 0, "", "default", None),
+    )
     def test_autodetect_no_providers(self, mock_probe: MagicMock):
         from ogx.cli.stack.lets_go import _autodetect_providers
 
@@ -246,7 +165,9 @@ class TestAutodetect:
         assert "tool_runtime=inline::file-search" in parts
         assert "responses=inline::builtin" in parts
 
-    @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.NO_KEY)
+    @patch(
+        "ogx.cli.stack.lets_go._probe_provider_availability", return_value=(_ProbeStatus.NO_KEY, 0, "", "default", None)
+    )
     def test_no_key_providers_excluded(self, mock_probe: MagicMock):
         from ogx.cli.stack.lets_go import _autodetect_providers
 
@@ -256,7 +177,10 @@ class TestAutodetect:
         assert "tool_runtime=inline::file-search" in parts
         assert "responses=inline::builtin" in parts
 
-    @patch("ogx.cli.stack.lets_go._probe_endpoint", return_value=_ProbeStatus.OK)
+    @patch(
+        "ogx.cli.stack.lets_go._probe_provider_availability",
+        return_value=(_ProbeStatus.OK, 3, "http://test", "default", None),
+    )
     def test_autodetect_all_ok(self, mock_probe: MagicMock):
         from ogx.cli.stack.lets_go import _autodetect_providers
 
@@ -268,21 +192,20 @@ class TestAutodetect:
         assert "responses=inline::builtin" in parts
         assert len(parts) == 14  # 8 probed + 6 inline
 
-    @patch("ogx.cli.stack.lets_go._probe_endpoint")
+    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
     def test_autodetect_only_ollama(self, mock_probe: MagicMock):
         from ogx.cli.stack.lets_go import _autodetect_providers
 
         def side_effect(
-            base_url: str,
-            probe_path: str,
-            requires_key: bool,
-            key_env: object,
-            extra_headers: object = None,
-            api_key_header: object = None,
-        ) -> _ProbeStatus:
-            if "11434" in base_url:
-                return _ProbeStatus.OK
-            return _ProbeStatus.UNREACHABLE
+            provider_type: str,
+            base_url_env: object,
+            default_base_url: str,
+            required_api_key_env: object,
+            optional_api_key_env: object = None,
+        ) -> tuple:
+            if provider_type == "remote::ollama":
+                return (_ProbeStatus.OK, 3, "http://localhost:11434/v1", "default", None)
+            return (_ProbeStatus.UNREACHABLE, 0, "", "default", None)
 
         mock_probe.side_effect = side_effect
         parts = _autodetect_providers().split(",")
@@ -291,29 +214,29 @@ class TestAutodetect:
         assert "responses=inline::builtin" in parts
         assert len(parts) == 7  # 1 inference + 6 inline
 
-    @patch("ogx.cli.stack.lets_go._probe_endpoint")
-    def test_autodetect_uses_env_var_base_url(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
+    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
+    def test_autodetect_uses_env_var_name(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
         from ogx.cli.stack.lets_go import _autodetect_providers
 
         monkeypatch.setenv("OLLAMA_URL", "http://myhost:11434/v1")
         captured: list[str] = []
 
         def side_effect(
-            base_url: str,
-            probe_path: str,
-            requires_key: bool,
-            key_env: object,
-            extra_headers: object = None,
-            api_key_header: object = None,
-        ) -> _ProbeStatus:
-            captured.append(base_url)
-            return _ProbeStatus.UNREACHABLE
+            provider_type: str,
+            base_url_env: object,
+            default_base_url: str,
+            required_api_key_env: object,
+            optional_api_key_env: object = None,
+        ) -> tuple:
+            if provider_type == "remote::ollama":
+                captured.append(base_url_env)
+            return (_ProbeStatus.UNREACHABLE, 0, "", "default", None)
 
         mock_probe.side_effect = side_effect
         _autodetect_providers()
-        assert captured[0] == "http://myhost:11434/v1"
+        assert captured[0] == "OLLAMA_URL"
 
-    @patch("ogx.cli.stack.lets_go._probe_endpoint")
+    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
     def test_autodetect_result_order_matches_candidate_order(
         self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch
     ):
@@ -322,42 +245,40 @@ class TestAutodetect:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
         def side_effect(
-            base_url: str,
-            probe_path: str,
-            requires_key: bool,
-            key_env: object,
-            extra_headers: object = None,
-            api_key_header: object = None,
-        ) -> _ProbeStatus:
-            if "11434" in base_url or "openai.com" in base_url:
-                return _ProbeStatus.OK
-            return _ProbeStatus.UNREACHABLE
+            provider_type: str,
+            base_url_env: object,
+            default_base_url: str,
+            required_api_key_env: object,
+            optional_api_key_env: object = None,
+        ) -> tuple:
+            if provider_type in ("remote::ollama", "remote::openai"):
+                return (_ProbeStatus.OK, 3, "http://test", "default", None)
+            return (_ProbeStatus.UNREACHABLE, 0, "", "default", None)
 
         mock_probe.side_effect = side_effect
         parts = _autodetect_providers().split(",")
         assert parts.index("inference=remote::ollama") < parts.index("inference=remote::openai")
 
-    @patch("ogx.cli.stack.lets_go._probe_endpoint")
+    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
     def test_autodetect_includes_vllm_on_needs_key(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
         from ogx.cli.stack.lets_go import _autodetect_providers
 
         monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
 
         def side_effect(
-            base_url: str,
-            probe_path: str,
-            requires_key: bool,
-            key_env: object,
-            extra_headers: object = None,
-            api_key_header: object = None,
-        ) -> _ProbeStatus:
-            if "8000" in base_url:
-                return _ProbeStatus.NEEDS_KEY
-            return _ProbeStatus.UNREACHABLE
+            provider_type: str,
+            base_url_env: object,
+            default_base_url: str,
+            required_api_key_env: object,
+            optional_api_key_env: object = None,
+        ) -> tuple:
+            if provider_type == "remote::vllm":
+                return (_ProbeStatus.NEEDS_KEY, 3, "http://localhost:8000/v1", "default", None)
+            return (_ProbeStatus.UNREACHABLE, 0, "", "default", None)
 
         mock_probe.side_effect = side_effect
         parts = _autodetect_providers().split(",")
-        assert "inference=remote::vllm" not in parts
+        assert "inference=remote::vllm" in parts
 
 
 class TestRunCommand:

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -19,7 +19,6 @@ from ogx.cli.stack.lets_go import (
     StackLetsGo,
     _build_claude_code_aliases,
     _ProbeStatus,
-    _substitute_env_vars,
 )
 
 
@@ -100,55 +99,6 @@ class TestTopLevelLetsGoArguments:
         assert args.persist_config is True
         assert args.providers_override == "inference=remote::ollama"
         assert args.skip_install_deps is True
-
-
-class TestSubstituteEnvVars:
-    def test_boolean_true_coercion(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("MY_VAR", "true")
-        assert _substitute_env_vars("${env.MY_VAR:=false}") is True
-
-    def test_boolean_false_coercion(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("MY_VAR", "false")
-        assert _substitute_env_vars("${env.MY_VAR:=true}") is False
-
-    def test_boolean_default_true_coercion(self):
-        assert _substitute_env_vars("${env.NONEXISTENT_VAR_XYZ:=true}") is True
-
-    def test_boolean_default_false_coercion(self):
-        assert _substitute_env_vars("${env.NONEXISTENT_VAR_XYZ:=false}") is False
-
-    def test_integer_coercion(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("MY_INT", "4096")
-        result = _substitute_env_vars("${env.MY_INT:=2048}")
-        assert result == 4096
-        assert isinstance(result, int)
-
-    def test_integer_default_coercion(self):
-        result = _substitute_env_vars("${env.NONEXISTENT_INT_XYZ:=2048}")
-        assert result == 2048
-        assert isinstance(result, int)
-
-    def test_string_passes_through(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("MY_URL", "http://example.com")
-        assert _substitute_env_vars("${env.MY_URL:=http://localhost}") == "http://example.com"
-
-    def test_nested_dict_booleans(self):
-        obj = {"tls": {"verify": "${env.NONEXISTENT_TLS_XYZ:=true}"}}
-        result = _substitute_env_vars(obj)
-        assert result["tls"]["verify"] is True
-
-    def test_list_items_coerced(self):
-        obj = ["${env.NONEXISTENT_XYZ:=true}", "${env.NONEXISTENT_XYZ:=42}"]
-        result = _substitute_env_vars(obj)
-        assert result[0] is True
-        assert result[1] == 42
-
-    def test_non_template_string_unchanged(self):
-        assert _substitute_env_vars("http://localhost:8080/v1") == "http://localhost:8080/v1"
-
-    def test_non_string_passthrough(self):
-        assert _substitute_env_vars(123) == 123
-        assert _substitute_env_vars(True) is True
 
 
 class TestAutodetect:


### PR DESCRIPTION
Replace HTTP endpoint probing with real provider instantiation and model listing to confirm configurations work and models are available. This ensures that detected providers can actually be used, not just reachable.

Changes:
- Refactor _probe_endpoint() to _probe_provider_availability() with provider registry lookup.
- Instantiate actual provider implementations using config factories instead of making HTTP requests.
- Call provider.list_models() with asyncio timeout to confirm availability.
- Add environment variable substitution for config templates (${env.VAR_NAME:=default}).
- Inject required provider attributes (__provider_id__, __provider_spec__, __provider_config__).
- Implement specific error categorization for authentication failures.
- Clean up provider resources via aclose() after model listing.
- Show pip packages needed when provider dependencies are missing
