### PR TITLE
fix(bing-search): use standard := env var syntax in sample config

### DIFF
--- a/docs/docs/providers/tool_runtime/remote_bing-search.mdx
+++ b/docs/docs/providers/tool_runtime/remote_bing-search.mdx
@@ -22,5 +22,5 @@ Bing Search tool for web search capabilities using Microsoft's search engine.
 ## Sample Configuration
 
 ```yaml
-api_key: ${env.BING_API_KEY:}
+api_key: ${env.BING_API_KEY:=}
 ```

--- a/src/ogx/providers/remote/tool_runtime/bing_search/config.py
+++ b/src/ogx/providers/remote/tool_runtime/bing_search/config.py
@@ -23,5 +23,5 @@ class BingSearchToolConfig(BaseToolRuntimeConfig):
     @classmethod
     def sample_run_config(cls, __distro_dir__: str, **kwargs: Any) -> dict[str, Any]:
         return {
-            "api_key": "${env.BING_API_KEY:}",
+            "api_key": "${env.BING_API_KEY:=}",
         }


### PR DESCRIPTION
Matches the ${env.VAR:=} pattern used everywhere else in the codebase instead of the non-standard ${env.VAR:}.
