### PR TITLE
fix(sql-store): add ssl_mode and ca_cert_path to PostgresSqlStoreConfig

### DIFF
--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -206,9 +206,27 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
     db: str = "ogx"
     user: str
     password: SecretStr | None = None
+    ssl_mode: str | None = Field(
+        default=None,
+        description="SSL mode for the connection (e.g. 'verify-full', 'require', 'disable')",
+    )
+    ca_cert_path: str | None = Field(
+        default=None,
+        description="Path to the CA certificate file for SSL verification",
+    )
     pool_size: int = Field(default=10, ge=1, description="Number of persistent connections in the pool")
     max_overflow: int = Field(default=20, ge=0, description="Max additional connections beyond pool_size")
     pool_recycle: int = Field(default=3600, ge=-1, description="Connection recycle interval in seconds, -1 to disable")
+
+    def build_ssl(self) -> object:
+        """Build an SSL context from ssl_mode and ca_cert_path, matching PostgresKVStoreConfig behavior."""
+        if self.ssl_mode == "verify-full" and self.ca_cert_path:
+            import ssl as _ssl
+
+            return _ssl.create_default_context(cafile=self.ca_cert_path)
+        if self.ssl_mode and self.ssl_mode != "disable":
+            return self.ssl_mode
+        return None
 
     @property
     def engine_str(self) -> URL:

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -136,6 +136,9 @@ class SqlAlchemySqlStoreImpl(SqlStore):
             engine_kwargs["max_overflow"] = self.config.max_overflow
             if self.config.pool_recycle >= 0:
                 engine_kwargs["pool_recycle"] = self.config.pool_recycle
+            ssl_ctx = self.config.build_ssl()
+            if ssl_ctx is not None:
+                connect_args["ssl"] = ssl_ctx
 
         engine = create_async_engine(
             self.config.engine_str,


### PR DESCRIPTION
Fixes #5978

`PostgresKVStoreConfig` already has `ssl_mode` and `ca_cert_path` fields for TLS connections. `PostgresSqlStoreConfig` does not, so users connecting to Postgres instances that require TLS have no way to configure SSL for the SQL store.

This adds the same two fields to `PostgresSqlStoreConfig` and a `build_ssl()` method that mirrors the `_build_ssl()` logic already in the KV store implementation. The SSL context is then passed to asyncpg via `connect_args["ssl"]` when constructing the SQLAlchemy async engine.

Behavior:
- `ssl_mode=None` (default): no change, backwards compatible
- `ssl_mode="disable"`: no SSL
- `ssl_mode="require"` (or any other string): pass the string directly to asyncpg
- `ssl_mode="verify-full"` + `ca_cert_path`: build a proper `ssl.SSLContext` from the CA cert

Tested with Python syntax checks and unit-level assertions on `build_ssl()` covering all four paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/5996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->