### PR TITLE
feat(messages): accept system-role messages in /v1/messages

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -10628,6 +10628,7 @@ components:
           enum:
           - user
           - assistant
+          - system
           title: Role
         content:
           anyOf:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -10181,6 +10181,7 @@ components:
           enum:
           - user
           - assistant
+          - system
           title: Role
         content:
           anyOf:

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -10628,6 +10628,7 @@ components:
           enum:
           - user
           - assistant
+          - system
           title: Role
         content:
           anyOf:

--- a/src/ogx/providers/inline/messages/impl.py
+++ b/src/ogx/providers/inline/messages/impl.py
@@ -678,6 +678,11 @@ class BuiltinMessagesImpl(Messages):
         if msg.role == "assistant":
             return [self._convert_assistant_message(msg.content)]
 
+        if msg.role == "system":
+            # System content blocks are text-only; concatenate to a single string.
+            system_text = "\n".join(block.text for block in msg.content if isinstance(block, AnthropicTextBlock))
+            return [{"role": "system", "content": system_text}]
+
         # User message: may contain text and/or tool_result blocks
         result: list[dict[str, Any]] = []
         text_parts: list[dict[str, Any]] = []

--- a/src/ogx_api/messages/models.py
+++ b/src/ogx_api/messages/models.py
@@ -127,7 +127,10 @@ AnthropicContentBlock = Annotated[
 class AnthropicMessage(BaseModel):
     """A message in the conversation."""
 
-    role: Literal["user", "assistant"]
+    # The Anthropic spec places the system prompt in a top-level `system` field, but
+    # real clients (e.g. the Claude Code CLI) interleave system-role messages inside
+    # the conversation. Accept "system" here so those requests are not rejected.
+    role: Literal["user", "assistant", "system"]
     content: str | list[AnthropicContentBlock] = Field(
         ...,
         description="Message content: a string for simple text, or a list of content blocks.",

--- a/tests/unit/providers/inline/messages/test_impl.py
+++ b/tests/unit/providers/inline/messages/test_impl.py
@@ -97,6 +97,44 @@ class TestRequestTranslation:
         assert m0["role"] == "system"
         assert m0["content"] == "Line 1.\nLine 2."
 
+    def test_inline_system_message_string(self, impl):
+        # Clients such as the Claude Code CLI interleave system-role messages
+        # inside the conversation rather than using the top-level system field.
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(role="user", content="Hi"),
+                AnthropicMessage(role="system", content="Stay terse."),
+            ],
+            max_tokens=100,
+        )
+        result = impl._anthropic_to_openai(request)
+
+        m1 = _msg_to_dict(result.messages[1])
+        assert m1["role"] == "system"
+        assert m1["content"] == "Stay terse."
+
+    def test_inline_system_message_text_blocks(self, impl):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(role="user", content="Hi"),
+                AnthropicMessage(
+                    role="system",
+                    content=[
+                        AnthropicTextBlock(text="Line 1."),
+                        AnthropicTextBlock(text="Line 2."),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = impl._anthropic_to_openai(request)
+
+        m1 = _msg_to_dict(result.messages[1])
+        assert m1["role"] == "system"
+        assert m1["content"] == "Line 1.\nLine 2."
+
     def test_tool_definitions(self, impl):
         request = AnthropicCreateMessageRequest(
             model="m",


### PR DESCRIPTION
## What

Closes #5982.

The Anthropic spec places the system prompt in a top-level `system` field, but real clients — notably the **Claude Code CLI** — interleave `system`-role messages *inside* the `messages` array on follow-up turns. OGX rejected these with a 400 because `AnthropicMessage.role` only permitted `user` and `assistant`:

```
API Error: 400 {'errors': [{'loc': ['body', 'messages', 1, 'role'],
  'msg': "Input should be 'user' or 'assistant'", 'type': 'literal_error'}]}
```

## Changes

- `src/ogx_api/messages/models.py` — widen `AnthropicMessage.role` to `Literal["user", "assistant", "system"]` (backward-compatible enum widening).
- `src/ogx/providers/inline/messages/impl.py` — in the translation path, map an inline `system`-role message to an OpenAI `system` message (string content already mapped correctly; this handles text-block content). Native passthrough forwards the message unchanged.
- Regenerated OpenAPI specs (the only change is the added `system` enum value).
- Unit tests for inline system messages (string + text-block content).

## Test plan

- `pytest tests/unit/providers/inline/messages/test_impl.py` — 39 passed (2 new).
- `pre-commit run` — mypy, breaking-change check, and Anthropic Messages API coverage all pass.
- **End-to-end:** ran the real Claude Code CLI (`claude --print --dangerously-skip-permissions`) against a local ci-tests server backed by Ollama (`ollama/llama3.2:3b-instruct-fp16`, native passthrough). Before this change the follow-up turn returned 400; after, both `POST /v1/messages` requests return 200 and the CLI session completes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->