### PR TITLE
ci(pypi): add skip_latest input to avoid moving the latest tag

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -70,6 +70,10 @@
 #   which were published under the old package name. The CLI binary and home
 #   directory are derived automatically ("llama-stack" -> "llama"/".llama").
 #
+# skip_latest: When true, production image builds are tagged only with the
+#   version and not also as "latest". Use when backfilling an older release so
+#   it does not become the default image users pull.
+#
 # =============================================================================
 
 name: Build, test, and publish packages
@@ -130,6 +134,11 @@ on:
         required: false
         type: string
         default: 'ogx'
+      skip_latest:
+        description: 'Do not also tag/push images as "latest". Use when backfilling an older release so it does not become the default pull.'
+        required: false
+        type: boolean
+        default: false
 
 env:
   LC_ALL: en_US.UTF-8
@@ -970,12 +979,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           if [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; then
+            if [ "${{ inputs.skip_latest }}" == "true" ]; then
+              TAGS="${IMAGE}:${VERSION}"
+              LATEST_NOTE=""
+            else
+              TAGS="${IMAGE}:${VERSION},${IMAGE}:latest"
+              LATEST_NOTE=" + latest"
+            fi
             {
               echo "install_mode=pypi"
-              echo "tags=${IMAGE}:${VERSION},${IMAGE}:latest"
+              echo "tags=${TAGS}"
               echo "version_arg=PYPI_VERSION=${VERSION}"
             } >> "$GITHUB_OUTPUT"
-            echo "Publishing production image: ${IMAGE}:${VERSION} + latest (package: ${PACKAGE_NAME})"
+            echo "Publishing production image: ${IMAGE}:${VERSION}${LATEST_NOTE} (package: ${PACKAGE_NAME})"
           else
             {
               echo "install_mode=test-pypi"


### PR DESCRIPTION
## What

Adds a `skip_latest` `workflow_dispatch` input (default `false`) to the publish workflow. When `true`, production Docker image builds are tagged **only** with the version, not also as `latest`.

## Why

Production image builds always tag both `:${VERSION}` and `:latest`. When backfilling an older release — e.g. publishing `0.5.2` images after newer versions already exist — this would move `:latest` backwards and make the old release the default pull. This complements the `package_name` backfill support added previously.

## Test plan

```
skip_latest=true  -> tags=ogxai/distribution-starter:0.5.2
skip_latest=false -> tags=ogxai/distribution-starter:0.5.2,ogxai/distribution-starter:latest
```

`pypi.yml` validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->