### PR TITLE
feat(web search): normalize search provider secret precedence to match inference providers

### DIFF
--- a/docs/docs/providers/tool_runtime/remote_bing-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_bing-search.mdx
@@ -16,7 +16,7 @@ Bing Search tool for web search capabilities using Microsoft's search engine.
 |-------|------|----------|---------|-------------|
 | `timeout` | `float` | No | 30.0 | Overall HTTP timeout in seconds for requests to external services. |
 | `connect_timeout` | `float` | No | 10.0 | TCP connect timeout in seconds. Shorter than the overall timeout to fail fast on unreachable hosts. |
-| `api_key` | `SecretStr \| None` | No |  |  |
+| `api_key` | `SecretStr \| None` | No |  | The Bing Search API Key. Can be overridden per-request via X-OGX-Provider-Data header. |
 | `top_k` | `int` | No | 3 |  |
 
 ## Sample Configuration

--- a/docs/docs/providers/tool_runtime/remote_brave-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_brave-search.mdx
@@ -16,7 +16,7 @@ Brave Search tool for web search capabilities with privacy-focused results.
 |-------|------|----------|---------|-------------|
 | `timeout` | `float` | No | 30.0 | Overall HTTP timeout in seconds for requests to external services. |
 | `connect_timeout` | `float` | No | 10.0 | TCP connect timeout in seconds. Shorter than the overall timeout to fail fast on unreachable hosts. |
-| `api_key` | `SecretStr \| None` | No |  | The Brave Search API Key |
+| `api_key` | `SecretStr \| None` | No |  | The Brave Search API Key. Can be overridden per-request via X-OGX-Provider-Data header. |
 | `max_results` | `int` | No | 3 | The maximum number of results to return |
 
 ## Sample Configuration

--- a/docs/docs/providers/tool_runtime/remote_tavily-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_tavily-search.mdx
@@ -16,7 +16,7 @@ Tavily Search tool for AI-optimized web search with structured results.
 |-------|------|----------|---------|-------------|
 | `timeout` | `float` | No | 30.0 | Overall HTTP timeout in seconds for requests to external services. |
 | `connect_timeout` | `float` | No | 10.0 | TCP connect timeout in seconds. Shorter than the overall timeout to fail fast on unreachable hosts. |
-| `api_key` | `SecretStr \| None` | No |  | The Tavily Search API Key |
+| `api_key` | `SecretStr \| None` | No |  | The Tavily Search API Key. Can be overridden per-request via X-OGX-Provider-Data header. |
 | `max_results` | `int` | No | 3 | The maximum number of results to return |
 
 ## Sample Configuration

--- a/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/bing_search.py
@@ -47,16 +47,14 @@ class BingSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsReq
     async def unregister_toolgroup(self, toolgroup_id: str) -> None:
         return
 
-    def _get_api_key(self) -> str:
-        if self.config.api_key:
-            return self.config.api_key.get_secret_value()
+    def _get_api_key(self) -> str | None:
+        api_key = self.config.api_key.get_secret_value() if self.config.api_key else None
 
         provider_data = self.get_request_provider_data()
-        if provider_data is None or not provider_data.bing_search_api_key:
-            raise ValueError(
-                'Pass Bing Search API Key in the header X-OGX-Provider-Data as { "bing_search_api_key": <your api key>}'
-            )
-        return provider_data.bing_search_api_key.get_secret_value()
+        if provider_data and provider_data.bing_search_api_key:
+            api_key = provider_data.bing_search_api_key.get_secret_value()
+
+        return api_key
 
     async def list_runtime_tools(
         self,
@@ -87,9 +85,9 @@ class BingSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsReq
         self, tool_name: str, kwargs: dict[str, Any], authorization: str | None = None
     ) -> ToolInvocationResult:
         api_key = self._get_api_key()
-        headers = {
-            "Ocp-Apim-Subscription-Key": api_key,
-        }
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Ocp-Apim-Subscription-Key"] = api_key
 
         query = kwargs["query"]
 

--- a/src/ogx/providers/remote/tool_runtime/bing_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/config.py
@@ -6,7 +6,7 @@
 
 from typing import Any
 
-from pydantic import SecretStr
+from pydantic import Field, SecretStr
 
 from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 
@@ -14,7 +14,10 @@ from ogx.providers.utils.common.http import BaseToolRuntimeConfig
 class BingSearchToolConfig(BaseToolRuntimeConfig):
     """Configuration for Bing Search Tool Runtime"""
 
-    api_key: SecretStr | None = None
+    api_key: SecretStr | None = Field(
+        default=None,
+        description="The Bing Search API Key. Can be overridden per-request via X-OGX-Provider-Data header.",
+    )
     top_k: int = 3
 
     @classmethod

--- a/src/ogx/providers/remote/tool_runtime/brave_search/brave_search.py
+++ b/src/ogx/providers/remote/tool_runtime/brave_search/brave_search.py
@@ -39,16 +39,14 @@ class BraveSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsRe
     async def unregister_toolgroup(self, toolgroup_id: str) -> None:
         return
 
-    def _get_api_key(self) -> str:
-        if self.config.api_key:
-            return self.config.api_key.get_secret_value()
+    def _get_api_key(self) -> str | None:
+        api_key = self.config.api_key.get_secret_value() if self.config.api_key else None
 
         provider_data = self.get_request_provider_data()
-        if provider_data is None or not provider_data.brave_search_api_key:
-            raise ValueError(
-                'Pass Search provider\'s API Key in the header X-OGX-Provider-Data as { "brave_search_api_key": <your api key>}'
-            )
-        return provider_data.brave_search_api_key.get_secret_value()
+        if provider_data and provider_data.brave_search_api_key:
+            api_key = provider_data.brave_search_api_key.get_secret_value()
+
+        return api_key
 
     async def list_runtime_tools(
         self,
@@ -80,11 +78,12 @@ class BraveSearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsRe
     ) -> ToolInvocationResult:
         api_key = self._get_api_key()
         url = "https://api.search.brave.com/res/v1/web/search"
-        headers = {
-            "X-Subscription-Token": api_key,
+        headers: dict[str, str] = {
             "Accept-Encoding": "gzip",
             "Accept": "application/json",
         }
+        if api_key:
+            headers["X-Subscription-Token"] = api_key
 
         query = kwargs["query"]
 

--- a/src/ogx/providers/remote/tool_runtime/brave_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/brave_search/config.py
@@ -16,7 +16,7 @@ class BraveSearchToolConfig(BaseToolRuntimeConfig):
 
     api_key: SecretStr | None = Field(
         default=None,
-        description="The Brave Search API Key",
+        description="The Brave Search API Key. Can be overridden per-request via X-OGX-Provider-Data header.",
     )
     max_results: int = Field(
         default=3,

--- a/src/ogx/providers/remote/tool_runtime/tavily_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/tavily_search/config.py
@@ -16,7 +16,7 @@ class TavilySearchToolConfig(BaseToolRuntimeConfig):
 
     api_key: SecretStr | None = Field(
         default=None,
-        description="The Tavily Search API Key",
+        description="The Tavily Search API Key. Can be overridden per-request via X-OGX-Provider-Data header.",
     )
     max_results: int = Field(
         default=3,

--- a/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
+++ b/src/ogx/providers/remote/tool_runtime/tavily_search/tavily_search.py
@@ -46,16 +46,14 @@ class TavilySearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsR
     async def unregister_toolgroup(self, toolgroup_id: str) -> None:
         return
 
-    def _get_api_key(self) -> str:
-        if self.config.api_key:
-            return self.config.api_key.get_secret_value()
+    def _get_api_key(self) -> str | None:
+        api_key = self.config.api_key.get_secret_value() if self.config.api_key else None
 
         provider_data = self.get_request_provider_data()
-        if provider_data is None or not provider_data.tavily_search_api_key:
-            raise ValueError(
-                'Pass Search provider\'s API Key in the header X-OGX-Provider-Data as { "tavily_search_api_key": <your api key>}'
-            )
-        return provider_data.tavily_search_api_key.get_secret_value()
+        if provider_data and provider_data.tavily_search_api_key:
+            api_key = provider_data.tavily_search_api_key.get_secret_value()
+
+        return api_key
 
     async def list_runtime_tools(
         self,
@@ -87,9 +85,10 @@ class TavilySearchToolRuntimeImpl(ToolGroupsProtocolPrivate, ToolRuntime, NeedsR
     ) -> ToolInvocationResult:
         api_key = self._get_api_key()
         request_body: dict[str, Any] = {
-            "api_key": api_key,
             "query": kwargs["query"],
         }
+        if api_key:
+            request_body["api_key"] = api_key
 
         allowed_domains = kwargs.get("allowed_domains")
         if allowed_domains:

--- a/tests/unit/providers/tool_runtime/test_bing_search.py
+++ b/tests/unit/providers/tool_runtime/test_bing_search.py
@@ -4,10 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 from ogx.providers.remote.tool_runtime.bing_search.bing_search import BingSearchToolRuntimeImpl
 from ogx.providers.remote.tool_runtime.bing_search.config import BingSearchToolConfig
@@ -15,9 +16,13 @@ from ogx.providers.remote.tool_runtime.bing_search.config import BingSearchToolC
 
 @pytest.fixture
 def bing_search():
-    impl = BingSearchToolRuntimeImpl(BingSearchToolConfig(api_key="test-key", top_k=3))
-    impl._client = MagicMock(spec=httpx.AsyncClient)
-    return impl
+    return BingSearchToolRuntimeImpl(BingSearchToolConfig(api_key="config-key", top_k=3))
+
+
+@pytest.fixture
+def bing_search_client(bing_search):
+    bing_search._client = MagicMock(spec=httpx.AsyncClient)
+    return bing_search
 
 
 @pytest.fixture
@@ -40,80 +45,148 @@ def mock_bing_response():
     )
 
 
-async def test_invoke_with_allowed_domains(bing_search, mock_bing_response):
-    bing_search._client.get = AsyncMock(return_value=mock_bing_response)
-    await bing_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "allowed_domains": ["example.com", "docs.example.com"],
-        },
-    )
-    call_kwargs = bing_search._client.get.call_args
+async def test_invoke_with_allowed_domains(bing_search_client, mock_bing_response):
+    with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+        bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+        await bing_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "allowed_domains": ["example.com", "docs.example.com"],
+            },
+        )
+    call_kwargs = bing_search_client._client.get.call_args
     query_param = call_kwargs.kwargs["params"]["q"]
     assert "site:example.com" in query_param
     assert "site:docs.example.com" in query_param
     assert query_param == "test query (site:example.com OR site:docs.example.com)"
 
 
-async def test_invoke_with_user_location_country(bing_search, mock_bing_response):
-    bing_search._client.get = AsyncMock(return_value=mock_bing_response)
-    await bing_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "user_location": {"country": "US", "city": "San Francisco"},
-        },
-    )
-    call_kwargs = bing_search._client.get.call_args
+async def test_invoke_with_user_location_country(bing_search_client, mock_bing_response):
+    with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+        bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+        await bing_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "user_location": {"country": "US", "city": "San Francisco"},
+            },
+        )
+    call_kwargs = bing_search_client._client.get.call_args
     assert call_kwargs.kwargs["params"]["cc"] == "US"
 
 
-async def test_invoke_with_search_context_size(bing_search, mock_bing_response):
-    bing_search._client.get = AsyncMock(return_value=mock_bing_response)
-    await bing_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "search_context_size": "high",
-        },
-    )
-    call_kwargs = bing_search._client.get.call_args
+async def test_invoke_with_search_context_size(bing_search_client, mock_bing_response):
+    with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+        bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+        await bing_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "search_context_size": "high",
+            },
+        )
+    call_kwargs = bing_search_client._client.get.call_args
     assert call_kwargs.kwargs["params"]["count"] == 10
 
 
-async def test_invoke_without_extra_params(bing_search, mock_bing_response):
-    bing_search._client.get = AsyncMock(return_value=mock_bing_response)
-    await bing_search.invoke_tool(
-        "web_search",
-        {"query": "test query"},
-    )
-    call_kwargs = bing_search._client.get.call_args
+async def test_invoke_without_extra_params(bing_search_client, mock_bing_response):
+    with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+        bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+        await bing_search_client.invoke_tool(
+            "web_search",
+            {"query": "test query"},
+        )
+    call_kwargs = bing_search_client._client.get.call_args
     params = call_kwargs.kwargs["params"]
     assert params["q"] == "test query"
     assert params["count"] == 3
     assert "cc" not in params
 
 
-async def test_invoke_with_empty_allowed_domains(bing_search, mock_bing_response):
-    bing_search._client.get = AsyncMock(return_value=mock_bing_response)
-    await bing_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "allowed_domains": [],
-        },
-    )
-    call_kwargs = bing_search._client.get.call_args
+async def test_invoke_with_empty_allowed_domains(bing_search_client, mock_bing_response):
+    with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+        bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+        await bing_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "allowed_domains": [],
+            },
+        )
+    call_kwargs = bing_search_client._client.get.call_args
     assert call_kwargs.kwargs["params"]["q"] == "test query"
 
 
-async def test_invoke_returns_source_metadata(bing_search, mock_bing_response):
+async def test_invoke_returns_source_metadata(bing_search_client, mock_bing_response):
     """Test that invoke_tool returns source URLs in metadata."""
-    bing_search._client.get = AsyncMock(return_value=mock_bing_response)
-    result = await bing_search.invoke_tool(tool_name="web_search", kwargs={"query": "test query"})
+    with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+        bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+        result = await bing_search_client.invoke_tool(
+            tool_name="web_search",
+            kwargs={"query": "test query"},
+        )
     assert result.metadata is not None
     assert "sources" in result.metadata
     assert len(result.metadata["sources"]) == 1
     assert result.metadata["sources"][0]["url"] == "https://example.com"
     assert result.metadata["query"] == "test query"
+
+
+class TestProviderDataApiKeyOverride:
+    async def test_provider_data_api_key_overrides_config_api_key(self, bing_search_client, mock_bing_response):
+        """Provider data API key should override the config API key."""
+        with patch.object(
+            bing_search_client,
+            "get_request_provider_data",
+            return_value=MagicMock(bing_search_api_key=SecretStr("provider-data-key")),
+        ):
+            bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+            await bing_search_client.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+        headers = bing_search_client._client.get.call_args.kwargs["headers"]
+        assert headers["Ocp-Apim-Subscription-Key"] == "provider-data-key"
+
+    async def test_config_api_key_used_when_no_provider_data(self, bing_search_client, mock_bing_response):
+        """Config API key should be used when no provider data is provided."""
+        with patch.object(bing_search_client, "get_request_provider_data", return_value=None):
+            bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+            await bing_search_client.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+        headers = bing_search_client._client.get.call_args.kwargs["headers"]
+        assert headers["Ocp-Apim-Subscription-Key"] == "config-key"
+
+    async def test_config_api_key_used_when_provider_data_key_is_none(self, bing_search_client, mock_bing_response):
+        """Config API key should be used when provider data key is None."""
+        with patch.object(
+            bing_search_client,
+            "get_request_provider_data",
+            return_value=MagicMock(bing_search_api_key=None),
+        ):
+            bing_search_client._client.get = AsyncMock(return_value=mock_bing_response)
+            await bing_search_client.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+        headers = bing_search_client._client.get.call_args.kwargs["headers"]
+        assert headers["Ocp-Apim-Subscription-Key"] == "config-key"
+
+    def test_returned_api_key_is_none_when_both_keys_null(self):
+        """_get_api_key should return None when both config and provider data keys are None."""
+        impl = BingSearchToolRuntimeImpl(BingSearchToolConfig(top_k=3))
+        with patch.object(impl, "get_request_provider_data", return_value=None):
+            assert impl._get_api_key() is None
+
+    async def test_api_key_header_omitted_when_no_key_available(self, mock_bing_response):
+        """Request should not include Ocp-Apim-Subscription-Key header when no key is available."""
+        impl = BingSearchToolRuntimeImpl(BingSearchToolConfig(top_k=3))
+        impl._client = MagicMock(spec=httpx.AsyncClient)
+        impl._client.get = AsyncMock(return_value=mock_bing_response)
+        with patch.object(impl, "get_request_provider_data", return_value=None):
+            await impl.invoke_tool("web_search", {"query": "test query"})
+        headers = impl._client.get.call_args.kwargs["headers"]
+        assert "Ocp-Apim-Subscription-Key" not in headers

--- a/tests/unit/providers/tool_runtime/test_brave_search.py
+++ b/tests/unit/providers/tool_runtime/test_brave_search.py
@@ -4,10 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 from ogx.providers.remote.tool_runtime.brave_search.brave_search import BraveSearchToolRuntimeImpl
 from ogx.providers.remote.tool_runtime.brave_search.config import BraveSearchToolConfig
@@ -15,7 +16,7 @@ from ogx.providers.remote.tool_runtime.brave_search.config import BraveSearchToo
 
 @pytest.fixture
 def brave_search():
-    return BraveSearchToolRuntimeImpl(BraveSearchToolConfig(api_key="test-key", max_results=3))
+    return BraveSearchToolRuntimeImpl(BraveSearchToolConfig(api_key="config-key", max_results=3))
 
 
 @pytest.fixture
@@ -46,58 +47,62 @@ def mock_brave_response():
 
 
 async def test_invoke_with_allowed_domains(brave_search, mock_brave_response):
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
-        await brave_search.invoke_tool(
-            "web_search",
-            {
-                "query": "test query",
-                "allowed_domains": ["example.com", "docs.example.com"],
-            },
-        )
-        call_kwargs = mock_get.call_args
-        query_param = call_kwargs.kwargs["params"]["q"]
-        assert "site:example.com" in query_param
-        assert "site:docs.example.com" in query_param
-        assert query_param == "test query (site:example.com OR site:docs.example.com)"
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+            await brave_search.invoke_tool(
+                "web_search",
+                {
+                    "query": "test query",
+                    "allowed_domains": ["example.com", "docs.example.com"],
+                },
+            )
+            call_kwargs = mock_get.call_args
+            query_param = call_kwargs.kwargs["params"]["q"]
+            assert "site:example.com" in query_param
+            assert "site:docs.example.com" in query_param
+            assert query_param == "test query (site:example.com OR site:docs.example.com)"
 
 
 async def test_invoke_with_user_location_country(brave_search, mock_brave_response):
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
-        await brave_search.invoke_tool(
-            "web_search",
-            {
-                "query": "test query",
-                "user_location": {"country": "US", "city": "San Francisco"},
-            },
-        )
-        call_kwargs = mock_get.call_args
-        assert call_kwargs.kwargs["params"]["country"] == "US"
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+            await brave_search.invoke_tool(
+                "web_search",
+                {
+                    "query": "test query",
+                    "user_location": {"country": "US", "city": "San Francisco"},
+                },
+            )
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs["params"]["country"] == "US"
 
 
 async def test_invoke_with_user_location_no_country(brave_search, mock_brave_response):
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
-        await brave_search.invoke_tool(
-            "web_search",
-            {
-                "query": "test query",
-                "user_location": {"city": "San Francisco"},
-            },
-        )
-        call_kwargs = mock_get.call_args
-        assert "country" not in call_kwargs.kwargs["params"]
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+            await brave_search.invoke_tool(
+                "web_search",
+                {
+                    "query": "test query",
+                    "user_location": {"city": "San Francisco"},
+                },
+            )
+            call_kwargs = mock_get.call_args
+            assert "country" not in call_kwargs.kwargs["params"]
 
 
 async def test_invoke_with_search_context_size(brave_search, mock_brave_response):
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
-        await brave_search.invoke_tool(
-            "web_search",
-            {
-                "query": "test query",
-                "search_context_size": "high",
-            },
-        )
-        call_kwargs = mock_get.call_args
-        assert call_kwargs.kwargs["params"]["count"] == 10
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+            await brave_search.invoke_tool(
+                "web_search",
+                {
+                    "query": "test query",
+                    "search_context_size": "high",
+                },
+            )
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs["params"]["count"] == 10
 
 
 async def test_invoke_with_search_context_size_updates_result_limit(brave_search):
@@ -160,55 +165,117 @@ async def test_invoke_with_search_context_size_updates_result_limit(brave_search
         },
         request=httpx.Request("GET", "https://api.search.brave.com/res/v1/web/search"),
     )
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=multi_result_response) as mock_get:
-        result = await brave_search.invoke_tool(
-            "web_search",
-            {
-                "query": "test query",
-                "search_context_size": "medium",
-            },
-        )
-        call_kwargs = mock_get.call_args
-        assert call_kwargs.kwargs["params"]["count"] == 5
-        assert result.metadata is not None
-        assert len(result.metadata["sources"]) == 5
-        source_urls = {s["url"] for s in result.metadata["sources"]}
-        expected_urls = {f"https://example{i}.com" for i in range(5)}
-        assert source_urls == expected_urls
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=multi_result_response) as mock_get:
+            result = await brave_search.invoke_tool(
+                "web_search",
+                {
+                    "query": "test query",
+                    "search_context_size": "medium",
+                },
+            )
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs["params"]["count"] == 5
+            assert result.metadata is not None
+            assert len(result.metadata["sources"]) == 5
+            source_urls = {s["url"] for s in result.metadata["sources"]}
+            expected_urls = {f"https://example{i}.com" for i in range(5)}
+            assert source_urls == expected_urls
 
 
 async def test_invoke_without_extra_params(brave_search, mock_brave_response):
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
-        await brave_search.invoke_tool(
-            "web_search",
-            {"query": "test query"},
-        )
-        call_kwargs = mock_get.call_args
-        params = call_kwargs.kwargs["params"]
-        assert params["q"] == "test query"
-        assert "country" not in params
-        assert "count" not in params
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+            await brave_search.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+            call_kwargs = mock_get.call_args
+            params = call_kwargs.kwargs["params"]
+            assert params["q"] == "test query"
+            assert "country" not in params
+            assert "count" not in params
 
 
 async def test_invoke_with_empty_allowed_domains(brave_search, mock_brave_response):
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
-        await brave_search.invoke_tool(
-            "web_search",
-            {
-                "query": "test query",
-                "allowed_domains": [],
-            },
-        )
-        call_kwargs = mock_get.call_args
-        assert call_kwargs.kwargs["params"]["q"] == "test query"
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+            await brave_search.invoke_tool(
+                "web_search",
+                {
+                    "query": "test query",
+                    "allowed_domains": [],
+                },
+            )
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs["params"]["q"] == "test query"
 
 
 async def test_invoke_returns_source_metadata(brave_search, mock_brave_response):
     """Test that invoke_tool returns source URLs in metadata."""
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response):
-        result = await brave_search.invoke_tool(tool_name="web_search", kwargs={"query": "test query"})
-        assert result.metadata is not None
-        assert "sources" in result.metadata
-        assert len(result.metadata["sources"]) == 1
-        assert result.metadata["sources"][0]["url"] == "https://example.com"
-        assert result.metadata["query"] == "test query"
+    with patch.object(brave_search, "get_request_provider_data", return_value=None):
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response):
+            result = await brave_search.invoke_tool(tool_name="web_search", kwargs={"query": "test query"})
+            assert result.metadata is not None
+            assert "sources" in result.metadata
+            assert len(result.metadata["sources"]) == 1
+            assert result.metadata["sources"][0]["url"] == "https://example.com"
+            assert result.metadata["query"] == "test query"
+
+
+class TestProviderDataApiKeyOverride:
+    async def test_provider_data_api_key_overrides_config_api_key(self, brave_search, mock_brave_response):
+        """Provider data API key should override the config API key."""
+        with patch.object(
+            brave_search,
+            "get_request_provider_data",
+            return_value=MagicMock(brave_search_api_key=SecretStr("provider-data-key")),
+        ):
+            with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+                await brave_search.invoke_tool(
+                    "web_search",
+                    {"query": "test query"},
+                )
+                headers = mock_get.call_args.kwargs["headers"]
+                assert headers["X-Subscription-Token"] == "provider-data-key"
+
+    async def test_config_api_key_used_when_no_provider_data(self, brave_search, mock_brave_response):
+        """Config API key should be used when no provider data is provided."""
+        with patch.object(brave_search, "get_request_provider_data", return_value=None):
+            with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+                await brave_search.invoke_tool(
+                    "web_search",
+                    {"query": "test query"},
+                )
+                headers = mock_get.call_args.kwargs["headers"]
+                assert headers["X-Subscription-Token"] == "config-key"
+
+    async def test_config_api_key_used_when_provider_data_key_is_none(self, brave_search, mock_brave_response):
+        """Config API key should be used when provider data key is None."""
+        with patch.object(
+            brave_search,
+            "get_request_provider_data",
+            return_value=MagicMock(brave_search_api_key=None),
+        ):
+            with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+                await brave_search.invoke_tool(
+                    "web_search",
+                    {"query": "test query"},
+                )
+                headers = mock_get.call_args.kwargs["headers"]
+                assert headers["X-Subscription-Token"] == "config-key"
+
+    async def test_returned_api_key_is_none_when_no_keys(self):
+        """_get_api_key should return None when both config and provider data keys are absent."""
+        impl = BraveSearchToolRuntimeImpl(BraveSearchToolConfig(max_results=3))
+        with patch.object(impl, "get_request_provider_data", return_value=None):
+            assert impl._get_api_key() is None
+
+    async def test_api_key_header_omitted_when_both_keys_null(self, mock_brave_response):
+        """Request should not include X-Subscription-Token header when no key is available."""
+        impl = BraveSearchToolRuntimeImpl(BraveSearchToolConfig(max_results=3))
+        with patch.object(impl, "get_request_provider_data", return_value=None):
+            with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_brave_response) as mock_get:
+                await impl.invoke_tool("web_search", {"query": "test query"})
+                headers = mock_get.call_args.kwargs["headers"]
+                assert "X-Subscription-Token" not in headers

--- a/tests/unit/providers/tool_runtime/test_tavily_search.py
+++ b/tests/unit/providers/tool_runtime/test_tavily_search.py
@@ -4,10 +4,11 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
 from ogx.providers.remote.tool_runtime.tavily_search.config import TavilySearchToolConfig
 from ogx.providers.remote.tool_runtime.tavily_search.tavily_search import TavilySearchToolRuntimeImpl
@@ -15,9 +16,13 @@ from ogx.providers.remote.tool_runtime.tavily_search.tavily_search import Tavily
 
 @pytest.fixture
 def tavily_search():
-    impl = TavilySearchToolRuntimeImpl(TavilySearchToolConfig(api_key="test-key", max_results=3))
-    impl._client = MagicMock(spec=httpx.AsyncClient)
-    return impl
+    return TavilySearchToolRuntimeImpl(TavilySearchToolConfig(api_key="test-key", max_results=3))
+
+
+@pytest.fixture
+def tavily_search_client(tavily_search):
+    tavily_search._client = MagicMock(spec=httpx.AsyncClient)
+    return tavily_search
 
 
 @pytest.fixture
@@ -39,41 +44,44 @@ def mock_tavily_response():
     )
 
 
-async def test_invoke_with_allowed_domains(tavily_search, mock_tavily_response):
-    tavily_search._client.post = AsyncMock(return_value=mock_tavily_response)
-    await tavily_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "allowed_domains": ["example.com", "docs.example.com"],
-        },
-    )
-    call_kwargs = tavily_search._client.post.call_args
+async def test_invoke_with_allowed_domains(tavily_search_client, mock_tavily_response):
+    with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+        tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+        await tavily_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "allowed_domains": ["example.com", "docs.example.com"],
+            },
+        )
+    call_kwargs = tavily_search_client._client.post.call_args
     request_body = call_kwargs.kwargs["json"]
     assert request_body["include_domains"] == ["example.com", "docs.example.com"]
 
 
-async def test_invoke_with_search_context_size(tavily_search, mock_tavily_response):
-    tavily_search._client.post = AsyncMock(return_value=mock_tavily_response)
-    await tavily_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "search_context_size": "high",
-        },
-    )
-    call_kwargs = tavily_search._client.post.call_args
+async def test_invoke_with_search_context_size(tavily_search_client, mock_tavily_response):
+    with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+        tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+        await tavily_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "search_context_size": "high",
+            },
+        )
+    call_kwargs = tavily_search_client._client.post.call_args
     request_body = call_kwargs.kwargs["json"]
     assert request_body["max_results"] == 10
 
 
-async def test_invoke_without_extra_params(tavily_search, mock_tavily_response):
-    tavily_search._client.post = AsyncMock(return_value=mock_tavily_response)
-    await tavily_search.invoke_tool(
-        "web_search",
-        {"query": "test query"},
-    )
-    call_kwargs = tavily_search._client.post.call_args
+async def test_invoke_without_extra_params(tavily_search_client, mock_tavily_response):
+    with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+        tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+        await tavily_search_client.invoke_tool(
+            "web_search",
+            {"query": "test query"},
+        )
+    call_kwargs = tavily_search_client._client.post.call_args
     request_body = call_kwargs.kwargs["json"]
     assert request_body["query"] == "test query"
     assert request_body["api_key"] == "test-key"
@@ -81,42 +89,115 @@ async def test_invoke_without_extra_params(tavily_search, mock_tavily_response):
     assert "max_results" not in request_body
 
 
-async def test_invoke_with_user_location_ignored(tavily_search, mock_tavily_response):
-    tavily_search._client.post = AsyncMock(return_value=mock_tavily_response)
-    await tavily_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "user_location": {"country": "US", "city": "San Francisco"},
-        },
-    )
-    call_kwargs = tavily_search._client.post.call_args
+async def test_invoke_with_user_location_ignored(tavily_search_client, mock_tavily_response):
+    with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+        tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+        await tavily_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "user_location": {"country": "US", "city": "San Francisco"},
+            },
+        )
+    call_kwargs = tavily_search_client._client.post.call_args
     request_body = call_kwargs.kwargs["json"]
     assert "user_location" not in request_body
     assert "country" not in request_body
     assert "location" not in request_body
 
 
-async def test_invoke_with_empty_allowed_domains(tavily_search, mock_tavily_response):
-    tavily_search._client.post = AsyncMock(return_value=mock_tavily_response)
-    await tavily_search.invoke_tool(
-        "web_search",
-        {
-            "query": "test query",
-            "allowed_domains": [],
-        },
-    )
-    call_kwargs = tavily_search._client.post.call_args
+async def test_invoke_with_empty_allowed_domains(tavily_search_client, mock_tavily_response):
+    with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+        tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+        await tavily_search_client.invoke_tool(
+            "web_search",
+            {
+                "query": "test query",
+                "allowed_domains": [],
+            },
+        )
+    call_kwargs = tavily_search_client._client.post.call_args
     request_body = call_kwargs.kwargs["json"]
     assert "include_domains" not in request_body
 
 
-async def test_invoke_returns_source_metadata(tavily_search, mock_tavily_response):
+async def test_invoke_returns_source_metadata(tavily_search_client, mock_tavily_response):
     """Test that invoke_tool returns source URLs in metadata."""
-    tavily_search._client.post = AsyncMock(return_value=mock_tavily_response)
-    result = await tavily_search.invoke_tool(tool_name="web_search", kwargs={"query": "test query"})
+    with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+        tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+        result = await tavily_search_client.invoke_tool(
+            tool_name="web_search",
+            kwargs={"query": "test query"},
+        )
     assert result.metadata is not None
     assert "sources" in result.metadata
     assert len(result.metadata["sources"]) == 1
     assert result.metadata["sources"][0]["url"] == "https://example.com"
     assert result.metadata["query"] == "test query"
+
+
+class TestProviderDataApiKeyOverride:
+    async def test_provider_data_api_key_overrides_config_api_key(self, tavily_search_client, mock_tavily_response):
+        """Provider data API key should override the config API key."""
+        with patch.object(
+            tavily_search_client,
+            "get_request_provider_data",
+            return_value=MagicMock(tavily_search_api_key=SecretStr("provider-data-key")),
+        ):
+            tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+            await tavily_search_client.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+        request_body = tavily_search_client._client.post.call_args.kwargs["json"]
+        assert request_body["api_key"] == "provider-data-key"
+
+    async def test_config_api_key_used_when_no_provider_data(self, tavily_search_client, mock_tavily_response):
+        """Config API key should be used when no provider data is provided."""
+        with patch.object(tavily_search_client, "get_request_provider_data", return_value=None):
+            tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+            await tavily_search_client.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+        request_body = tavily_search_client._client.post.call_args.kwargs["json"]
+        assert request_body["api_key"] == "test-key"
+
+    async def test_config_api_key_used_when_provider_data_key_is_none(self, tavily_search_client, mock_tavily_response):
+        """Config API key should be used when provider data key is None."""
+        with patch.object(
+            tavily_search_client,
+            "get_request_provider_data",
+            return_value=MagicMock(tavily_search_api_key=None),
+        ):
+            tavily_search_client._client.post = AsyncMock(return_value=mock_tavily_response)
+            await tavily_search_client.invoke_tool(
+                "web_search",
+                {"query": "test query"},
+            )
+        request_body = tavily_search_client._client.post.call_args.kwargs["json"]
+        assert request_body["api_key"] == "test-key"
+
+    async def test_returned_api_key_is_none_when_no_keys(self):
+        """_get_api_key should return None when both config and provider data keys are absent."""
+        impl = TavilySearchToolRuntimeImpl(TavilySearchToolConfig(max_results=3))
+        with patch.object(impl, "get_request_provider_data", return_value=None):
+            assert impl._get_api_key() is None
+
+    async def test_api_key_omitted_from_body_when_both_keys_null(self):
+        """Request body should not include api_key field when no key is available."""
+        mock_response = httpx.Response(
+            200,
+            json={
+                "query": "test query",
+                "results": [],
+            },
+            request=httpx.Request("POST", "https://api.tavily.com/search"),
+        )
+        impl = TavilySearchToolRuntimeImpl(TavilySearchToolConfig(max_results=3))
+        impl._client = MagicMock(spec=httpx.AsyncClient)
+        impl._client.post = AsyncMock(return_value=mock_response)
+        with patch.object(impl, "get_request_provider_data", return_value=None):
+            await impl.invoke_tool("web_search", {"query": "test query"})
+        request_body = impl._client.post.call_args.kwargs["json"]
+        assert "api_key" not in request_body


### PR DESCRIPTION
Search tools previously used config-key > provider-data-key precedence, whereas inference providers use provider-data-key > config-key. This breaks multi-tenant patterns where provider data should override config.

Normalize the following search providers (brave, bing, tavily) to match inference provider behavior: provider data key always overrides config key, both are optional, and _get_api_key() returns None when neither is set.

Add TestProviderDataApiKeyOverride test classes to bing, brave, and tavily.
