### PR TITLE
fix(vertexai): prevent RuntimeError from stale client after startup event loop

### DIFF
--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -147,6 +147,17 @@ class StackApp(FastAPI):
 
         reset_sqlstore_engines()
 
+        # Reset VertexAI provider clients that may have been created in the
+        # temporary event loop during model listing (refresh_registry_once).
+        # Like SQL engines, the Google genai Client eagerly binds an internal
+        # httpx.AsyncClient to the current event loop, and the cached client
+        # becomes unusable after the temporary loop is terminated.
+        if self.stack.impls:
+            for impl in self.stack.impls.values():
+                reset_fn = getattr(impl, "_reset_client", None)
+                if reset_fn is not None:
+                    reset_fn()
+
 
 @asynccontextmanager
 async def lifespan(app: StackApp) -> AsyncIterator[None]:

--- a/src/ogx/providers/remote/inference/vertexai/vertexai.py
+++ b/src/ogx/providers/remote/inference/vertexai/vertexai.py
@@ -202,6 +202,29 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 exc_info=True,
             )
 
+    def _reset_client(self) -> None:
+        """Reset cached client and HTTP options after a temporary event loop exits.
+
+        When StackApp.__init__ runs stack.initialize() inside a temporary event
+        loop (via ThreadPoolExecutor), model listing may trigger lazy client
+        creation via _get_client().  The Google genai Client eagerly creates an
+        internal httpx.AsyncClient bound to the temporary loop.  After the
+        temporary loop is closed, the cached client holds connections tied to
+        the dead loop, causing ``RuntimeError: Event loop is closed`` on the
+        first inference request.
+
+        This method clears the cached client without awaiting async close
+        (the temporary loop is already terminated) so that a fresh client is
+        created on the next _get_client() call — this time on uvicorn's
+        request-handling event loop.
+
+        Compare ``reset_sqlstore_engines()`` which serves the same purpose for
+        SQL engines.
+        """
+        self._default_client = None
+        self._http_options = None
+        self._http_options_initialized = False
+
     async def shutdown(self) -> None:
         await self._close_managed_httpx_client()
         self._http_options = None
@@ -315,7 +338,30 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
                 return self._create_client(project=project, location=location, access_token=access_token)
 
-        # Lazily create the default client on first use
+        # Lazily create the default client on first use.
+        # If we already have a cached client, verify it is still usable before
+        # returning it — a previous request may have left connections tied to an
+        # event loop that is now closed (e.g., after a temporary startup loop).
+        if self._default_client is not None:
+            try:
+                # Touch the underlying httpx client to detect event loop binding
+                # issues.  If the client was created in a now-closed loop,
+                # accessing its transport raises RuntimeError.
+                if self._http_options is not None:
+                    _client = getattr(self._http_options, "httpx_async_client", None)
+                    if _client is not None and _client.is_closed:
+                        logger.info(
+                            "VertexAI default client transport is closed; recreating",
+                            project=self.config.project,
+                        )
+                        self._default_client = None
+            except RuntimeError:
+                logger.warning(
+                    "VertexAI default client is bound to a closed event loop; recreating",
+                    project=self.config.project,
+                )
+                self._default_client = None
+
         if self._default_client is None:
             access_token = self.config.auth_credential.get_secret_value() if self.config.auth_credential else None
             try:


### PR DESCRIPTION
Ran into #6057 while setting up a VertexAI provider — the server would crash with `RuntimeError: Event loop is closed` on the first inference request after startup.

Turns out the issue is that during `StackApp.__init__`, the stack initialization runs in a temporary event loop, and `refresh_registry_once()` triggers model listing which calls `_get_client()` on the VertexAI adapter. The Google genai `Client` eagerly creates an `httpx.AsyncClient` internal to itself, binding it to that temporary loop. After the temp loop goes away and uvicorn starts on a fresh loop, the cached client is still holding connections tied to the dead loop.

Two things in this PR:

1. Added `_reset_client()` on `VertexAIInferenceAdapter` — clears the cached default client and HTTP options. This is called from `StackApp.__init__` right after `reset_sqlstore_engines()`, following the exact same pattern that already exists for SQL engines.

2. Added a safety check in `_get_client()` itself — before returning the cached default client, it checks whether the underlying httpx transport has been closed. If it has (which happens when the event loop it was created on is terminated), it logs and recreates the client. This is defense-in-depth in case the reset isn't called.

Not entirely sure about the `is_closed` check — it relies on httpx's internal state tracking which seems stable across recent versions but could change. Happy to remove that part if you'd prefer to keep it simpler.

## Test Plan
Ran `python3.12 -m py_compile` on both modified files — they compile cleanly. The existing test suite should cover the normal code paths since these changes only affect the initialization/recreation path. The event loop simulation is tricky to unit test without bringing up a full server, but the pattern mirrors the tested `reset_sqlstore_engines()` flow exactly.