### PR TITLE
fix(messages)!: resolve Claude Code alias models to the caller's last real model

### DIFF
--- a/docs/docs/providers/messages/inline_builtin.mdx
+++ b/docs/docs/providers/messages/inline_builtin.mdx
@@ -19,6 +19,8 @@ Implements the Anthropic Messages API with two modes: native passthrough for pro
 | `kvstore.backend` | `str` | No |  | Name of backend from storage.backends |
 | `max_concurrent_batches` | `int` | No | 1 | Maximum number of concurrent message batches to process simultaneously. |
 | `max_concurrent_requests_per_batch` | `int` | No | 10 | Maximum number of concurrent requests to process per batch. |
+| `alias_prefixes` | `list[str]` | No | ['claude-'] | Model-ID prefixes treated as fallback aliases. Claude Code hardcodes model IDs (e.g. 'claude-haiku-4-5-...') into its background requests; when an unprefixed model with one of these prefixes is requested and is not registered, it is rewritten to the last real model the same caller used, so those requests follow the user's actual model and provider instead of failing. |
+| `fallback_model` | `str \| None` | No |  | Model ID to use for an alias request when the caller has not yet made a request with a real model (cold start). When None, an alias request with no prior model returns an error rather than silently routing to an arbitrary, possibly expensive, provider. |
 
 ## Sample Configuration
 

--- a/src/ogx/core/stack.py
+++ b/src/ogx/core/stack.py
@@ -176,63 +176,6 @@ async def register_resources(run_config: StackConfig, impls: dict[Api, Any]) -> 
                 if not obj.provider_id or obj.provider_id == "__disabled__":
                     logger.debug("Skipping registration for disabled provider", resource=rsrc.capitalize())
                     continue
-                # Handle provider_id="all" - register unprefixed alias using first active provider
-                if obj.provider_id == "all":
-                    if rsrc != "models":
-                        logger.warning(
-                            "provider_id=all is only supported for models, skipping",
-                            resource=rsrc.capitalize(),
-                        )
-                        continue
-                    # Get all active inference providers from the routing table
-                    routing_table = impls[api]
-                    if not hasattr(routing_table, "impls_by_provider_id"):
-                        logger.warning(
-                            "Cannot resolve provider_id=all - routing table has no providers",
-                            resource=rsrc.capitalize(),
-                        )
-                        continue
-                    provider_ids = list(routing_table.impls_by_provider_id.keys())
-                    if not provider_ids:
-                        logger.warning(
-                            "Cannot resolve provider_id=all - no active providers found",
-                            resource=rsrc.capitalize(),
-                        )
-                        continue
-                    # Use first active provider for the unprefixed alias
-                    first_provider = provider_ids[0]
-                    logger.info(
-                        "Registering unprefixed model alias using first active inference provider",
-                        model_id=obj.model_id,
-                        provider_id=first_provider,
-                        available_providers=provider_ids,
-                    )
-
-                    # Mark this as an unprefixed alias in metadata
-                    metadata = (obj.metadata or {}).copy()
-                    metadata["_unprefixed_alias"] = True
-                    obj_copy = obj.model_copy(
-                        update={
-                            "provider_id": first_provider,
-                            "metadata": metadata,
-                        }
-                    )
-
-                    if request_class is not None:
-                        request = request_class(**obj_copy.model_dump())
-                        try:
-                            await method(request)
-                        except Exception as e:
-                            logger.warning(
-                                "Failed to register unprefixed model alias",
-                                model_id=obj_copy.model_id,
-                                provider_id=first_provider,
-                                error=str(e),
-                            )
-                    else:
-                        await method(**{k: getattr(obj_copy, k) for k in obj_copy.model_dump().keys()})
-                    continue
-
                 logger.debug(
                     "Registering resource for provider",
                     resource=rsrc.capitalize(),

--- a/src/ogx/distributions/ci-tests/config.yaml
+++ b/src/ogx/distributions/ci-tests/config.yaml
@@ -267,21 +267,6 @@ storage:
 registered_resources:
   models:
   - metadata: {}
-    model_id: claude-haiku-4-5-20251001
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-sonnet-4-5-20250514
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-opus-4-6-20260314
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
     model_id: azure/gpt-4o
     provider_id: ${env.AZURE_API_KEY:+azure}
     provider_model_id: gpt-4o

--- a/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
@@ -280,21 +280,6 @@ storage:
 registered_resources:
   models:
   - metadata: {}
-    model_id: claude-haiku-4-5-20251001
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-sonnet-4-5-20250514
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-opus-4-6-20260314
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
     model_id: azure/gpt-4o
     provider_id: ${env.AZURE_API_KEY:+azure}
     provider_model_id: gpt-4o

--- a/src/ogx/distributions/starter/config.yaml
+++ b/src/ogx/distributions/starter/config.yaml
@@ -259,22 +259,7 @@ storage:
       table_name: connectors
       backend: sql_default
 registered_resources:
-  models:
-  - metadata: {}
-    model_id: claude-haiku-4-5-20251001
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-sonnet-4-5-20250514
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-opus-4-6-20260314
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
+  models: []
   vector_dbs: []
 server:
   port: 8321

--- a/src/ogx/distributions/starter/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/starter/run-with-postgres-store.yaml
@@ -272,22 +272,7 @@ storage:
       table_name: connectors
       backend: sql_default
 registered_resources:
-  models:
-  - metadata: {}
-    model_id: claude-haiku-4-5-20251001
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-sonnet-4-5-20250514
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
-  - metadata: {}
-    model_id: claude-opus-4-6-20260314
-    provider_id: all
-    provider_model_id: auto
-    model_type: llm
+  models: []
   vector_dbs: []
 server:
   port: 8321

--- a/src/ogx/distributions/starter/starter.py
+++ b/src/ogx/distributions/starter/starter.py
@@ -9,7 +9,6 @@ from typing import Any
 
 from ogx.core.datatypes import (
     BuildProvider,
-    ModelInput,
     Provider,
     ProviderSpec,
     QualifiedModel,
@@ -275,28 +274,9 @@ def get_distribution_template(name: str = "starter") -> DistributionTemplate:
         ],
     }
 
-    # Claude model aliases for zero-config Claude Code compatibility
-    claude_model_aliases = [
-        ModelInput(
-            model_id="claude-haiku-4-5-20251001",
-            provider_id="all",
-            provider_model_id="auto",
-        ),
-        ModelInput(
-            model_id="claude-sonnet-4-5-20250514",
-            provider_id="all",
-            provider_model_id="auto",
-        ),
-        ModelInput(
-            model_id="claude-opus-4-6-20260314",
-            provider_id="all",
-            provider_model_id="auto",
-        ),
-    ]
-
     base_run_settings = RunConfigSettings(
         provider_overrides=default_overrides,
-        default_models=claude_model_aliases,
+        default_models=[],
         default_connectors=[],
         vector_stores_config=VectorStoresConfig(
             default_provider_id="faiss",

--- a/src/ogx/providers/inline/messages/config.py
+++ b/src/ogx/providers/inline/messages/config.py
@@ -30,6 +30,26 @@ class MessagesConfig(BaseModel):
         ge=1,
     )
 
+    alias_prefixes: list[str] = Field(
+        default=["claude-"],
+        description=(
+            "Model-ID prefixes treated as fallback aliases. Claude Code hardcodes model IDs "
+            "(e.g. 'claude-haiku-4-5-...') into its background requests; when an unprefixed model "
+            "with one of these prefixes is requested and is not registered, it is rewritten to the "
+            "last real model the same caller used, so those requests follow the user's actual model "
+            "and provider instead of failing."
+        ),
+    )
+
+    fallback_model: str | None = Field(
+        default=None,
+        description=(
+            "Model ID to use for an alias request when the caller has not yet made a request with a "
+            "real model (cold start). When None, an alias request with no prior model returns an error "
+            "rather than silently routing to an arbitrary, possibly expensive, provider."
+        ),
+    )
+
     @classmethod
     def sample_run_config(cls, __distro_dir__: str = "") -> dict[str, Any]:
         return {

--- a/src/ogx/providers/inline/messages/impl.py
+++ b/src/ogx/providers/inline/messages/impl.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import httpx
 
+from ogx.core.request_headers import get_authenticated_user
 from ogx.core.storage.kvstore import KVStore
 from ogx.log import get_logger
 from ogx_api import (
@@ -84,6 +85,9 @@ _BATCH_PREFIX = "msgbatch:"
 _BATCH_RESULTS_PREFIX = "msgbatch_results:"
 _BATCH_EXPIRY_HOURS = 24
 
+# Key used for the last-real-model map when auth is disabled (single local caller).
+_ANONYMOUS_PRINCIPAL = "__local__"
+
 logger = get_logger(name=__name__, category="messages")
 
 
@@ -143,6 +147,11 @@ class BuiltinMessagesImpl(Messages):
         # Partial results held in memory so a cancellation can finalize with the
         # truly-completed outcomes, not "all canceled". Keyed by batch_id.
         self._partial_results: dict[str, list[dict[str, Any]]] = {}
+        # Last real (registered) model each caller drove a messages request with,
+        # keyed by auth principal. Used to resolve Claude Code's hardcoded alias
+        # model IDs to the model the caller is actually using. In-memory and
+        # ephemeral by design: a cold start falls back to config.fallback_model.
+        self._last_real_model: dict[str, str] = {}
 
     async def initialize(self) -> None:
         self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0))
@@ -155,10 +164,56 @@ class BuiltinMessagesImpl(Messages):
                 active_tasks=len(self._processing_tasks),
             )
 
+    @staticmethod
+    def _principal_key() -> str:
+        user = get_authenticated_user()
+        return user.principal if user and user.principal else _ANONYMOUS_PRINCIPAL
+
+    async def _is_registered_model(self, model: str) -> bool:
+        router = self.inference_api
+        routing_table = getattr(router, "routing_table", None)
+        if routing_table is None:
+            return True
+        try:
+            return await routing_table.get_object_by_identifier("model", model) is not None
+        except (KeyError, ValueError, AttributeError):
+            return False
+
+    async def _resolve_model(self, model: str) -> str:
+        """Resolve a requested model, rewriting Claude Code alias IDs to a real model.
+
+        A registered model is returned unchanged and recorded as the caller's last
+        real model. An unregistered model whose ID matches a configured alias prefix
+        is rewritten to that last real model (or the configured fallback on cold
+        start). Any other unregistered model is returned unchanged so the inference
+        layer raises its usual "model not found" error.
+        """
+        if await self._is_registered_model(model):
+            self._last_real_model[self._principal_key()] = model
+            return model
+
+        if not any(model.startswith(prefix) for prefix in self.config.alias_prefixes):
+            return model
+
+        principal = self._principal_key()
+        target = self._last_real_model.get(principal) or self.config.fallback_model
+        if target is None:
+            raise ValueError(
+                f"Failed to resolve alias model '{model}': no prior model used by this caller and no "
+                "fallback_model configured. Make a request with a real model first, or set "
+                "fallback_model on the messages provider."
+            )
+        logger.info("Resolving alias model to last real model", requested=model, resolved=target, principal=principal)
+        return target
+
     async def create_message(
         self,
         request: AnthropicCreateMessageRequest,
     ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        resolved_model = await self._resolve_model(request.model)
+        if resolved_model != request.model:
+            request = request.model_copy(update={"model": resolved_model})
+
         # Try native passthrough for providers that support /v1/messages directly
         passthrough_url = await self._get_passthrough_url(request.model)
         if passthrough_url:
@@ -177,6 +232,10 @@ class BuiltinMessagesImpl(Messages):
         self,
         request: AnthropicCountTokensRequest,
     ) -> AnthropicCountTokensResponse:
+        resolved_model = await self._resolve_model(request.model)
+        if resolved_model != request.model:
+            request = request.model_copy(update={"model": resolved_model})
+
         passthrough_url = await self._get_passthrough_url(request.model)
         if passthrough_url:
             return await self._passthrough_count_tokens(passthrough_url, request)

--- a/tests/unit/providers/inline/messages/test_impl.py
+++ b/tests/unit/providers/inline/messages/test_impl.py
@@ -478,3 +478,60 @@ class TestStreamingTranslation:
 
         msg_delta = [e for e in events if e.type == "message_delta"]
         assert msg_delta[0].delta.stop_reason == "tool_use"
+
+
+def _impl_with_registered(registered: set[str], **config_kwargs):
+    """Build an impl whose routing table reports `registered` model IDs as known."""
+    mock_inference = AsyncMock()
+    routing_table = AsyncMock()
+
+    async def get_object_by_identifier(_type, identifier):
+        return object() if identifier in registered else None
+
+    routing_table.get_object_by_identifier.side_effect = get_object_by_identifier
+    # MagicMock attribute access on an AsyncMock would itself be an AsyncMock, so set
+    # routing_table explicitly to control resolution.
+    mock_inference.routing_table = routing_table
+
+    mock_kvstore = MagicMock()
+    config = MessagesConfig(
+        kvstore=KVStoreReference(backend="kv_default", namespace="test"),
+        **config_kwargs,
+    )
+    return BuiltinMessagesImpl(config=config, inference_api=mock_inference, kvstore=mock_kvstore)
+
+
+class TestAliasResolution:
+    async def test_registered_model_is_recorded_and_unchanged(self):
+        impl = _impl_with_registered({"ollama/gpt-oss"})
+        resolved = await impl._resolve_model("ollama/gpt-oss")
+        assert resolved == "ollama/gpt-oss"
+        assert impl._last_real_model["__local__"] == "ollama/gpt-oss"
+
+    async def test_alias_resolves_to_last_real_model(self):
+        impl = _impl_with_registered({"ollama/gpt-oss"})
+        await impl._resolve_model("ollama/gpt-oss")
+        resolved = await impl._resolve_model("claude-haiku-4-5-20251001")
+        assert resolved == "ollama/gpt-oss"
+
+    async def test_alias_cold_start_uses_fallback_model(self):
+        impl = _impl_with_registered(set(), fallback_model="ollama/llama3.2:1b")
+        resolved = await impl._resolve_model("claude-opus-4-6-20260314")
+        assert resolved == "ollama/llama3.2:1b"
+
+    async def test_alias_cold_start_without_fallback_errors(self):
+        impl = _impl_with_registered(set())
+        with pytest.raises(ValueError, match="no fallback_model configured"):
+            await impl._resolve_model("claude-haiku-4-5-20251001")
+
+    async def test_unknown_non_alias_model_passes_through(self):
+        impl = _impl_with_registered(set())
+        # Not an alias prefix: returned unchanged so inference raises its own error.
+        resolved = await impl._resolve_model("gpt-typo")
+        assert resolved == "gpt-typo"
+
+    async def test_registered_alias_is_not_overridden(self):
+        # A claude-* id that is actually registered (e.g. via lets_go) wins over fallback.
+        impl = _impl_with_registered({"claude-haiku-4-5"})
+        resolved = await impl._resolve_model("claude-haiku-4-5")
+        assert resolved == "claude-haiku-4-5"


### PR DESCRIPTION
## What

Claude Code hardcodes model IDs into its background requests (`claude-haiku-*`, `claude-opus-*`, `claude-sonnet-*`). These are aliases — no provider actually serves them; they're meant to fall back to a *real* model so Claude Code's auxiliary requests succeed.

The previous `provider_id="all"` handler registered these as unprefixed aliases against the **first active inference provider**. In a multi-provider distribution like `starter`, that meant `fireworks` won the alias and every registration failed:

```
INFO  Registering unprefixed model alias using first active inference provider
      available_providers=['fireworks','together','bedrock','openai','anthropic',...]
      model_id=claude-haiku-4-5-20251001 provider_id=fireworks
WARN  Failed to register unprefixed model alias
      error=Provider 'fireworks' returned no models for auto resolution
```

## How

Resolve aliases at the Messages API chokepoint instead of at registration time. Every Claude Code request — both the user's real `--model` calls and the hardcoded background ones — flows through `BuiltinMessagesImpl.create_message`. So:

- A **registered** model is recorded as that caller's last real model (keyed by auth principal, `__local__` when auth is off).
- An **unregistered** model whose ID matches a configured alias prefix (default `claude-`) is rewritten to the caller's last real model — so background requests follow the user's actual provider and model (same provider, predictable cost).
- **Cold start** (an alias arrives before any real request) uses the new `fallback_model` config, or raises a clear error if unset — never an arbitrary, possibly expensive, provider.
- An unregistered **non-alias** model is passed through unchanged so inference raises its usual "model not found" error.

In-memory, O(1), no persistence, no routing-table changes.

### Removed
- The `provider_id="all"` handling in `register_resources` (`core/stack.py`).
- The baked `claude_model_aliases` (`provider_id: all` / `provider_model_id: auto`) in `starter`/`ci-tests` configs.

The interactive `lets_go` alias path is untouched — those aliases become *registered* models, so they're recorded as real rather than rewritten.

## Config
- `alias_prefixes: list[str] = ["claude-"]`
- `fallback_model: str | None = None`

## Test plan
- `uv run pytest tests/unit/providers/inline/messages/test_impl.py` — 28 passed (6 new: record/passthrough, alias→last-model, cold-start fallback, cold-start error, typo passthrough, registered-alias-wins).
- `uv run pytest tests/unit/cli/test_stack_lets_go.py` — 54 passed.
- `ruff` and `mypy` clean on changed files.
- Regenerated distro + provider docs via `distro_codegen.py` / provider-codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)