### PR TITLE
test(batches): skip text completions batch test for Anthropic

### DIFF
--- a/tests/integration/batches/test_batches.py
+++ b/tests/integration/batches/test_batches.py
@@ -31,6 +31,8 @@ The test_batch_e2e_chat_completions test does clean up its output and error file
 
 import json
 
+import pytest
+
 
 class TestBatchesIntegration:
     """Integration tests for the batches API."""
@@ -269,8 +271,10 @@ class TestBatchesIntegration:
         deleted_error_file = openai_client.files.delete(final_batch.error_file_id)
         assert deleted_error_file.deleted, f"Error file {final_batch.error_file_id} was not deleted successfully"
 
-    def test_batch_e2e_completions(self, openai_client, batch_helper, text_model_id):
+    def test_batch_e2e_completions(self, openai_client, batch_helper, text_model_id, inference_provider_type):
         """Run an end-to-end batch with a single successful text completion request."""
+        if inference_provider_type == "remote::anthropic":
+            pytest.skip("Anthropic does not support /v1/completions endpoint")
         request_body = {"model": text_model_id, "prompt": "Say completions", "max_tokens": 20}
 
         batch_requests = [


### PR DESCRIPTION
## Summary

- Skip the `/v1/completions` batch test when running against Anthropic, which does not support the legacy text completions endpoint

## Test plan

- [x] Test skipped for Anthropic setup
- [x] Test still runs for OpenAI setup
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->