### PR TITLE
feat(messages): retrieve provider API key for Messages API passthrough requests

### DIFF
--- a/src/ogx/providers/inline/messages/impl.py
+++ b/src/ogx/providers/inline/messages/impl.py
@@ -472,11 +472,21 @@ class BuiltinMessagesImpl(Messages):
         # Use the provider_resource_id (model name without provider prefix)
         provider_model = request.model
         router = self.inference_api
+        api_key = "no-key-required"
         if hasattr(router, "routing_table"):
             try:
                 obj = await router.routing_table.get_object_by_identifier("model", request.model)
                 if obj:
                     provider_model = obj.provider_resource_id
+                    provider_impl = await router.routing_table.get_provider_impl(obj.identifier)
+                    # TODO: this is a sever abstration violation. this all needs to be refactored
+                    #       to use a proper provider interface for messages
+                    if hasattr(provider_impl, "_get_api_key_from_config_or_provider_data"):
+                        key = provider_impl._get_api_key_from_config_or_provider_data()
+                    else:
+                        key = provider_impl.get_api_key() if hasattr(provider_impl, "get_api_key") else None
+                    if key:
+                        api_key = key
             except (KeyError, ValueError, AttributeError):
                 logger.debug("Failed to resolve provider model name, using original", model=request.model)
 
@@ -485,7 +495,7 @@ class BuiltinMessagesImpl(Messages):
         headers = {
             "content-type": "application/json",
             "anthropic-version": ANTHROPIC_VERSION,
-            "x-api-key": "no-key-required",
+            "x-api-key": api_key,
         }
 
         if request.stream:
@@ -571,11 +581,21 @@ class BuiltinMessagesImpl(Messages):
         # Use the provider_resource_id (model name without provider prefix)
         provider_model = request.model
         router = self.inference_api
+        api_key = "no-key-required"
         if hasattr(router, "routing_table"):
             try:
                 obj = await router.routing_table.get_object_by_identifier("model", request.model)
                 if obj:
                     provider_model = obj.provider_resource_id
+                    provider_impl = await router.routing_table.get_provider_impl(obj.identifier)
+                    # TODO: this needs to be rafactored to avoid abstraction violations and remove
+                    #       duplicated logic with _passthrough_request
+                    if hasattr(provider_impl, "_get_api_key_from_config_or_provider_data"):
+                        key = provider_impl._get_api_key_from_config_or_provider_data()
+                    else:
+                        key = provider_impl.get_api_key() if hasattr(provider_impl, "get_api_key") else None
+                    if key:
+                        api_key = key
             except (KeyError, ValueError, AttributeError):
                 logger.debug("Failed to resolve provider model name, using original", model=request.model)
 
@@ -584,7 +604,7 @@ class BuiltinMessagesImpl(Messages):
         headers = {
             "content-type": "application/json",
             "anthropic-version": ANTHROPIC_VERSION,
-            "x-api-key": "no-key-required",
+            "x-api-key": api_key,
         }
 
         resp = await self._client.post(url, json=body, headers=headers, timeout=30)


### PR DESCRIPTION
Replace hardcoded "no-key-required" header value in _passthrough_request and _passthrough_count_tokens with dynamically retrieved API keys from the provider configuration. This allows authenticated providers like vLLM to successfully authenticate passthrough requests to their native /v1/messages endpoints.

The implementation preferentially calls _get_api_key_from_config_or_provider_data() to support both static configuration and per-request credential overrides via request headers, falling back to get_api_key() if unavailable.

Note: This introduces a temporary abstraction violation that will be refactored in a future change to use a proper provider interface for Messages API support.

Fixes providers requiring authentication (e.g., vLLM) when using native passthrough mode.