### PR TITLE
feat(cli): add --dry-run flag to validate config without starting server

### DIFF
--- a/src/ogx/cli/stack/run.py
+++ b/src/ogx/cli/stack/run.py
@@ -17,7 +17,12 @@ import yaml
 from termcolor import cprint
 
 from ogx.cli.subcommand import Subcommand
+from ogx.core.datatypes import StackConfig
+from ogx.core.distribution import builtin_automatically_routed_apis, get_provider_registry
+from ogx.core.resolver import validate_and_prepare_providers
+from ogx.core.server.server import remove_disabled_providers
 from ogx.core.stack import run_config_from_dynamic_config_spec
+from ogx.core.utils.config import redact_sensitive_fields
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR, UI_LOGS_DIR
 from ogx.core.utils.config_resolution import resolve_config_or_distro
 from ogx.log import get_logger
@@ -52,6 +57,11 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Run a stack with only a list of providers. This list is formatted like: api1=provider1,api1=provider2,api2=provider3. Where there can be multiple providers per API.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the config without starting the server.",
+    )
 
 
 def run_stack_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
@@ -59,15 +69,13 @@ def run_stack_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
 
     from ogx.core.configure import parse_and_maybe_upgrade_config
 
-    if args.enable_ui:
+    if args.enable_ui and not args.dry_run:
         env_port = os.getenv("OGX_PORT")
         ui_port = args.port or (int(env_port) if env_port else None) or 8321
         _start_ui_development_server(ui_port)
 
     if args.config:
         try:
-            from ogx.core.utils.config_resolution import resolve_config_or_distro
-
             config_file = resolve_config_or_distro(args.config)
         except ValueError as e:
             parser.error(str(e))
@@ -108,7 +116,28 @@ def run_stack_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
         except AttributeError as e:
             parser.error(f"failed to parse config file '{config_file}':\n {e}")
 
+    if args.dry_run:
+        if not config_file:
+            parser.error("--dry-run requires a config file or --providers")
+        _dry_run_validate(config, config_file)
+        return
+
     _uvicorn_run(config_file, args, parser)
+
+
+def _dry_run_validate(config: StackConfig, config_file: Path) -> None:
+    routed_apis = builtin_automatically_routed_apis()
+    validate_and_prepare_providers(
+        run_config=config,
+        provider_registry=get_provider_registry(),
+        routing_table_apis={x.routing_table_api for x in routed_apis},
+        router_apis={x.router_api for x in routed_apis},
+    )
+    logger.info("Config validation passed", config_file=config_file)
+
+    safe_config = redact_sensitive_fields(config.model_dump(mode="json"))
+    clean_config = remove_disabled_providers(safe_config)
+    logger.info("Resolved configuration", config=clean_config)
 
 
 def _uvicorn_run(config_file: Path | None, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:

--- a/src/ogx/cli/stack/run.py
+++ b/src/ogx/cli/stack/run.py
@@ -137,7 +137,7 @@ def _dry_run_validate(config: StackConfig, config_file: Path) -> None:
 
     safe_config = redact_sensitive_fields(config.model_dump(mode="json"))
     clean_config = remove_disabled_providers(safe_config)
-    logger.info("Resolved configuration", config=clean_config)
+    print(yaml.dump(clean_config, indent=2, default_flow_style=False, sort_keys=False))
 
 
 def _uvicorn_run(config_file: Path | None, args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:

--- a/tests/unit/cli/test_stack_config.py
+++ b/tests/unit/cli/test_stack_config.py
@@ -244,6 +244,7 @@ def test_providers_flag_generates_config_with_api_keys():
         image_type=None,
         distro_name=None,
         enable_ui=False,
+        dry_run=False,
     )
 
     # Mock _uvicorn_run to prevent starting a server

--- a/tests/unit/cli/test_stack_run.py
+++ b/tests/unit/cli/test_stack_run.py
@@ -8,11 +8,12 @@
 Unit tests for `ogx run` and `ogx stack run` CLI commands.
 
 Categories:
-  - Arguments: --providers flag is registered and parsed correctly
+  - Arguments: --providers and --dry-run flags are registered and parsed correctly
   - Delegation: --providers delegates to run_config_from_dynamic_config_spec
   - Error propagation: ValueError from the unified impl is printed and causes exit
   - Deprecation: `ogx stack run` emits a FutureWarning
   - Top-level run: `ogx run` works without the `stack` subcommand
+  - Dry run: --dry-run validates config without starting the server
 """
 
 import argparse
@@ -185,3 +186,56 @@ class TestDeprecation:
 
         future_warnings = [x for x in w if issubclass(x.category, FutureWarning)]
         assert len(future_warnings) == 0
+
+
+class TestDryRun:
+    def test_dry_run_flag_registered(self, top_level_run: Run):
+        args = top_level_run.parser.parse_args(["starter", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_dry_run_default_is_false(self, top_level_run: Run):
+        args = top_level_run.parser.parse_args(["starter"])
+        assert args.dry_run is False
+
+    def test_dry_run_validates_and_exits_without_starting_server(self, top_level_run: Run, tmp_path: Path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("version: 2\ndistro_name: test\napis: []\nproviders: {}\n")
+
+        mock_config = MagicMock(external_providers_dir=None)
+
+        with (
+            patch("ogx.core.configure.parse_and_maybe_upgrade_config", return_value=mock_config),
+            patch("ogx.cli.stack.run._dry_run_validate") as mock_validate,
+            patch("ogx.cli.stack.run._uvicorn_run") as mock_uvicorn,
+            patch("ogx.cli.stack.run.resolve_config_or_distro", return_value=config_file),
+        ):
+            args = top_level_run.parser.parse_args([str(config_file), "--dry-run"])
+            top_level_run._run_cmd(args)
+
+        mock_validate.assert_called_once_with(mock_config, config_file)
+        mock_uvicorn.assert_not_called()
+
+    def test_dry_run_without_config_errors(self, top_level_run: Run):
+        with pytest.raises(SystemExit):
+            args = top_level_run.parser.parse_args(["--dry-run"])
+            top_level_run._run_cmd(args)
+
+    def test_dry_run_with_providers_flag(self, top_level_run: Run, tmp_path: Path):
+        mock_config = MagicMock()
+        mock_config.model_dump.return_value = {}
+
+        with (
+            patch("ogx.cli.stack.run.run_config_from_dynamic_config_spec", return_value=mock_config),
+            patch("ogx.cli.stack.run.DISTRIBS_BASE_DIR", tmp_path),
+            patch(
+                "ogx.core.configure.parse_and_maybe_upgrade_config",
+                return_value=MagicMock(external_providers_dir=None),
+            ),
+            patch("ogx.cli.stack.run._dry_run_validate") as mock_validate,
+            patch("ogx.cli.stack.run._uvicorn_run") as mock_uvicorn,
+        ):
+            args = top_level_run.parser.parse_args(["--providers", "inference=fireworks", "--dry-run"])
+            top_level_run._run_cmd(args)
+
+        mock_validate.assert_called_once()
+        mock_uvicorn.assert_not_called()


### PR DESCRIPTION
## Summary

- Add a `--dry-run` option to `ogx run` that validates the stack configuration (provider specs, routing tables) and prints the redacted resolved config without starting the uvicorn server
- Useful for CI pipelines and pre-deploy validation where you want to catch config errors early without spinning up the full server
- Skips UI server startup when `--dry-run` is active

## Test plan

- [x] Unit tests added covering flag registration, default value, validation path, error on missing config, and compatibility with `--providers`
- [x] Manual test: `ogx run starter --dry-run` validates and prints config without starting server
- [x] Manual test: `ogx run --dry-run` (no config) exits with error
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->