### PR TITLE
feat(ci): build nightly distribution images from source

### DIFF
--- a/.github/workflows/nightly-distro.yml
+++ b/.github/workflows/nightly-distro.yml
@@ -1,0 +1,240 @@
+# =============================================================================
+# Nightly Distribution Images
+# =============================================================================
+#
+# Builds distribution container images from the current main source tree
+# (INSTALL_MODE=editable) every night, smoke-tests each image on a native
+# runner, and publishes a multi-arch manifest to DockerHub so users can pull a
+# trustworthy "latest main" image.
+#
+# Why build from source instead of test.pypi:
+#   The package-publish nightly (pypi.yml) builds its images from test.pypi and
+#   must wait for package propagation, which is the main flake source. This
+#   workflow builds straight from the checked-out commit, so it has no external
+#   package dependency and reflects exactly that night's main.
+#
+# Image naming:
+#   ogxai/distribution-<distro>:nightly        (most recent successful nightly)
+#   ogxai/distribution-<distro>:<YYYYMMDD>     (dated, immutable-ish)
+#   ogxai/distribution-<distro>:<short-sha>    (traceable to a commit)
+#
+# Note: ":latest" is intentionally NOT published here. It is owned by the
+# release pipeline (pypi.yml) and means "latest stable release". Pull ":nightly"
+# to track main.
+#
+# Each architecture is built and smoke-tested on its own native runner (no QEMU
+# at runtime), pushed by a per-arch tag, then combined into a single manifest.
+#
+# REQUIRED SECRETS: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN (Read & Write).
+# =============================================================================
+
+name: Nightly Distribution Images
+
+on:
+  schedule:
+    # 02:00 UTC — after the package nightly, but independent of it.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      distributions:
+        description: 'Comma-separated distributions to build (empty = curated default set)'
+        required: false
+        type: string
+      push:
+        description: 'Push images to DockerHub (false = build + smoke test only)'
+        required: false
+        type: boolean
+        default: true
+  pull_request:
+    # On PRs touching build-relevant code, build + boot-smoke the starter distro
+    # (amd64 only, no push) so a change that breaks server startup is caught
+    # before merge instead of at the next nightly. The full multi-distro,
+    # multi-arch, publishing run stays schedule-only.
+    paths:
+      - '.github/workflows/nightly-distro.yml'
+      - 'scripts/smoke-test-distro.sh'
+      - 'containers/Containerfile'
+      - 'src/ogx/**'
+      - 'src/ogx_api/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_PREFIX: ogxai/distribution
+  # Curated default set built on a schedule. Override via workflow_dispatch.
+  DEFAULT_DISTROS: 'starter,postgres-demo'
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      distros: ${{ steps.set.outputs.distros }}
+      arches: ${{ steps.set.outputs.arches }}
+      date_tag: ${{ steps.set.outputs.date_tag }}
+      sha_tag: ${{ steps.set.outputs.sha_tag }}
+      push: ${{ steps.set.outputs.push }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Resolve matrix and tags
+        id: set
+        run: |
+          # On PRs this is a pre-merge gate: build + smoke only starter on amd64,
+          # never push. Schedule/dispatch get the full distro set and both arches.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            REQUESTED="starter"
+            arches='["amd64"]'
+            push="false"
+          else
+            REQUESTED="${{ inputs.distributions }}"
+            [ -z "$REQUESTED" ] && REQUESTED="$DEFAULT_DISTROS"
+            arches='["amd64","arm64"]'
+            push="${{ inputs.push == false && 'false' || 'true' }}"
+          fi
+
+          # Validate each requested distro exists before fanning out the matrix.
+          IFS=',' read -ra REQUESTED_ARR <<< "$REQUESTED"
+          valid=()
+          for d in "${REQUESTED_ARR[@]}"; do
+            d="$(echo "$d" | xargs)"  # trim surrounding whitespace
+            [ -z "$d" ] && continue
+            if [ ! -f "src/ogx/distributions/${d}/config.yaml" ]; then
+              echo "::error::Unknown distribution: ${d} (no src/ogx/distributions/${d}/config.yaml)"
+              exit 1
+            fi
+            valid+=("$d")
+          done
+          json=$(printf '%s\n' "${valid[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          {
+            echo "distros=$json"
+            echo "arches=$arches"
+            echo "date_tag=$(date -u +%Y%m%d)"
+            echo "sha_tag=$(git rev-parse --short HEAD)"
+            echo "push=$push"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Distributions: $json"
+          echo "Arches: $arches"
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        # distro x arch cross-product. The include entries match on the existing
+        # "arch" axis to attach the right runner (they do NOT add new jobs).
+        distro: ${{ fromJson(needs.prepare.outputs.distros) }}
+        arch: ${{ fromJson(needs.prepare.outputs.arches) }}
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af --volumes || true
+          df -h
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-runner
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+
+      - name: Build image (native ${{ matrix.arch }})
+        env:
+          DISTRO_NAME: ${{ matrix.distro }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          LOCAL_TAG="${IMAGE_PREFIX}-${DISTRO_NAME}:smoke-${ARCH}"
+          echo "LOCAL_TAG=${LOCAL_TAG}" >> "$GITHUB_ENV"
+
+          CONFIG_LABELS=$(bash scripts/generate-config-labels.sh "$DISTRO_NAME" "${{ needs.prepare.outputs.date_tag }}")
+          mapfile -t LABEL_ARGS <<< "$CONFIG_LABELS"
+
+          # Build natively for this runner's architecture and load into the
+          # local docker so the smoke test can run it directly.
+          docker buildx build \
+            --load \
+            -f containers/Containerfile \
+            --build-arg "INSTALL_MODE=editable" \
+            --build-arg "DISTRO_NAME=${DISTRO_NAME}" \
+            "${LABEL_ARGS[@]}" \
+            --tag "${LOCAL_TAG}" \
+            .
+
+      - name: Smoke test image
+        run: bash scripts/smoke-test-distro.sh "${LOCAL_TAG}"
+
+      - name: Log in to DockerHub
+        if: needs.prepare.outputs.push == 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push per-arch tag
+        id: push
+        if: needs.prepare.outputs.push == 'true'
+        env:
+          DISTRO_NAME: ${{ matrix.distro }}
+          ARCH: ${{ matrix.arch }}
+          DATE_TAG: ${{ needs.prepare.outputs.date_tag }}
+        run: |
+          ARCH_TAG="${IMAGE_PREFIX}-${DISTRO_NAME}:${DATE_TAG}-${ARCH}"
+          docker tag "${LOCAL_TAG}" "${ARCH_TAG}"
+          docker push "${ARCH_TAG}"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+          echo "Pushed ${ARCH_TAG}"
+
+  manifest:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.push == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: ${{ fromJson(needs.prepare.outputs.distros) }}
+    steps:
+      - name: Log in to DockerHub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        env:
+          DISTRO_NAME: ${{ matrix.distro }}
+          DATE_TAG: ${{ needs.prepare.outputs.date_tag }}
+          SHA_TAG: ${{ needs.prepare.outputs.sha_tag }}
+        run: |
+          IMAGE="${IMAGE_PREFIX}-${DISTRO_NAME}"
+          AMD64="${IMAGE}:${DATE_TAG}-amd64"
+          ARM64="${IMAGE}:${DATE_TAG}-arm64"
+
+          # ":latest" is owned by the release pipeline (pypi.yml). Nightly
+          # tracks main via ":nightly".
+          for TAG in "${DATE_TAG}" "${SHA_TAG}" "nightly"; do
+            echo "Creating manifest ${IMAGE}:${TAG}"
+            docker buildx imagetools create \
+              --tag "${IMAGE}:${TAG}" \
+              "${AMD64}" "${ARM64}"
+          done
+
+          echo "Published ${IMAGE}: nightly, ${DATE_TAG}, ${SHA_TAG} (linux/amd64, linux/arm64)"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -901,7 +901,12 @@ jobs:
   #
   # Images are pushed to: ogxai/distribution-<distro>:<tag>
   #   - Production (release or dry_run=off): tagged with VERSION and "latest"
-  #   - Test (test-pypi or schedule): tagged with "test-VERSION"
+  #   - Test (dry_run=test-pypi via workflow_dispatch): tagged with "test-VERSION"
+  #
+  # Nightly (schedule) image builds are intentionally NOT handled here. They are
+  # built from source by nightly-distro.yml, which avoids waiting on test.pypi
+  # propagation and publishes the ":nightly" tag. This job only builds versioned
+  # release images (and on-demand test images via workflow_dispatch).
   publish-docker-images:
     name: Publish Docker ${{ matrix.distro }}
     if: |
@@ -912,8 +917,7 @@ jobs:
       (inputs.dry_run || 'test-pypi') != 'build-only' &&
       (inputs.packages || 'all') != 'clients-only' && (
         github.event_name == 'workflow_dispatch' ||
-        github.event.action == 'published' ||
-        github.event_name == 'schedule'
+        github.event.action == 'published'
       )
     permissions:
       contents: read

--- a/scripts/smoke-test-distro.sh
+++ b/scripts/smoke-test-distro.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+# Smoke test a built distribution image: start the container, wait for the
+# server to report healthy, and exercise a couple of read-only endpoints. This
+# does not call a real inference backend; it only verifies that the image boots
+# and serves the API. Provider API keys are stubbed so distros that interpolate
+# them can start without real credentials.
+set -euo pipefail
+
+IMAGE="${1:-}"
+if [ -z "$IMAGE" ]; then
+    echo "Usage: $0 IMAGE_NAME" >&2
+    exit 1
+fi
+
+PORT="${SMOKE_PORT:-8321}"
+CONTAINER_NAME="ogx-smoke-$$"
+HEALTH_URL="http://localhost:${PORT}/v1/health"
+RETRIES="${SMOKE_RETRIES:-30}"
+SLEEP_SECONDS="${SMOKE_SLEEP_SECONDS:-5}"
+
+cleanup() {
+    echo "Collecting container logs for ${CONTAINER_NAME}:"
+    docker logs "$CONTAINER_NAME" 2>&1 | tail -n 200 || true
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Starting container from image: ${IMAGE}"
+docker run -d --name "$CONTAINER_NAME" \
+    -p "${PORT}:8321" \
+    -e OPENAI_API_KEY="smoke-test-dummy-key" \
+    -e FIREWORKS_API_KEY="smoke-test-dummy-key" \
+    -e TOGETHER_API_KEY="smoke-test-dummy-key" \
+    -e GEMINI_API_KEY="smoke-test-dummy-key" \
+    -e ANTHROPIC_API_KEY="smoke-test-dummy-key" \
+    "$IMAGE" >/dev/null
+
+echo "Waiting for ${HEALTH_URL} (up to $((RETRIES * SLEEP_SECONDS))s)..."
+for i in $(seq 1 "$RETRIES"); do
+    if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+        echo "::error::Container exited before becoming healthy"
+        exit 1
+    fi
+    if curl -sf "$HEALTH_URL" 2>/dev/null | grep -q "OK"; then
+        echo "Server is healthy after $((i * SLEEP_SECONDS))s"
+        break
+    fi
+    if [ "$i" -eq "$RETRIES" ]; then
+        echo "::error::Server did not become healthy within $((RETRIES * SLEEP_SECONDS))s"
+        exit 1
+    fi
+    sleep "$SLEEP_SECONDS"
+done
+
+# Read-only sanity checks. /v1/models must respond with valid JSON; the models
+# list may be empty when no provider credentials are present, which is fine.
+echo "Checking /v1/models endpoint..."
+if ! curl -sf "http://localhost:${PORT}/v1/models" | python3 -c "import sys, json; json.load(sys.stdin)"; then
+    echo "::error::/v1/models did not return valid JSON"
+    exit 1
+fi
+
+echo "Smoke test passed for ${IMAGE}"


### PR DESCRIPTION
## What

Adds a maintained **nightly distribution-image build** so users can pull a trustworthy "latest main" container, and retires the flaky test.pypi-based nightly docker build.

### `nightly-distro.yml` (new)
- Builds distribution images from the current `main` source tree (`INSTALL_MODE=editable`) every night at 02:00 UTC. Building from source removes the test.pypi propagation wait that was the main flake source in the old nightly.
- Each architecture builds on its **own native runner** (`ubuntu-24.04` + `ubuntu-24.04-arm`) — no QEMU at runtime — so each image is **boot-smoke-tested on its real architecture** before it's trusted.
- A push only happens if the image actually booted. Per-arch tags are then merged into a single multi-arch manifest via `docker buildx imagetools create`.
- Tags: `:nightly`, `:<YYYYMMDD>`, `:<short-sha>`. **`:latest` is intentionally not touched** — it stays owned by the release pipeline and means "latest stable release". Pull `:nightly` to track `main`.
- **Per-PR gate:** on PRs touching build-relevant paths, it builds + boot-smoke-tests the `starter` distro on amd64 only, **no push** — so a change that breaks server startup is caught before merge instead of at the next nightly. (`providers-build.yml` builds venv-only on PRs, so nothing booted a distro container per-PR before this.)

### `pypi.yml` (changed)
- Removes the `schedule` trigger from the `publish-docker-images` job. Nightly images are now built from source by `nightly-distro.yml`. **Release and `workflow_dispatch` image builds are unchanged**, and the nightly **test.pypi package publish is untouched**.

### `scripts/smoke-test-distro.sh` (new)
- Boots a built image with stubbed provider keys, polls `/v1/health` for `OK`, asserts `/v1/models` returns valid JSON, and dumps container logs on failure. Reusable locally and in CI.

## Test plan

Static checks:
- `actionlint` on both workflows — clean
- `shellcheck scripts/smoke-test-distro.sh` — clean
- Matrix resolution simulated for `pull_request` / `schedule` / `workflow_dispatch`:
  - PR → `[starter/amd64]`, push=false
  - schedule → `[starter/amd64] [starter/arm64] [postgres-demo/amd64] [postgres-demo/arm64]`, push=true

End-to-end, locally (native arm64):
```
docker buildx build --load -f containers/Containerfile \
  --build-arg INSTALL_MODE=editable --build-arg DISTRO_NAME=starter \
  --tag ogxai/distribution-starter:smoke-local .
bash scripts/smoke-test-distro.sh ogxai/distribution-starter:smoke-local
```
Output:
```
Waiting for http://localhost:8321/v1/health (up to 150s)...
Server is healthy after 15s
Checking /v1/models endpoint...
Smoke test passed for ogxai/distribution-starter:smoke-local
EXIT CODE = 0
```
(The `401` provider model-refresh errors from the dummy keys are expected and non-fatal — the server still starts and serves.)

## Notes / follow-ups
- Requires `ubuntu-24.04-arm` GitHub-hosted runners enabled for the org.
- Reuses existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets — nothing new to provision.
- Curated nightly set is `starter,postgres-demo`; expand later as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)