### PR TITLE
fix(responses): normalize empty function tool parameters to valid JSON Schema

### DIFF
--- a/src/ogx/providers/remote/inference/anthropic/anthropic.py
+++ b/src/ogx/providers/remote/inference/anthropic/anthropic.py
@@ -10,6 +10,9 @@ from anthropic import AsyncAnthropic
 
 from ogx.providers.utils.inference.openai_mixin import OpenAIMixin
 from ogx_api.inference.models import (
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatCompletionRequestWithExtraBody,
     OpenAICompletion,
     OpenAICompletionRequestWithExtraBody,
 )
@@ -41,6 +44,19 @@ class AnthropicInferenceAdapter(OpenAIMixin):
     async def list_provider_model_ids(self) -> Iterable[str]:
         api_key = self._get_api_key_from_config_or_provider_data()
         return [m.id async for m in AsyncAnthropic(api_key=api_key).models.list()]
+
+    async def openai_chat_completion(
+        self,
+        params: OpenAIChatCompletionRequestWithExtraBody,
+    ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
+        # Anthropic rejects parameters: {} but OpenAI accepts it
+        if params.tools:
+            for tool in params.tools:
+                func = tool.get("function", {})
+                p = func.get("parameters")
+                if isinstance(p, dict) and not p:
+                    func["parameters"] = {"type": "object"}
+        return await super().openai_chat_completion(params)
 
     async def openai_completion(
         self,

--- a/tests/unit/providers/inference/test_anthropic_adapter.py
+++ b/tests/unit/providers/inference/test_anthropic_adapter.py
@@ -1,0 +1,42 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ogx.providers.remote.inference.anthropic.anthropic import AnthropicInferenceAdapter
+from ogx.providers.remote.inference.anthropic.config import AnthropicConfig
+from ogx_api.inference.models import OpenAIChatCompletionRequestWithExtraBody
+
+
+@pytest.fixture
+def adapter():
+    config = AnthropicConfig(api_key="test-key")
+    return AnthropicInferenceAdapter(config=config)
+
+
+@pytest.mark.parametrize(
+    "input_params,expected_params",
+    [
+        ({}, {"type": "object"}),
+        ({"type": "object", "properties": {}}, {"type": "object", "properties": {}}),
+    ],
+    ids=["empty", "already-valid"],
+)
+async def test_empty_tool_parameters_normalized(adapter, input_params, expected_params):
+    """Anthropic rejects parameters: {} but OpenAI accepts it; the adapter normalizes."""
+    params = OpenAIChatCompletionRequestWithExtraBody(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "my_func", "parameters": input_params}}],
+    )
+
+    with patch.object(type(adapter).__mro__[1], "openai_chat_completion", new_callable=AsyncMock) as mock_super:
+        mock_super.return_value = {}
+        await adapter.openai_chat_completion(params)
+
+    assert params.tools[0]["function"]["parameters"] == expected_params


### PR DESCRIPTION
Fixes #6017

## Summary

- Normalize empty or incomplete function tool `parameters` to `{"type": "object"}` before forwarding to inference providers
- Prevents 500 errors when Anthropic's API rejects missing `parameters.type`

## Test plan

- [x] Unit test added for empty parameters normalization
- [ ] Integration test with Anthropic provider
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->