### PR TITLE
fix: use SecretStr for search provider api_key fields

### DIFF
--- a/docs/docs/providers/tool_runtime/remote_bing-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_bing-search.mdx
@@ -16,7 +16,7 @@ Bing Search tool for web search capabilities using Microsoft's search engine.
 |-------|------|----------|---------|-------------|
 | `timeout` | `float` | No | 30.0 | Overall HTTP timeout in seconds for requests to external services. |
 | `connect_timeout` | `float` | No | 10.0 | TCP connect timeout in seconds. Shorter than the overall timeout to fail fast on unreachable hosts. |
-| `api_key` | `str \| None` | No |  |  |
+| `api_key` | `SecretStr \| None` | No |  |  |
 | `top_k` | `int` | No | 3 |  |
 
 ## Sample Configuration

--- a/docs/docs/providers/tool_runtime/remote_brave-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_brave-search.mdx
@@ -16,7 +16,7 @@ Brave Search tool for web search capabilities with privacy-focused results.
 |-------|------|----------|---------|-------------|
 | `timeout` | `float` | No | 30.0 | Overall HTTP timeout in seconds for requests to external services. |
 | `connect_timeout` | `float` | No | 10.0 | TCP connect timeout in seconds. Shorter than the overall timeout to fail fast on unreachable hosts. |
-| `api_key` | `str \| None` | No |  | The Brave Search API Key |
+| `api_key` | `SecretStr \| None` | No |  | The Brave Search API Key |
 | `max_results` | `int` | No | 3 | The maximum number of results to return |
 
 ## Sample Configuration

--- a/docs/docs/providers/tool_runtime/remote_tavily-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_tavily-search.mdx
@@ -16,7 +16,7 @@ Tavily Search tool for AI-optimized web search with structured results.
 |-------|------|----------|---------|-------------|
 | `timeout` | `float` | No | 30.0 | Overall HTTP timeout in seconds for requests to external services. |
 | `connect_timeout` | `float` | No | 10.0 | TCP connect timeout in seconds. Shorter than the overall timeout to fail fast on unreachable hosts. |
-| `api_key` | `str \| None` | No |  | The Tavily Search API Key |
+| `api_key` | `SecretStr \| None` | No |  | The Tavily Search API Key |
 | `max_results` | `int` | No | 3 | The maximum number of results to return |
 
 ## Sample Configuration

--- a/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
@@ -49,7 +49,7 @@ class BingSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsReq
 
     def _get_api_key(self) -> str:
         if self.config.api_key:
-            return self.config.api_key
+            return self.config.api_key.get_secret_value()
 
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.bing_search_api_key:

--- a/src/ogx/providers/remote/tool_runtime/bing_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/config.py
@@ -6,13 +6,15 @@
 
 from typing import Any
 
+from pydantic import SecretStr
+
 from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 
 
 class BingSearchToolConfig(BaseToolRuntimeConfig):
     """Configuration for Bing Search Tool Runtime"""
 
-    api_key: str | None = None
+    api_key: SecretStr | None = None
     top_k: int = 3
 
     @classmethod

--- a/src/ogx/providers/remote/tool_runtime/brave_search/brave_search.py
+++ b/src/ogx/providers/remote/tool_runtime/brave_search/brave_search.py
@@ -41,7 +41,7 @@ class BraveSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsRe
 
     def _get_api_key(self) -> str:
         if self.config.api_key:
-            return self.config.api_key
+            return self.config.api_key.get_secret_value()
 
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.brave_search_api_key:

--- a/src/ogx/providers/remote/tool_runtime/brave_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/brave_search/config.py
@@ -6,7 +6,7 @@
 
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 
@@ -14,7 +14,7 @@ from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 class BraveSearchToolConfig(BaseToolRuntimeConfig):
     """Configuration for the Brave Search tool runtime."""
 
-    api_key: str | None = Field(
+    api_key: SecretStr | None = Field(
         default=None,
         description="The Brave Search API Key",
     )

--- a/src/ogx/providers/remote/tool_runtime/tavily_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/tavily_search/config.py
@@ -6,7 +6,7 @@
 
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 
@@ -14,7 +14,7 @@ from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 class TavilySearchToolConfig(BaseToolRuntimeConfig):
     """Configuration for the Tavily Search tool runtime."""
 
-    api_key: str | None = Field(
+    api_key: SecretStr | None = Field(
         default=None,
         description="The Tavily Search API Key",
     )

--- a/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
+++ b/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
@@ -48,7 +48,7 @@ class TavilySearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsR
 
     def _get_api_key(self) -> str:
         if self.config.api_key:
-            return self.config.api_key
+            return self.config.api_key.get_secret_value()
 
         provider_data = self.get_request_provider_data()
         if provider_data is None or not provider_data.tavily_search_api_key:


### PR DESCRIPTION
Change api_key types from str | None to SecretStr | None in Brave Search, Tavily Search, and Bing Search config classes, and unwrap with .get_secret_value() when reading from config.
