### PR TITLE
ci(dependabot): add dependency scanning for ogx-api package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,17 @@ updates:
     commit-message:
       prefix: chore(python-deps)
 
+  - package-ecosystem: "uv"
+    directory: "/src/ogx_api"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    labels:
+      - type/dependencies
+      - python
+    commit-message:
+      prefix: chore(api-deps)
+
   - package-ecosystem: npm
     directory: "/ogx_ui"
     schedule:

--- a/.github/workflows/commit-constraint-updates.yml
+++ b/.github/workflows/commit-constraint-updates.yml
@@ -217,6 +217,14 @@ jobs:
             cp constraint-update/uv.lock uv.lock
             echo "Copied updated uv.lock"
           fi
+          if [ -f constraint-update/src/ogx_api/pyproject.toml ]; then
+            cp constraint-update/src/ogx_api/pyproject.toml src/ogx_api/pyproject.toml
+            echo "Copied updated src/ogx_api/pyproject.toml"
+          fi
+          if [ -f constraint-update/src/ogx_api/uv.lock ]; then
+            cp constraint-update/src/ogx_api/uv.lock src/ogx_api/uv.lock
+            echo "Copied updated src/ogx_api/uv.lock"
+          fi
 
       - name: Commit and push constraint updates
         id: commit
@@ -233,13 +241,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if [[ -z $(git status --porcelain pyproject.toml uv.lock) ]]; then
+          if [[ -z $(git status --porcelain pyproject.toml uv.lock src/ogx_api/pyproject.toml src/ogx_api/uv.lock) ]]; then
             echo "No changes to commit"
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          git add pyproject.toml uv.lock
+          git add pyproject.toml uv.lock src/ogx_api/pyproject.toml src/ogx_api/uv.lock
           git commit -s -m "fix(deps): update constraint-dependencies for ${DEP_NAME}"
 
           if [ "$IS_FORK_PR" = "true" ]; then

--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     paths:
       - 'uv.lock'
+      - 'src/ogx_api/uv.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -119,9 +119,17 @@ jobs:
 
       - name: Regenerate uv.lock files
         if: steps.update.outputs.changed == 'true'
+        env:
+          TARGET_PYPROJECTS: ${{ steps.target.outputs.pyprojects }}
         run: |
-          uv lock
-          uv lock --directory src/ogx_api
+          if echo " $TARGET_PYPROJECTS " | grep -q ' pyproject.toml '; then
+            echo "Regenerating root uv.lock"
+            uv lock
+          fi
+          if echo " $TARGET_PYPROJECTS " | grep -q ' src/ogx_api/pyproject.toml '; then
+            echo "Regenerating src/ogx_api/uv.lock"
+            uv lock --directory src/ogx_api
+          fi
 
       - name: Create PR metadata artifact
         if: steps.parse.outputs.skip != 'true'
@@ -164,6 +172,7 @@ jobs:
           CHANGED: ${{ steps.update.outputs.changed }}
           DEP_NAME: ${{ steps.parse.outputs.dep_name }}
           DEP_VERSION: ${{ steps.parse.outputs.dep_version }}
+          TARGET_PYPROJECTS: ${{ steps.target.outputs.pyprojects }}
         run: |
           mkdir -p constraint-update
           cat > constraint-update/change-info.json <<EOF
@@ -175,11 +184,15 @@ jobs:
           EOF
 
           if [ "$CHANGED" = "true" ]; then
-            cp pyproject.toml constraint-update/
-            cp uv.lock constraint-update/
-            mkdir -p constraint-update/src/ogx_api
-            cp src/ogx_api/pyproject.toml constraint-update/src/ogx_api/
-            cp src/ogx_api/uv.lock constraint-update/src/ogx_api/
+            if echo " $TARGET_PYPROJECTS " | grep -q ' pyproject.toml '; then
+              cp pyproject.toml constraint-update/
+              cp uv.lock constraint-update/
+            fi
+            if echo " $TARGET_PYPROJECTS " | grep -q ' src/ogx_api/pyproject.toml '; then
+              mkdir -p constraint-update/src/ogx_api
+              cp src/ogx_api/pyproject.toml constraint-update/src/ogx_api/
+              cp src/ogx_api/uv.lock constraint-update/src/ogx_api/
+            fi
           fi
 
       - name: Upload constraint update

--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -69,20 +69,39 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Parsed: $dep_name $dep_version"
 
-      - name: Update dependency version floors in pyproject.toml
+      - name: Determine target pyproject from changed lock files
         if: steps.parse.outputs.skip != 'true'
+        id: target
+        run: |
+          pyprojects=""
+          if git diff HEAD~1 --name-only | grep -q '^uv\.lock$'; then
+            pyprojects="pyproject.toml"
+          fi
+          if git diff HEAD~1 --name-only | grep -q '^src/ogx_api/uv\.lock$'; then
+            pyprojects="$pyprojects src/ogx_api/pyproject.toml"
+          fi
+          pyprojects=$(echo "$pyprojects" | xargs)
+
+          if [ -z "$pyprojects" ]; then
+            echo "No lock file changes detected, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Target pyproject files: $pyprojects"
+            echo "pyprojects=$pyprojects" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update dependency version floors in pyproject.toml
+        if: steps.parse.outputs.skip != 'true' && steps.target.outputs.skip != 'true'
         id: update
         env:
           DEP_NAME: ${{ steps.parse.outputs.dep_name }}
           DEP_VERSION: ${{ steps.parse.outputs.dep_version }}
+          TARGET_PYPROJECTS: ${{ steps.target.outputs.pyprojects }}
         run: |
           changed=false
 
-          for pyproject in pyproject.toml src/ogx_api/pyproject.toml; do
-            if [ ! -f "$pyproject" ]; then
-              continue
-            fi
-
+          for pyproject in $TARGET_PYPROJECTS; do
             echo "--- Checking $pyproject ---"
             output=$(python3 .github/scripts/update_constraint_deps.py \
               --dependency-name "$DEP_NAME" \

--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -75,21 +75,33 @@ jobs:
           DEP_NAME: ${{ steps.parse.outputs.dep_name }}
           DEP_VERSION: ${{ steps.parse.outputs.dep_version }}
         run: |
-          output=$(python3 .github/scripts/update_constraint_deps.py \
-            --dependency-name "$DEP_NAME" \
-            --dependency-version "$DEP_VERSION")
+          changed=false
 
-          echo "$output"
+          for pyproject in pyproject.toml src/ogx_api/pyproject.toml; do
+            if [ ! -f "$pyproject" ]; then
+              continue
+            fi
 
-          if echo "$output" | grep -q "updated=true"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
+            echo "--- Checking $pyproject ---"
+            output=$(python3 .github/scripts/update_constraint_deps.py \
+              --dependency-name "$DEP_NAME" \
+              --dependency-version "$DEP_VERSION" \
+              --pyproject "$pyproject")
 
-      - name: Regenerate uv.lock
+            echo "$output"
+
+            if echo "$output" | grep -q "updated=true"; then
+              changed=true
+            fi
+          done
+
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate uv.lock files
         if: steps.update.outputs.changed == 'true'
-        run: uv lock
+        run: |
+          uv lock
+          uv lock --directory src/ogx_api
 
       - name: Create PR metadata artifact
         if: steps.parse.outputs.skip != 'true'
@@ -145,6 +157,9 @@ jobs:
           if [ "$CHANGED" = "true" ]; then
             cp pyproject.toml constraint-update/
             cp uv.lock constraint-update/
+            mkdir -p constraint-update/src/ogx_api
+            cp src/ogx_api/pyproject.toml constraint-update/src/ogx_api/
+            cp src/ogx_api/uv.lock constraint-update/src/ogx_api/
           fi
 
       - name: Upload constraint update


### PR DESCRIPTION
# What does this PR do?

The `ogx-api` package (`src/ogx_api/`) has its own `pyproject.toml` and `uv.lock` but was not covered by Dependabot. This adds scanning for it and updates the constraint-update workflows to handle both packages.

Changes:
- Add a new `uv` ecosystem entry in `dependabot.yml` for `/src/ogx_api` with `chore(api-deps)` prefix
- Update `dependabot-constraints.yml` to run the constraint update script against both `pyproject.toml` files, regenerate both lock files, and include the API package files in the artifact
- Update `commit-constraint-updates.yml` to copy, stage, and commit the API package's `pyproject.toml` and `uv.lock` alongside the root files

## Test Plan

1. Verify the three modified workflow files parse correctly (pre-commit `check yaml` and `Lint GitHub Actions workflow files` both pass)
2. On the next Dependabot PR for a shared dependency (e.g. `pydantic`, `openai`), confirm the constraint-dependencies workflow updates both `pyproject.toml` files and regenerates both `uv.lock` files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->