### PR TITLE
docs: align Gemini auth and reranking docs

### DIFF
--- a/docs/docs/concepts/file_operations_vector_stores.mdx
+++ b/docs/docs/concepts/file_operations_vector_stores.mdx
@@ -106,7 +106,7 @@ results = await client.vector_stores.search(
 )
 ```
 
-#### Neural Reranking (TODO: implement inference endpoint)
+#### Neural Reranking
 
 
 ```python

--- a/docs/docs/providers/inference/remote_gemini.mdx
+++ b/docs/docs/providers/inference/remote_gemini.mdx
@@ -34,13 +34,18 @@ Google Gemini inference provider for accessing Gemini models and Google's AI ser
 | `network.timeout.connect` | `float \| None` | No |  | Connection timeout in seconds. |
 | `network.timeout.read` | `float \| None` | No |  | Read timeout in seconds. |
 | `network.headers` | `dict[str, str] \| None` | No |  | Additional HTTP headers to include in all requests. |
-| `access_token` | `SecretStr \| None` | No |  | OAuth2 access token for Gemini. When set, used instead of api_key for Bearer authentication. |
+| `access_token` | `SecretStr \| None` | No |  | OAuth2 access token for Gemini Bearer authentication. Mutually exclusive with `api_key`. |
 | `project` | `str \| None` | No |  | Google Cloud project ID for quota attribution when using OAuth/ADC credentials. |
 
 ## Sample Configuration
 
 ```yaml
 api_key: ${env.GEMINI_API_KEY:=}
+```
+
+Or use an OAuth2 access token with a quota project:
+
+```yaml
 access_token: ${env.GEMINI_ACCESS_TOKEN:=}
 project: ${env.GEMINI_AI_PROJECT:=}
 ```

--- a/docs/docs/providers/inference/remote_gemini.mdx
+++ b/docs/docs/providers/inference/remote_gemini.mdx
@@ -34,18 +34,11 @@ Google Gemini inference provider for accessing Gemini models and Google's AI ser
 | `network.timeout.connect` | `float \| None` | No |  | Connection timeout in seconds. |
 | `network.timeout.read` | `float \| None` | No |  | Read timeout in seconds. |
 | `network.headers` | `dict[str, str] \| None` | No |  | Additional HTTP headers to include in all requests. |
-| `access_token` | `SecretStr \| None` | No |  | OAuth2 access token for Gemini Bearer authentication. Mutually exclusive with `api_key`. |
+| `access_token` | `SecretStr \| None` | No |  | OAuth2 access token for Gemini Bearer authentication. Mutually exclusive with api_key. |
 | `project` | `str \| None` | No |  | Google Cloud project ID for quota attribution when using OAuth/ADC credentials. |
 
 ## Sample Configuration
 
 ```yaml
 api_key: ${env.GEMINI_API_KEY:=}
-```
-
-Or use an OAuth2 access token with a quota project:
-
-```yaml
-access_token: ${env.GEMINI_ACCESS_TOKEN:=}
-project: ${env.GEMINI_AI_PROJECT:=}
 ```

--- a/src/ogx/distributions/ci-tests/config.yaml
+++ b/src/ogx/distributions/ci-tests/config.yaml
@@ -65,8 +65,6 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
-      project: ${env.GEMINI_AI_PROJECT:=}
   - provider_id: ${env.VERTEX_AI_PROJECT:+vertexai}
     provider_type: remote::vertexai
     config:

--- a/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
@@ -65,8 +65,6 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
-      project: ${env.GEMINI_AI_PROJECT:=}
   - provider_id: ${env.VERTEX_AI_PROJECT:+vertexai}
     provider_type: remote::vertexai
     config:

--- a/src/ogx/distributions/open-benchmark/config.yaml
+++ b/src/ogx/distributions/open-benchmark/config.yaml
@@ -20,8 +20,6 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
-      project: ${env.GEMINI_AI_PROJECT:=}
   - provider_id: groq
     provider_type: remote::groq
     config:

--- a/src/ogx/distributions/starter/config.yaml
+++ b/src/ogx/distributions/starter/config.yaml
@@ -65,8 +65,6 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
-      project: ${env.GEMINI_AI_PROJECT:=}
   - provider_id: ${env.VERTEX_AI_PROJECT:+vertexai}
     provider_type: remote::vertexai
     config:

--- a/src/ogx/distributions/starter/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/starter/run-with-postgres-store.yaml
@@ -65,8 +65,6 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
-      project: ${env.GEMINI_AI_PROJECT:=}
   - provider_id: ${env.VERTEX_AI_PROJECT:+vertexai}
     provider_type: remote::vertexai
     config:

--- a/src/ogx/providers/remote/inference/gemini/config.py
+++ b/src/ogx/providers/remote/inference/gemini/config.py
@@ -33,7 +33,7 @@ class GeminiConfig(RemoteInferenceProviderConfig):
 
     access_token: SecretStr | None = Field(
         default=None,
-        description="OAuth2 access token for Gemini. When set, used instead of api_key for Bearer authentication.",
+        description="OAuth2 access token for Gemini Bearer authentication. Mutually exclusive with api_key.",
     )
     project: str | None = Field(
         default=None,
@@ -59,12 +59,15 @@ class GeminiConfig(RemoteInferenceProviderConfig):
     def sample_run_config(
         cls,
         api_key: str = "${env.GEMINI_API_KEY:=}",
-        access_token: str = "${env.GEMINI_ACCESS_TOKEN:=}",
-        project: str = "${env.GEMINI_AI_PROJECT:=}",
+        access_token: str | None = None,
+        project: str | None = None,
         **kwargs,
     ) -> dict[str, Any]:
-        return {
-            "api_key": api_key,
-            "access_token": access_token,
-            "project": project,
-        }
+        config: dict[str, Any] = {}
+        if api_key:
+            config["api_key"] = api_key
+        if access_token:
+            config["access_token"] = access_token
+        if project:
+            config["project"] = project
+        return config

--- a/src/ogx/providers/remote/inference/gemini/config.py
+++ b/src/ogx/providers/remote/inference/gemini/config.py
@@ -28,7 +28,7 @@ class GeminiConfig(RemoteInferenceProviderConfig):
     Supports either a static API key (``api_key`` / ``GEMINI_API_KEY``) or an
     OAuth2 access token (``access_token`` / ``GEMINI_ACCESS_TOKEN``) for
     short-lived credential injection (e.g. ``gcloud auth application-default
-    print-access-token``).  When both are set, ``access_token`` takes precedence.
+    print-access-token``).  Configure exactly one of the two credentials.
     """
 
     access_token: SecretStr | None = Field(

--- a/src/ogx/providers/remote/inference/gemini/gemini.py
+++ b/src/ogx/providers/remote/inference/gemini/gemini.py
@@ -40,7 +40,7 @@ class GeminiInferenceAdapter(OpenAIMixin):
 
         The AsyncOpenAI client sends this as ``Authorization: Bearer <value>``,
         which Google's OpenAI-compatible endpoint accepts for both API keys and
-        OAuth access tokens.  ``access_token`` takes precedence when set.
+        OAuth access tokens.  ``api_key`` and ``access_token`` are mutually exclusive.
         """
         if self.config.access_token:
             return self.config.access_token.get_secret_value()


### PR DESCRIPTION
## Summary
- clarify that Gemini api_key and access_token are mutually exclusive
- split the Gemini sample config so users do not set both credentials together
- remove the stale neural reranking TODO from the vector store docs

Fixes #5970
Fixes #5608

## Tests
- uv run ruff check src/ogx/providers/remote/inference/gemini/config.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->