### PR TITLE
fix(storage): URL-encode credentials in sql_postgres connection string

### DIFF
--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -220,7 +220,7 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
                 host=self.host,
                 port=int(self.port),
                 database=self.db,
-            ).render_as_string(hide_password=False)
+            ).render_as_string(hide_password=False)  # TODO: avoid rendering password
         )
 
     @classmethod

--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -165,7 +165,7 @@ class SqlAlchemySqlStoreConfig(BaseModel):
 
     @property
     @abstractmethod
-    def engine_str(self) -> str: ...
+    def engine_str(self) -> str | URL: ...
 
     # TODO: move this when we have a better way to specify dependencies with internal APIs
     @classmethod
@@ -211,16 +211,14 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
     pool_recycle: int = Field(default=3600, ge=-1, description="Connection recycle interval in seconds, -1 to disable")
 
     @property
-    def engine_str(self) -> str:
-        return str(
-            URL.create(
-                drivername="postgresql+asyncpg",
-                username=self.user,
-                password=self.password.get_secret_value() if self.password else None,
-                host=self.host,
-                port=int(self.port),
-                database=self.db,
-            ).render_as_string(hide_password=False)  # TODO: avoid rendering password
+    def engine_str(self) -> URL:
+        return URL.create(
+            drivername="postgresql+asyncpg",
+            username=self.user,
+            password=self.password.get_secret_value() if self.password else None,
+            host=self.host,
+            port=int(self.port),
+            database=self.db,
         )
 
     @classmethod

--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -211,8 +211,18 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
 
     @property
     def engine_str(self) -> str:
-        pw = self.password.get_secret_value() if self.password else ""
-        return f"postgresql+asyncpg://{self.user}:{pw}@{self.host}:{self.port}/{self.db}"
+        from sqlalchemy.engine import URL
+
+        return str(
+            URL.create(
+                drivername="postgresql+asyncpg",
+                username=self.user,
+                password=self.password.get_secret_value() if self.password else None,
+                host=self.host,
+                port=int(self.port),
+                database=self.db,
+            ).render_as_string(hide_password=False)
+        )
 
     @classmethod
     def pip_packages(cls) -> list[str]:

--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
+from sqlalchemy.engine import URL
 
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR
 
@@ -211,8 +212,6 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
 
     @property
     def engine_str(self) -> str:
-        from sqlalchemy.engine import URL
-
         return str(
             URL.create(
                 drivername="postgresql+asyncpg",

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -29,7 +29,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine
 from sqlalchemy.ext.asyncio.session import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
-from ogx.core.storage.datatypes import PostgresSqlStoreConfig, SqlAlchemySqlStoreConfig
+from ogx.core.storage.datatypes import PostgresSqlStoreConfig, SqlAlchemySqlStoreConfig, SqliteSqlStoreConfig
 from ogx.log import get_logger
 from ogx_api import PaginatedResponse
 from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType, SqlStore
@@ -76,7 +76,7 @@ class SqlAlchemySqlStoreImpl(SqlStore):
 
     def __init__(self, config: SqlAlchemySqlStoreConfig) -> None:
         self.config = config
-        self._is_sqlite_backend = "sqlite" in self.config.engine_str
+        self._is_sqlite_backend = isinstance(self.config, SqliteSqlStoreConfig)
         self._engine: AsyncEngine | None = None  # Lazy initialization
         self.async_session: async_sessionmaker[AsyncSession] | None = None
         self.metadata = MetaData()

--- a/tests/unit/core/test_sql_postgres_engine_str.py
+++ b/tests/unit/core/test_sql_postgres_engine_str.py
@@ -74,3 +74,20 @@ class TestSqlPostgresEngineStr:
         assert parsed.hostname == "h"
         assert parsed.port == 5432
         assert parsed.path == "/d"
+
+
+@pytest.mark.parametrize(
+    "username",
+    ["u@ss", "u:ss", "u/ss", "u%ss", "u@ss:w/o%rd", "a@b:c/d%e#f"],
+)
+def test_special_chars_in_username_produce_valid_url(username):
+    config = PostgresSqlStoreConfig(user=username, password=SecretStr("p"), host="h", port=5432, db="d")
+    url = config.engine_str
+    assert url.startswith("postgresql+asyncpg://")
+    assert "@h:5432/d" in url
+    parsed = urlparse(url)
+    assert unquote(parsed.username) == username
+    assert unquote(parsed.password) == "p"
+    assert parsed.hostname == "h"
+    assert parsed.port == 5432
+    assert parsed.path == "/d"

--- a/tests/unit/core/test_sql_postgres_engine_str.py
+++ b/tests/unit/core/test_sql_postgres_engine_str.py
@@ -4,90 +4,73 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-"""Unit tests for PostgresSqlStoreConfig.engine_str URL encoding."""
-
-from urllib.parse import unquote, urlparse
+"""Unit tests for PostgresSqlStoreConfig.engine_str URL construction."""
 
 import pytest
 from pydantic import SecretStr
+from sqlalchemy.engine import URL
 
 from ogx.core.storage.datatypes import PostgresSqlStoreConfig
 
 
 class TestSqlPostgresEngineStr:
-    def test_simple_password(self):
+    def test_simple_credentials(self):
         config = PostgresSqlStoreConfig(
             user="pguser", password=SecretStr("simple"), host="db.local", port=5432, db="mydb"
         )
-        assert config.engine_str == "postgresql+asyncpg://pguser:simple@db.local:5432/mydb"
-
-    def test_password_with_at_sign(self):
-        config = PostgresSqlStoreConfig(
-            user="pguser", password=SecretStr("p@ss"), host="db.local", port=5432, db="mydb"
-        )
         url = config.engine_str
-        assert "db.local" in url
-        assert url.startswith("postgresql+asyncpg://")
-        parsed = urlparse(url)
-        assert parsed.username == "pguser"
-        assert unquote(parsed.password) == "p@ss"
-        assert parsed.hostname == "db.local"
-        assert parsed.port == 5432
-        assert parsed.path == "/mydb"
-
-    def test_password_with_special_characters(self):
-        config = PostgresSqlStoreConfig(
-            user="pguser", password=SecretStr("my@pass:word/foo%bar"), host="db.local", port=5432, db="mydb"
-        )
-        url = config.engine_str
-        assert "db.local:5432/mydb" in url
-        assert url.startswith("postgresql+asyncpg://pguser:")
-        parsed = urlparse(url)
-        assert parsed.username == "pguser"
-        assert unquote(parsed.password) == "my@pass:word/foo%bar"
-        assert parsed.hostname == "db.local"
-        assert parsed.port == 5432
-        assert parsed.path == "/mydb"
+        assert isinstance(url, URL)
+        assert url.drivername == "postgresql+asyncpg"
+        assert url.username == "pguser"
+        assert url.password == "simple"
+        assert url.host == "db.local"
+        assert url.port == 5432
+        assert url.database == "mydb"
 
     def test_no_password(self):
         config = PostgresSqlStoreConfig(user="pguser", password=None, host="db.local", port=5432, db="mydb")
-        assert config.engine_str == "postgresql+asyncpg://pguser@db.local:5432/mydb"
-        parsed = urlparse(config.engine_str)
-        assert parsed.username == "pguser"
-        assert parsed.password is None
-        assert parsed.hostname == "db.local"
-        assert parsed.port == 5432
-        assert parsed.path == "/mydb"
+        url = config.engine_str
+        assert url.username == "pguser"
+        assert url.password is None
+        assert url.host == "db.local"
+        assert url.port == 5432
+        assert url.database == "mydb"
 
     @pytest.mark.parametrize(
         "password",
         ["p@ss", "p:ss", "p/ss", "p%ss", "p@ss:w/o%rd", "a@b:c/d%e#f"],
     )
-    def test_special_chars_produce_valid_url(self, password):
+    def test_special_chars_in_password(self, password):
         config = PostgresSqlStoreConfig(user="u", password=SecretStr(password), host="h", port=5432, db="d")
         url = config.engine_str
-        assert url.startswith("postgresql+asyncpg://u:")
-        assert "@h:5432/d" in url
-        parsed = urlparse(url)
-        assert parsed.username == "u"
-        assert unquote(parsed.password) == password
-        assert parsed.hostname == "h"
-        assert parsed.port == 5432
-        assert parsed.path == "/d"
+        assert url.password == password
+        assert url.username == "u"
+        assert url.host == "h"
+        assert url.port == 5432
+        assert url.database == "d"
 
+    @pytest.mark.parametrize(
+        "username",
+        ["u@ss", "u:ss", "u/ss", "u%ss", "u@ss:w/o%rd", "a@b:c/d%e#f"],
+    )
+    def test_special_chars_in_username(self, username):
+        config = PostgresSqlStoreConfig(user=username, password=SecretStr("p"), host="h", port=5432, db="d")
+        url = config.engine_str
+        assert url.username == username
+        assert url.password == "p"
+        assert url.host == "h"
+        assert url.port == 5432
+        assert url.database == "d"
 
-@pytest.mark.parametrize(
-    "username",
-    ["u@ss", "u:ss", "u/ss", "u%ss", "u@ss:w/o%rd", "a@b:c/d%e#f"],
-)
-def test_special_chars_in_username_produce_valid_url(username):
-    config = PostgresSqlStoreConfig(user=username, password=SecretStr("p"), host="h", port=5432, db="d")
-    url = config.engine_str
-    assert url.startswith("postgresql+asyncpg://")
-    assert "@h:5432/d" in url
-    parsed = urlparse(url)
-    assert unquote(parsed.username) == username
-    assert unquote(parsed.password) == "p"
-    assert parsed.hostname == "h"
-    assert parsed.port == 5432
-    assert parsed.path == "/d"
+    @pytest.mark.parametrize(
+        "db",
+        ["my-db", "my.db", "db_name"],
+    )
+    def test_special_chars_in_db(self, db):
+        config = PostgresSqlStoreConfig(user="u", password=SecretStr("p"), host="h", port=5432, db=db)
+        url = config.engine_str
+        assert url.username == "u"
+        assert url.password == "p"
+        assert url.host == "h"
+        assert url.port == 5432
+        assert url.database == db

--- a/tests/unit/core/test_sql_postgres_engine_str.py
+++ b/tests/unit/core/test_sql_postgres_engine_str.py
@@ -1,0 +1,50 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for PostgresSqlStoreConfig.engine_str URL encoding."""
+
+import pytest
+from pydantic import SecretStr
+
+from ogx.core.storage.datatypes import PostgresSqlStoreConfig
+
+
+class TestSqlPostgresEngineStr:
+    def test_simple_password(self):
+        config = PostgresSqlStoreConfig(
+            user="pguser", password=SecretStr("simple"), host="db.local", port=5432, db="mydb"
+        )
+        assert config.engine_str == "postgresql+asyncpg://pguser:simple@db.local:5432/mydb"
+
+    def test_password_with_at_sign(self):
+        config = PostgresSqlStoreConfig(
+            user="pguser", password=SecretStr("p@ss"), host="db.local", port=5432, db="mydb"
+        )
+        url = config.engine_str
+        assert "db.local" in url
+        assert url.startswith("postgresql+asyncpg://")
+
+    def test_password_with_special_characters(self):
+        config = PostgresSqlStoreConfig(
+            user="pguser", password=SecretStr("my@pass:word/foo%bar"), host="db.local", port=5432, db="mydb"
+        )
+        url = config.engine_str
+        assert "db.local:5432/mydb" in url
+        assert url.startswith("postgresql+asyncpg://pguser:")
+
+    def test_no_password(self):
+        config = PostgresSqlStoreConfig(user="pguser", password=None, host="db.local", port=5432, db="mydb")
+        assert config.engine_str == "postgresql+asyncpg://pguser@db.local:5432/mydb"
+
+    @pytest.mark.parametrize(
+        "password",
+        ["p@ss", "p:ss", "p/ss", "p%ss", "p@ss:w/o%rd", "a@b:c/d%e#f"],
+    )
+    def test_special_chars_produce_valid_url(self, password):
+        config = PostgresSqlStoreConfig(user="u", password=SecretStr(password), host="h", port=5432, db="d")
+        url = config.engine_str
+        assert url.startswith("postgresql+asyncpg://u:")
+        assert "@h:5432/d" in url

--- a/tests/unit/core/test_sql_postgres_engine_str.py
+++ b/tests/unit/core/test_sql_postgres_engine_str.py
@@ -6,6 +6,8 @@
 
 """Unit tests for PostgresSqlStoreConfig.engine_str URL encoding."""
 
+from urllib.parse import unquote, urlparse
+
 import pytest
 from pydantic import SecretStr
 
@@ -26,6 +28,12 @@ class TestSqlPostgresEngineStr:
         url = config.engine_str
         assert "db.local" in url
         assert url.startswith("postgresql+asyncpg://")
+        parsed = urlparse(url)
+        assert parsed.username == "pguser"
+        assert unquote(parsed.password) == "p@ss"
+        assert parsed.hostname == "db.local"
+        assert parsed.port == 5432
+        assert parsed.path == "/mydb"
 
     def test_password_with_special_characters(self):
         config = PostgresSqlStoreConfig(
@@ -34,10 +42,22 @@ class TestSqlPostgresEngineStr:
         url = config.engine_str
         assert "db.local:5432/mydb" in url
         assert url.startswith("postgresql+asyncpg://pguser:")
+        parsed = urlparse(url)
+        assert parsed.username == "pguser"
+        assert unquote(parsed.password) == "my@pass:word/foo%bar"
+        assert parsed.hostname == "db.local"
+        assert parsed.port == 5432
+        assert parsed.path == "/mydb"
 
     def test_no_password(self):
         config = PostgresSqlStoreConfig(user="pguser", password=None, host="db.local", port=5432, db="mydb")
         assert config.engine_str == "postgresql+asyncpg://pguser@db.local:5432/mydb"
+        parsed = urlparse(config.engine_str)
+        assert parsed.username == "pguser"
+        assert parsed.password is None
+        assert parsed.hostname == "db.local"
+        assert parsed.port == 5432
+        assert parsed.path == "/mydb"
 
     @pytest.mark.parametrize(
         "password",
@@ -48,3 +68,9 @@ class TestSqlPostgresEngineStr:
         url = config.engine_str
         assert url.startswith("postgresql+asyncpg://u:")
         assert "@h:5432/d" in url
+        parsed = urlparse(url)
+        assert parsed.username == "u"
+        assert unquote(parsed.password) == password
+        assert parsed.hostname == "h"
+        assert parsed.port == 5432
+        assert parsed.path == "/d"


### PR DESCRIPTION
## Summary

The `sql_postgres` storage backend fails to connect when the password contains special characters like `@`, `:`, `/`, or `%`. The connection string was built with f-string interpolation, which broke URL parsing — `@` in the password was interpreted as the user/host separator, causing DNS resolution errors.

## Changes

- **`datatypes.py`**: Replace f-string interpolation with `sqlalchemy.engine.URL.create()`, returning the `URL` object directly instead of rendering it as a string. This handles all special character encoding automatically and avoids exposing the password as a plaintext string via `render_as_string(hide_password=False)`.
- **`sqlalchemy_sqlstore.py`**: Use `isinstance(config, SqliteSqlStoreConfig)` for sqlite backend detection instead of string matching on `engine_str`, since `engine_str` now returns a `URL` object for postgres.
- **Added unit tests**: 17 test cases covering special characters in passwords, usernames, and database names.

Before:
```python
return f"postgresql+asyncpg://{self.user}:{pw}@{self.host}:{self.port}/{self.db}"
```

After:
```python
return URL.create(
    drivername="postgresql+asyncpg",
    username=self.user,
    password=self.password.get_secret_value() if self.password else None,
    host=self.host,
    port=int(self.port),
    database=self.db,
)
```

Note: The `kv_postgres` backend is not affected — it passes parameters directly to `asyncpg.create_pool()` without URL string construction.

## Test Plan

- [x] 17 unit tests covering special characters in passwords, usernames, and database names
- [x] 287 core unit tests pass
- [x] Pre-commit hooks pass (mypy, ruff, all checks)

Fixes #5936
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->