### PR TITLE
ci(pypi): make Docker image publishing package-name aware

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -65,6 +65,11 @@
 #   published successfully but image builds failed. Requires "version" to be
 #   set to the already-published version.
 #
+# package_name: PyPI package to bundle in the Docker images. Defaults to "ogx".
+#   Set to "llama-stack" to publish images for pre-rename releases (e.g. 0.5.0),
+#   which were published under the old package name. The CLI binary and home
+#   directory are derived automatically ("llama-stack" -> "llama"/".llama").
+#
 # =============================================================================
 
 name: Build, test, and publish packages
@@ -120,6 +125,11 @@ on:
         required: false
         type: boolean
         default: false
+      package_name:
+        description: 'PyPI package to bundle in Docker images. Use "llama-stack" for pre-rename releases (e.g. 0.5.0).'
+        required: false
+        type: string
+        default: 'ogx'
 
 env:
   LC_ALL: en_US.UTF-8
@@ -949,37 +959,48 @@ jobs:
           DRY_RUN="${{ inputs.dry_run }}"
           EVENT="${{ github.event_name }}"
 
+          # PyPI package to bundle. Pre-rename releases (e.g. 0.5.0) shipped as
+          # "llama-stack"; the CLI binary is derived by stripping the "-stack"
+          # suffix ("llama-stack" -> "llama", "ogx" -> "ogx").
+          PACKAGE_NAME="${{ inputs.package_name || 'ogx' }}"
+          CLI_NAME="${PACKAGE_NAME%-stack}"
+          {
+            echo "package_name=${PACKAGE_NAME}"
+            echo "cli_name=${CLI_NAME}"
+          } >> "$GITHUB_OUTPUT"
+
           if [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; then
             {
               echo "install_mode=pypi"
               echo "tags=${IMAGE}:${VERSION},${IMAGE}:latest"
               echo "version_arg=PYPI_VERSION=${VERSION}"
             } >> "$GITHUB_OUTPUT"
-            echo "Publishing production image: ${IMAGE}:${VERSION} + latest"
+            echo "Publishing production image: ${IMAGE}:${VERSION} + latest (package: ${PACKAGE_NAME})"
           else
             {
               echo "install_mode=test-pypi"
               echo "tags=${IMAGE}:test-${VERSION}"
               echo "version_arg=TEST_PYPI_VERSION=${VERSION}"
             } >> "$GITHUB_OUTPUT"
-            echo "Publishing test image: ${IMAGE}:test-${VERSION}"
+            echo "Publishing test image: ${IMAGE}:test-${VERSION} (package: ${PACKAGE_NAME})"
           fi
 
       - name: Wait for package on test PyPI
         if: steps.meta.outputs.install_mode == 'test-pypi'
         run: |
           VERSION="${{ needs.compute-version.outputs.version }}"
-          URL="https://test.pypi.org/pypi/ogx/${VERSION}/json"
+          PACKAGE_NAME="${{ steps.meta.outputs.package_name }}"
+          URL="https://test.pypi.org/pypi/${PACKAGE_NAME}/${VERSION}/json"
           echo "Polling ${URL} ..."
           for i in $(seq 1 20); do
             if curl -sf "$URL" -o /dev/null; then
-              echo "ogx==${VERSION} is available on test PyPI"
+              echo "${PACKAGE_NAME}==${VERSION} is available on test PyPI"
               exit 0
             fi
             echo "Attempt ${i}/20: not yet available, waiting 30s..."
             sleep 30
           done
-          echo "::error::ogx==${VERSION} did not appear on test PyPI after 10 minutes"
+          echo "::error::${PACKAGE_NAME}==${VERSION} did not appear on test PyPI after 10 minutes"
           exit 1
 
       - name: Build and push Docker image
@@ -993,4 +1014,6 @@ jobs:
           build-args: |
             DISTRO_NAME=${{ matrix.distro }}
             INSTALL_MODE=${{ steps.meta.outputs.install_mode }}
+            PACKAGE_NAME=${{ steps.meta.outputs.package_name }}
+            CLI_NAME=${{ steps.meta.outputs.cli_name }}
             ${{ steps.meta.outputs.version_arg }}

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -27,6 +27,10 @@ ARG PYPI_VERSION=""
 ARG TEST_PYPI_VERSION=""
 ARG KEEP_WORKSPACE=""
 ARG DISTRO_NAME="starter"
+# PyPI package to install (e.g. "ogx", or "llama-stack" for pre-rename releases).
+ARG PACKAGE_NAME="ogx"
+# CLI binary the package provides (e.g. "ogx", or "llama" for llama-stack).
+ARG CLI_NAME="ogx"
 ARG RUN_CONFIG_PATH=""
 ARG UV_HTTP_TIMEOUT=500
 ARG UV_EXTRA_INDEX_URL=""
@@ -68,6 +72,8 @@ ENV PYPI_VERSION=${PYPI_VERSION}
 ENV TEST_PYPI_VERSION=${TEST_PYPI_VERSION}
 ENV KEEP_WORKSPACE=${KEEP_WORKSPACE}
 ENV DISTRO_NAME=${DISTRO_NAME}
+ENV PACKAGE_NAME=${PACKAGE_NAME}
+ENV CLI_NAME=${CLI_NAME}
 ENV RUN_CONFIG_PATH=${RUN_CONFIG_PATH}
 
 # Copy the repository so editable installs and run configurations are available.
@@ -106,15 +112,15 @@ RUN set -eux; \
     elif [ "$INSTALL_MODE" = "test-pypi" ]; then \
         uv pip install --no-cache fastapi libcst; \
         if [ -n "$TEST_PYPI_VERSION" ]; then \
-            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "ogx==$TEST_PYPI_VERSION"; \
+            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "${PACKAGE_NAME}==$TEST_PYPI_VERSION"; \
         else \
-            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match ogx; \
+            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "$PACKAGE_NAME"; \
         fi; \
     else \
         if [ -n "$PYPI_VERSION" ]; then \
-            uv pip install --no-cache "ogx==$PYPI_VERSION"; \
+            uv pip install --no-cache "${PACKAGE_NAME}==$PYPI_VERSION"; \
         else \
-            uv pip install --no-cache ogx; \
+            uv pip install --no-cache "$PACKAGE_NAME"; \
         fi; \
     fi;
 
@@ -129,7 +135,7 @@ RUN set -eux; \
         echo "DISTRO_NAME must be provided" >&2; \
         exit 1; \
     fi; \
-    deps="$(ogx stack list-deps "$DISTRO_NAME")"; \
+    deps="$("$CLI_NAME" stack list-deps "$DISTRO_NAME")"; \
     if [ -n "$deps" ]; then \
         printf '%s\n' "$deps" | xargs -L1 uv pip install --no-cache; \
     fi
@@ -171,18 +177,20 @@ if env | grep -q '^OTEL_'; then
   export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS="${OTEL_PYTHON_DISABLED_INSTRUMENTATIONS:+$OTEL_PYTHON_DISABLED_INSTRUMENTATIONS,}asyncpg,sqlite3"
 fi
 
+CLI_NAME="${CLI_NAME:-ogx}"
+
 if [ -n "$RUN_CONFIG_PATH" ] && [ -f "$RUN_CONFIG_PATH" ]; then
-  exec $CMD_PREFIX ogx stack run "$RUN_CONFIG_PATH" "$@"
+  exec $CMD_PREFIX "$CLI_NAME" stack run "$RUN_CONFIG_PATH" "$@"
 fi
 
 if [ -n "$DISTRO_NAME" ]; then
-  exec $CMD_PREFIX ogx stack run "$DISTRO_NAME" "$@"
+  exec $CMD_PREFIX "$CLI_NAME" stack run "$DISTRO_NAME" "$@"
 fi
 
-exec $CMD_PREFIX ogx stack run "$@"
+exec $CMD_PREFIX "$CLI_NAME" stack run "$@"
 EOF
 RUN chmod +x /usr/local/bin/ogx-entrypoint.sh
 
-RUN mkdir -p /.ogx /.cache && chmod -R g+rw /app /.ogx /.cache
+RUN mkdir -p "/.${CLI_NAME}" /.cache && chmod -R g+rw /app "/.${CLI_NAME}" /.cache
 
 ENTRYPOINT ["/usr/local/bin/ogx-entrypoint.sh"]


### PR DESCRIPTION
## What

Makes the Docker image publishing path in `pypi.yml` package-name aware so we can build distribution images for pre-rename releases that were published under the `llama-stack` PyPI package name (e.g. `0.5.0`), not just `ogx`.

## Why

The image publishing job and `containers/Containerfile` hardcoded `ogx` as both the PyPI package to install and the CLI binary (`ogx stack run`, `ogx stack list-deps`, `/.ogx`). Old releases shipped as the `llama-stack` package with a `llama stack` CLI, so the current workflow cannot rebuild/publish their images.

## Changes

- **`.github/workflows/pypi.yml`**
  - New `package_name` `workflow_dispatch` input (default `ogx`).
  - The docker `meta` step derives `cli_name` from the package by stripping the `-stack` suffix (`llama-stack` → `llama`, `ogx` → `ogx`) and exposes both as outputs.
  - Test-PyPI availability poll uses the selected package name instead of a hardcoded `ogx`.
  - Passes `PACKAGE_NAME` and `CLI_NAME` as Docker build args. Images still push to `ogxai/distribution-*`.
- **`containers/Containerfile`**
  - New `PACKAGE_NAME` / `CLI_NAME` build args (default `ogx`), exported as ENV.
  - All `pip install` targets (pypi + test-pypi, with/without pinned version) use `$PACKAGE_NAME`.
  - `$CLI_NAME stack list-deps`, the entrypoint `$CLI_NAME stack run`, and the home dir `/.${CLI_NAME}` are all derived, so a `llama-stack` image gets the `llama` CLI and `/.llama`.

## Test plan

Verified the derivation, install-target construction, and entrypoint resolution for both packages:

```
package=ogx         -> cli=ogx,   home=/.ogx
package=llama-stack -> cli=llama, home=/.llama

pip target (with version): "ogx==0.5.0" / "llama-stack==0.5.0"
pip target (no version)  : "ogx"        / "llama-stack"

entrypoint: CLI_NAME=ogx   -> exec "ogx" stack run ...
            CLI_NAME=llama -> exec "llama" stack run ...
            CLI_NAME unset -> exec "ogx" stack run ...   (fallback)
```

- `pypi.yml` validated as YAML.
- No hardcoded `ogx` remains in the Containerfile install/CLI/home lines.

To publish 0.5.0 images: trigger the workflow via `workflow_dispatch` with `version=0.5.0`, `package_name=llama-stack`, `docker_only=true`, `dry_run=off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->