### PR TITLE
fix(ci): treat cancelled checks as non-failures in CI status aggregator

### DIFF
--- a/.github/workflows/ci-status.yml
+++ b/.github/workflows/ci-status.yml
@@ -43,8 +43,8 @@ jobs:
             const excludedApps = new Set(['mergify']);
 
             const terminalStatuses = new Set(['completed']);
-            const successConclusions = new Set(['success', 'skipped', 'neutral']);
-            const failureConclusions = new Set(['failure', 'cancelled', 'timed_out']);
+            const successConclusions = new Set(['success', 'skipped', 'neutral', 'cancelled']);
+            const failureConclusions = new Set(['failure', 'timed_out']);
 
             while (true) {
               const { data: checkRuns } = await github.rest.checks.listForRef({


### PR DESCRIPTION
## Summary

Cancelled checks (e.g., `title-check`) are typically caused by `cancel-in-progress: true` when a newer commit supersedes an in-flight run. The CI status aggregator was treating `cancelled` as a failure, causing flaky CI failures on every push.

Moves `cancelled` from `failureConclusions` to `successConclusions` in `.github/workflows/ci-status.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)