### PR TITLE
fix(anthropic): raise NotImplementedError for /v1/completions endpoint

### DIFF
--- a/src/ogx/providers/remote/inference/anthropic/anthropic.py
+++ b/src/ogx/providers/remote/inference/anthropic/anthropic.py
@@ -4,11 +4,15 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-from collections.abc import Iterable
+from collections.abc import AsyncIterator, Iterable
 
 from anthropic import AsyncAnthropic
 
 from ogx.providers.utils.inference.openai_mixin import OpenAIMixin
+from ogx_api.inference.models import (
+    OpenAICompletion,
+    OpenAICompletionRequestWithExtraBody,
+)
 
 from .config import AnthropicConfig
 
@@ -37,3 +41,12 @@ class AnthropicInferenceAdapter(OpenAIMixin):
     async def list_provider_model_ids(self) -> Iterable[str]:
         api_key = self._get_api_key_from_config_or_provider_data()
         return [m.id async for m in AsyncAnthropic(api_key=api_key).models.list()]
+
+    async def openai_completion(
+        self,
+        params: OpenAICompletionRequestWithExtraBody,
+    ) -> OpenAICompletion | AsyncIterator[OpenAICompletion]:
+        """Anthropic does not support the /v1/completions endpoint."""
+        raise NotImplementedError(
+            "Anthropic does not support /v1/completions endpoint. Only /v1/chat/completions is supported. "
+        )


### PR DESCRIPTION
## Summary

- Anthropic does not support the legacy `/v1/completions` endpoint. The inherited `OpenAIMixin` implementation silently attempts the call and gets a 404 from Anthropic's API, producing an unhelpful error message.
- Explicitly override `openai_completion` to raise `NotImplementedError` with a clear message, matching the pattern used by Bedrock, Databricks, and other providers.

Related: #6019

## Test plan

- [x] Verified against a running server with `remote::anthropic` provider
- [x] Direct `/v1/completions` call returns clear error instead of cryptic 404
- [x] Batch API error file now shows actionable message: `"Anthropic does not support /v1/completions endpoint. Only /v1/chat/completions is supported."`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->