### PR TITLE
fix: constrain starlette to >=1.0.1 (CVE-2026-48710)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ constraint-dependencies = [
     "python-socketio>=5.14.0",         # CVE-2025-61765: RCE via pickle deserialization
     "requests>=2.34.2",
     "setuptools<81",                   # milvus-lite imports pkg_resources; setuptools 81+ removes it
-    "starlette>=0.49.1",
+    "starlette>=1.0.1",
     "tornado>=6.5.5",
     "urllib3>=2.7.0",
     "transformers>=4.57.2,<5.0.0",     # CVE-2026-1839 fix only in 5.x; ogx doesn't use Trainer; 5.x breaks HybridCache imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ constraint-dependencies = [
     "python-socketio>=5.14.0",         # CVE-2025-61765: RCE via pickle deserialization
     "requests>=2.34.2",
     "setuptools<81",                   # milvus-lite imports pkg_resources; setuptools 81+ removes it
-    "starlette>=1.0.1",
+    "starlette>=1.0.1",                # CVE-2026-48710
     "tornado>=6.5.5",
     "urllib3>=2.7.0",
     "transformers>=4.57.2,<5.0.0",     # CVE-2026-1839 fix only in 5.x; ogx doesn't use Trainer; 5.x breaks HybridCache imports

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,7 @@ constraints = [
     { name = "python-socketio", specifier = ">=5.14.0" },
     { name = "requests", specifier = ">=2.34.2" },
     { name = "setuptools", specifier = "<81" },
-    { name = "starlette", specifier = ">=0.49.1" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "transformers", specifier = ">=4.57.2,<5.0.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -7292,15 +7292,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/Kludex/starlette/security/advisories/GHSA-86qp-5c8j-p5mr
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->