### PR TITLE
fix(ci): return full test matrix for unrecognized changed file paths

### DIFF
--- a/scripts/generate_ci_matrix.py
+++ b/scripts/generate_ci_matrix.py
@@ -68,7 +68,7 @@ def _setups_from_changed_files(changed_files: list[str]) -> set[str] | None:
                 matched = True
                 break
 
-        if not matched and filepath.startswith("src/ogx/providers/remote/inference/"):
+        if not matched:
             return None
 
     return setups


### PR DESCRIPTION
# What does this PR do?

Fixes the CI matrix generator to return the full test matrix when a changed file doesn't match any known provider path or core path. Previously, the fallback only applied to unrecognized paths under src/ogx/providers/remote/inference/. Changes to shared files silently collapsed CI to the Ollama smoke subset, missing real regressions.

## Test Plan

Pre-commit checks pass. Logic validated with inline assertions.