### PR TITLE
fix(deps): always regenerate root uv.lock in constraint-dependencies workflow

### DIFF
--- a/.github/workflows/dependabot-constraints.yml
+++ b/.github/workflows/dependabot-constraints.yml
@@ -122,14 +122,15 @@ jobs:
         env:
           TARGET_PYPROJECTS: ${{ steps.target.outputs.pyprojects }}
         run: |
-          if echo " $TARGET_PYPROJECTS " | grep -q ' pyproject.toml '; then
-            echo "Regenerating root uv.lock"
-            uv lock
-          fi
           if echo " $TARGET_PYPROJECTS " | grep -q ' src/ogx_api/pyproject.toml '; then
             echo "Regenerating src/ogx_api/uv.lock"
             uv lock --directory src/ogx_api
           fi
+          # Always regenerate root uv.lock: ogx-api is a workspace dependency
+          # of the root project, so any change to src/ogx_api/pyproject.toml
+          # also invalidates the root lock file.
+          echo "Regenerating root uv.lock"
+          uv lock
 
       - name: Create PR metadata artifact
         if: steps.parse.outputs.skip != 'true'
@@ -184,10 +185,12 @@ jobs:
           EOF
 
           if [ "$CHANGED" = "true" ]; then
-            if echo " $TARGET_PYPROJECTS " | grep -q ' pyproject.toml '; then
+            # Always include root uv.lock since ogx-api is a workspace
+            # dependency — any sub-package change invalidates the root lock.
+            if [ -f pyproject.toml ]; then
               cp pyproject.toml constraint-update/
-              cp uv.lock constraint-update/
             fi
+            cp uv.lock constraint-update/
             if echo " $TARGET_PYPROJECTS " | grep -q ' src/ogx_api/pyproject.toml '; then
               mkdir -p constraint-update/src/ogx_api
               cp src/ogx_api/pyproject.toml constraint-update/src/ogx_api/


### PR DESCRIPTION
# What does this PR do?

Fixes pre-commit `uv-lock` hook failures on Dependabot PRs that update dependencies in `src/ogx_api/`.

The `ogx-api` package is a workspace dependency of the root project (`pyproject.toml` line 58, sourced via `tool.uv.sources` line 278). When the constraint-dependencies workflow bumps a floor version in `src/ogx_api/pyproject.toml`, it only regenerated `src/ogx_api/uv.lock` — leaving the root `uv.lock` stale. Pre-commit then fails because the root lock is out of sync.

This change makes the workflow always regenerate the root `uv.lock` and always include it in the commit artifact, since any sub-package constraint change invalidates it.

## Test Plan

1. Verify the workflow YAML is valid: `pre-commit run check-yaml --all-files` — passed.
2. Verify GitHub Actions syntax: `pre-commit run actionlint --all-files` — passed.
3. Full pre-commit suite: `pre-commit run --all-files` — all 40 hooks passed.
4. Functional verification: trigger a Dependabot PR that updates a dep in `ogx_api` and confirm the constraint-dependencies workflow now also regenerates and commits the root `uv.lock`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5984" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->