### PR TITLE
fix(responses): propagate provider 4xx errors instead of returning 500

### DIFF
--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -793,14 +793,18 @@ class OpenAIResponsesImpl:
                             if failed_response.error
                             else "response failed but no error message was provided"
                         )
+                        error_code = failed_response.error.code if failed_response.error else "server_error"
                         logger.error(
                             "response creation failed",
                             error_message=error_message,
+                            error_code=error_code,
                             response_id=failed_response.id,
                             model=model,
                         )
-                        # Surface the provider message — it may be actionable (e.g. context window exceeded)
-                        # and is already visible to callers in streaming mode via the response.failed event.
+                        # Surface the provider message — it may be actionable (e.g. wrong tool-call-parser,
+                        # context window exceeded). Use the error code to pick the right HTTP status.
+                        if error_code == "invalid_prompt":
+                            raise InvalidParameterError("model", model, error_message)
                         raise InternalServerError(error_message)
                     case _:
                         pass  # Other event types don't have .response

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -191,6 +191,8 @@ def extract_openai_error(exc: Exception) -> tuple[str, str]:
 
     if raw_code and isinstance(raw_code, str):
         final_code: str = _RESPONSES_API_ERROR_CODES[raw_code] if raw_code in _RESPONSES_API_ERROR_CODES else raw_code
+    elif isinstance(raw_code, int) and 400 <= raw_code < 500:
+        final_code = "invalid_prompt"
     else:
         final_code = "server_error"
 

--- a/tests/unit/providers/responses/builtin/test_streaming_errors.py
+++ b/tests/unit/providers/responses/builtin/test_streaming_errors.py
@@ -134,6 +134,24 @@ class TestExtractOpenaiError:
             assert code == valid_code
             assert message == "example"
 
+    def test_integer_4xx_code_maps_to_invalid_prompt(self):
+        """vLLM returns integer error codes (e.g. 400). 4xx should map to invalid_prompt."""
+        body = {
+            "error": {"message": "'dict object' has no attribute 'description'", "type": "BadRequestError", "code": 400}
+        }
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "invalid_prompt"
+        assert "'dict object' has no attribute 'description'" in message
+
+    def test_integer_5xx_code_maps_to_server_error(self):
+        """Integer 5xx codes should fall back to server_error."""
+        body = {"error": {"message": "Internal error", "code": 500}}
+        exc = _make_mock_exc(body=body)
+        code, message = extract_openai_error(exc)
+        assert code == "server_error"
+        assert message == "Internal error"
+
     def test_all_spec_codes_are_valid(self):
         """All spec-defined error codes should be accepted (no fallback)."""
         spec_codes = {


### PR DESCRIPTION
## Summary

When an inference provider (e.g. vLLM) returns a 4xx error during tool processing, OGX was swallowing the error and returning a generic HTTP 500. This made provider-side issues (like incompatible `--tool-call-parser` configuration) undiagnosable for users.

**Root cause investigated in [RHOAIENG-64172](https://redhat.atlassian.net/browse/RHOAIENG-64172):** vLLM serving Apertus 8B with `--tool-call-parser=hermes` (incompatible) returns `{"error": {"message": "'dict object' has no attribute 'description'", "code": 400}}`. OGX surfaced this as HTTP 500 with the raw message, making it look like an OGX bug.

## Changes

- **`streaming.py` / `extract_openai_error()`**: Map integer 4xx error codes from providers (e.g. vLLM's `"code": 400`) to `"invalid_prompt"` so the error category is preserved. Previously, integer codes fell through to `"server_error"`.
- **`openai_responses.py`**: In the non-streaming path, raise `InvalidParameterError` (HTTP 400) instead of `InternalServerError` (HTTP 500) when the error code is `"invalid_prompt"`.
- The actual provider error message is always surfaced to the user.

## Test Plan

- [x] Added unit tests for integer 4xx and 5xx error code handling in `extract_openai_error()`
- [x] All 16 existing + 2 new tests pass
- [x] Pre-commit hooks pass

Fixes #5915