### PR TITLE
fix: bump litellm to >=1.83.0 for CVEs

### DIFF
--- a/src/llama_stack/providers/registry/inference.py
+++ b/src/llama_stack/providers/registry/inference.py
@@ -279,7 +279,7 @@ Available Models:
             api=Api.inference,
             adapter_type="watsonx",
             provider_type="remote::watsonx",
-            pip_packages=["litellm"],
+            pip_packages=["litellm>=1.83.7"],
             module="llama_stack.providers.remote.inference.watsonx",
             config_class="llama_stack.providers.remote.inference.watsonx.WatsonXConfig",
             provider_data_validator="llama_stack.providers.remote.inference.watsonx.config.WatsonXProviderDataValidator",

--- a/src/llama_stack/providers/registry/safety.py
+++ b/src/llama_stack/providers/registry/safety.py
@@ -69,7 +69,7 @@ def available_providers() -> list[ProviderSpec]:
             api=Api.safety,
             adapter_type="sambanova",
             provider_type="remote::sambanova",
-            pip_packages=["litellm", "requests"],
+            pip_packages=["litellm>=1.83.7", "requests"],
             module="llama_stack.providers.remote.safety.sambanova",
             config_class="llama_stack.providers.remote.safety.sambanova.SambaNovaSafetyConfig",
             provider_data_validator="llama_stack.providers.remote.safety.sambanova.config.SambaNovaProviderDataValidator",


### PR DESCRIPTION
# What does this PR do?

Bump litellm to >=1.83.0 in provider registry to address three security vulnerabilities:

- https://github.com/BerriAI/litellm/security/advisories/GHSA-53mr-6c8q-9789
- https://github.com/BerriAI/litellm/security/advisories/GHSA-jjhc-v7c2-5hh6
- https://github.com/BerriAI/litellm/security/advisories/GHSA-wxxx-gvqv-xp7p

Only applies to release-0.4.x; litellm was removed on main and release-0.7.x.

## Test Plan  
No functional changes. Version floor pin only.