### PR TITLE
fix(letsgo): include persistence config when adding responses provider

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -225,7 +225,20 @@ def _add_file_search_and_responses(run_config: StackConfig) -> None:
     if "responses" not in run_config.providers:
         run_config.providers["responses"] = []
     if not any(p.provider_type == "inline::builtin" for p in run_config.providers["responses"]):
-        run_config.providers["responses"].append(Provider(provider_id="builtin", provider_type="inline::builtin"))
+        run_config.providers["responses"].append(
+            Provider(
+                provider_id="builtin",
+                provider_type="inline::builtin",
+                config={
+                    "persistence": {
+                        "responses": {
+                            "table_name": "responses",
+                            "backend": "sql_default",
+                        }
+                    }
+                },
+            )
+        )
     # Add responses to APIs if not already present
     if "responses" not in run_config.apis:
         run_config.apis.append("responses")


### PR DESCRIPTION
When --default-embedding-model is set or auto-detected, _add_file_search_and_responses() adds the inline::builtin responses provider without a config dict, defaulting to {}.

Since BuiltinResponsesImplConfig requires the persistence field (in #5776), this causes a Pydantic validation error at startup.

Include the default persistence config inline when creating the responses provider to match the starter distribution config.
