### PR TITLE
fix(containers): pin the API package to the meta-package version

### DIFF
--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -94,6 +94,10 @@ RUN set -eux; \
 
 # Install ogx
 # Use UV_EXTRA_INDEX_URL inline only for editable install with RC dependencies
+# When a version is pinned, also pin the matching API package. The meta package
+# depends on "<package>-api" without a version constraint, so an unpinned install
+# would resolve to the latest API package, which is incompatible with older
+# meta-package releases (e.g. llama-stack 0.5.2 + llama-stack-api 0.7.x).
 RUN set -eux; \
     SAVED_UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL:-}"; \
     SAVED_UV_INDEX_STRATEGY="${UV_INDEX_STRATEGY:-}"; \
@@ -112,13 +116,13 @@ RUN set -eux; \
     elif [ "$INSTALL_MODE" = "test-pypi" ]; then \
         uv pip install --no-cache fastapi libcst; \
         if [ -n "$TEST_PYPI_VERSION" ]; then \
-            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "${PACKAGE_NAME}==$TEST_PYPI_VERSION"; \
+            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "${PACKAGE_NAME}==$TEST_PYPI_VERSION" "${PACKAGE_NAME}-api==$TEST_PYPI_VERSION"; \
         else \
             uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "$PACKAGE_NAME"; \
         fi; \
     else \
         if [ -n "$PYPI_VERSION" ]; then \
-            uv pip install --no-cache "${PACKAGE_NAME}==$PYPI_VERSION"; \
+            uv pip install --no-cache "${PACKAGE_NAME}==$PYPI_VERSION" "${PACKAGE_NAME}-api==$PYPI_VERSION"; \
         else \
             uv pip install --no-cache "$PACKAGE_NAME"; \
         fi; \

--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -98,6 +98,9 @@ RUN set -eux; \
 # depends on "<package>-api" without a version constraint, so an unpinned install
 # would resolve to the latest API package, which is incompatible with older
 # meta-package releases (e.g. llama-stack 0.5.2 + llama-stack-api 0.7.x).
+# The API package is installed first and best-effort: very old releases
+# (e.g. llama-stack < 0.4.0) bundled the API in the meta package and have no
+# separate "<package>-api" distribution, so a missing pin is not an error.
 RUN set -eux; \
     SAVED_UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL:-}"; \
     SAVED_UV_INDEX_STRATEGY="${UV_INDEX_STRATEGY:-}"; \
@@ -116,13 +119,19 @@ RUN set -eux; \
     elif [ "$INSTALL_MODE" = "test-pypi" ]; then \
         uv pip install --no-cache fastapi libcst; \
         if [ -n "$TEST_PYPI_VERSION" ]; then \
-            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "${PACKAGE_NAME}==$TEST_PYPI_VERSION" "${PACKAGE_NAME}-api==$TEST_PYPI_VERSION"; \
+            if ! uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "${PACKAGE_NAME}-api==$TEST_PYPI_VERSION"; then \
+                echo "No ${PACKAGE_NAME}-api==$TEST_PYPI_VERSION found; assuming the API is bundled in ${PACKAGE_NAME}"; \
+            fi; \
+            uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "${PACKAGE_NAME}==$TEST_PYPI_VERSION"; \
         else \
             uv pip install --no-cache --extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match "$PACKAGE_NAME"; \
         fi; \
     else \
         if [ -n "$PYPI_VERSION" ]; then \
-            uv pip install --no-cache "${PACKAGE_NAME}==$PYPI_VERSION" "${PACKAGE_NAME}-api==$PYPI_VERSION"; \
+            if ! uv pip install --no-cache "${PACKAGE_NAME}-api==$PYPI_VERSION"; then \
+                echo "No ${PACKAGE_NAME}-api==$PYPI_VERSION found; assuming the API is bundled in ${PACKAGE_NAME}"; \
+            fi; \
+            uv pip install --no-cache "${PACKAGE_NAME}==$PYPI_VERSION"; \
         else \
             uv pip install --no-cache "$PACKAGE_NAME"; \
         fi; \


### PR DESCRIPTION
## What

When a version is pinned, the Containerfile now installs the companion API package (`${PACKAGE_NAME}-api`) pinned to the **same** version as the meta package.

## Why

The meta package depends on `<package>-api` **without a version constraint**. A versioned image build (`PYPI_VERSION`/`TEST_PYPI_VERSION`) therefore resolved the API package to the *latest* release rather than the matching one. For older releases this is an incompatible pairing and the build fails during `stack list-deps`:

```
ImportError: cannot import name 'agents' from 'llama_stack_api'
```

This was hit while backfilling `llama-stack` 0.5.2 images: `llama-stack==0.5.2` pulled in `llama-stack-api==0.7.2`. The same latent issue applies to `ogx`/`ogx-api` (both pinned loosely); it only works today because the latest versions happen to be compatible.

## Fix

`ogx` and `ogx-api` (and `llama-stack`/`llama-stack-api`) are released in lockstep, so the matching version always exists. Co-install it pinned:

```
uv pip install --no-cache "llama-stack==0.5.2" "llama-stack-api==0.5.2"
```

Unpinned (latest) installs are unchanged.

## Test plan

- Verified the generated install commands for both the pypi and test-pypi versioned branches.
- `llama-stack-api==0.5.2` confirmed present on PyPI (lockstep with `llama-stack==0.5.2`).
- Full image build validation happens on the next 0.5.2 dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ogx-ai/ogx/pull/6062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->