### PR TITLE
ci: pin postgres image to postgres:16.6 in setup-test-environment action

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -87,7 +87,7 @@ runs:
           -e POSTGRES_PASSWORD=ogx \
           -e POSTGRES_DB=ogx \
           -p 5432:5432 \
-          postgres:16
+          postgres:16.6
 
         echo "Waiting for Postgres to become ready..."
         for i in {1..30}; do


### PR DESCRIPTION
Fixes #5990

The ollama-postgres CI job uses `postgres:16` without pinning to a specific version. A recent patch release of that image changed the default authentication method, which broke asyncpg connections and caused all ollama-postgres integration tests to fail with `InvalidPasswordError`.

This PR pins the image to `postgres:16.6`, a known-good version that predates the authentication method change.

Changed file: `.github/actions/setup-test-environment/action.yml`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->