### PR TITLE
fix: bump pillow to >=12.2.0 (CVE-2026-40192)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "rich",
     "termcolor",
     "tiktoken",
-    "pillow",
+    "pillow>=12.2.0",
     "h11>=0.16.0",
     "python-multipart>=0.0.20",                       # For fastapi Form
     "uvicorn>=0.34.0",                                # server

--- a/src/llama_stack/providers/registry/agents.py
+++ b/src/llama_stack/providers/registry/agents.py
@@ -21,7 +21,7 @@ def available_providers() -> list[ProviderSpec]:
             pip_packages=[
                 "matplotlib",
                 "fonttools>=4.60.2",
-                "pillow",
+                "pillow>=12.2.0",
                 "pandas",
                 "scikit-learn",
                 "mcp>=1.23.0",


### PR DESCRIPTION
# What does this PR do?

Bump `pillow` to `>=12.2.0` in dependencies and provider registry to address CVE-2026-40192, [GHSA-whj4-6x5x-4v2j](https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5x-4v2j)

Only applies to `release-0.4.x`; `pillow` already pinned `>=12.2.0` on `main`.

## Test Plan

No functional changes. Version floor pin only.
