### PR TITLE
feat(ci): add Trivy security scanning

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,5 +37,7 @@ OGX uses GitHub Actions for Continuous Integration (CI). Below is a table detail
 | Test External Providers Installed via Module | [test-external-provider-module.yml](test-external-provider-module.yml) | Test External Provider installation via Python module |
 | Test External API and Providers | [test-external.yml](test-external.yml) | Test the External API and Provider mechanisms |
 | Trigger Docs Deploy | [trigger-docs-deploy.yml](trigger-docs-deploy.yml) | Trigger docs site rebuild after docs change |
+| Trivy Scheduled Security Scan | [trivy-scheduled.yml](trivy-scheduled.yml) | Trivy Scheduled Security Scan |
+| Trivy Security Scan | [trivy-security.yml](trivy-security.yml) | Trivy Security Scan |
 | UI Tests | [ui-unit-tests.yml](ui-unit-tests.yml) | Run the UI test suite |
 | Unit Tests | [unit-tests.yml](unit-tests.yml) | Run the unit test suite |

--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -138,3 +138,15 @@ jobs:
         run: |
           LOCAL_IMAGE_NAME="${IMAGE_PREFIX}-${DISTRO_NAME}:${IMAGE_TAG}"
           bash scripts/verify-config-labels.sh "${LOCAL_IMAGE_NAME}"
+
+      - name: Scan container image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          DISTRO_NAME: ${{ matrix.distro }}
+          IMAGE_TAG: ${{ needs.generate-matrix.outputs.version }}
+        with:
+          image-ref: '${{ env.IMAGE_PREFIX }}-${{ matrix.distro }}:${{ needs.generate-matrix.outputs.version }}'
+          scan-type: 'image'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          format: 'table'

--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read
   actions: write
+  security-events: write
 
 env:
   IMAGE_PREFIX: ogx/distribution
@@ -149,4 +150,12 @@ jobs:
           scan-type: 'image'
           severity: 'CRITICAL,HIGH'
           exit-code: '0'
-          format: 'table'
+          format: 'sarif'
+          output: 'trivy-container-${{ matrix.distro }}.sarif'
+
+      - name: Upload container scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-container-${{ matrix.distro }}.sarif'
+          category: 'trivy-container-${{ matrix.distro }}'

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1040,3 +1040,54 @@ jobs:
             CLI_NAME=${{ steps.meta.outputs.cli_name }}
             OTEL_BEST_EFFORT=${{ steps.meta.outputs.otel_best_effort }}
             ${{ steps.meta.outputs.version_arg }}
+
+  scan-docker-images:
+    name: Scan Docker ${{ matrix.distro }}
+    if: |
+      always() &&
+      needs.publish-docker-images.result == 'success'
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    needs: [publish-docker-images, compute-version]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: starter
+          - distro: postgres-demo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          VERSION="${{ needs.compute-version.outputs.version }}"
+          DRY_RUN="${{ inputs.dry_run }}"
+          EVENT="${{ github.event_name }}"
+          if [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; then
+            echo "tag=${VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=test-${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scan published image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'ogxai/distribution-${{ matrix.distro }}:${{ steps.tag.outputs.tag }}'
+          scan-type: 'image'
+          scanners: 'vuln'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          format: 'sarif'
+          output: 'trivy-image-${{ matrix.distro }}.sarif'
+          trivy-config: 'trivy.yaml'
+
+      - name: Upload Trivy image scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-image-${{ matrix.distro }}.sarif'
+          category: 'trivy-image-${{ matrix.distro }}'

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -1,0 +1,101 @@
+name: Trivy Scheduled Security Scan
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  repo-scan:
+    name: Repository scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'vuln'
+          format: 'sarif'
+          output: 'trivy-scheduled-vuln.sarif'
+          exit-code: '0'
+          trivy-config: 'trivy.yaml'
+
+      - name: Upload vulnerability results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-scheduled-vuln.sarif'
+          category: 'trivy-scheduled-vuln'
+
+      - name: Run Trivy secret scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'secret'
+          format: 'sarif'
+          output: 'trivy-scheduled-secret.sarif'
+          exit-code: '0'
+
+      - name: Upload secret results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-scheduled-secret.sarif'
+          category: 'trivy-scheduled-secret'
+
+      - name: Run Trivy misconfiguration scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          scanners: 'misconfig'
+          format: 'sarif'
+          output: 'trivy-scheduled-misconfig.sarif'
+          exit-code: '0'
+
+      - name: Upload misconfiguration results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-scheduled-misconfig.sarif'
+          category: 'trivy-scheduled-misconfig'
+
+  image-scan:
+    name: Scan ${{ matrix.distro }} image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - starter
+          - postgres-demo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Scan published image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'ogxai/distribution-${{ matrix.distro }}:latest'
+          scan-type: 'image'
+          scanners: 'vuln'
+          format: 'sarif'
+          output: 'trivy-image-${{ matrix.distro }}.sarif'
+          exit-code: '0'
+          trivy-config: 'trivy.yaml'
+
+      - name: Upload image scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-image-${{ matrix.distro }}.sarif'
+          category: 'trivy-scheduled-image-${{ matrix.distro }}'

--- a/.github/workflows/trivy-security.yml
+++ b/.github/workflows/trivy-security.yml
@@ -1,6 +1,7 @@
 name: Trivy Security Scan
 
 on:
+  merge_group:
   pull_request:
     branches:
       - main
@@ -83,6 +84,7 @@ jobs:
           output: 'trivy-misconfig.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
           exit-code: '0'
+          trivy-config: 'trivy.yaml'
 
       - name: Upload misconfiguration results to GitHub Security
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
@@ -107,6 +109,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-secret.sarif'
           exit-code: '0'
+          trivy-config: 'trivy.yaml'
 
       - name: Upload secret detection results to GitHub Security
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3

--- a/.github/workflows/trivy-security.yml
+++ b/.github/workflows/trivy-security.yml
@@ -1,0 +1,116 @@
+name: Trivy Security Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-**"
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - 'src/ogx_api/pyproject.toml'
+      - 'src/ogx_ui/package-lock.json'
+      - 'containers/Containerfile'
+      - 'src/ogx_ui/Containerfile'
+      - 'docs/docs/distributions/k8s/**'
+      - 'docs/docs/distributions/eks/**'
+      - '.trivyignore'
+      - 'trivy.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - 'src/ogx_api/pyproject.toml'
+      - 'src/ogx_ui/package-lock.json'
+      - 'containers/Containerfile'
+      - 'src/ogx_ui/Containerfile'
+      - 'docs/docs/distributions/k8s/**'
+      - 'docs/docs/distributions/eks/**'
+      - '.trivyignore'
+      - 'trivy.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  vulnerability-scan:
+    name: Dependency vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'vuln'
+          format: 'sarif'
+          output: 'trivy-vuln.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          trivy-config: 'trivy.yaml'
+
+      - name: Upload vulnerability results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-vuln.sarif'
+          category: 'trivy-vuln'
+
+  misconfig-scan:
+    name: IaC misconfigurations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy misconfiguration scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          scanners: 'misconfig'
+          format: 'sarif'
+          output: 'trivy-misconfig.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'
+
+      - name: Upload misconfiguration results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-misconfig.sarif'
+          category: 'trivy-misconfig'
+
+  secret-scan:
+    name: Secret detection
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Trivy secret scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'secret'
+          format: 'sarif'
+          output: 'trivy-secret.sarif'
+          exit-code: '0'
+
+      - name: Upload secret detection results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-secret.sarif'
+          category: 'trivy-secret'

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# Trivy ignore file for OGX
+# https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#trivyignore
+#
+# Add CVE IDs or vulnerability IDs (one per line) for accepted risks.
+# Document the reason for each exclusion.
+#
+# Example:
+#   # CVE-YYYY-NNNNN: <reason for accepting this risk>
+#   CVE-YYYY-NNNNN

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,4 @@
+vulnerability:
+  type:
+    - os
+    - library


### PR DESCRIPTION
# What does this PR do?
Add Trivy vulnerability scanning across the CI pipeline to complement existing CodeQL SAST coverage. All scans start as informational (SARIF upload to GitHub Security tab, no PR blocking) so existing findings can be triaged before tightening thresholds.

New workflows:
- trivy-security.yml: PR/push scanning with path filters for dependency vulnerabilities, IaC misconfigurations, and secret detection
- trivy-scheduled.yml: weekly full repo and published container image scans

Modified workflows:
- build-distributions.yml: scan built images after config label verification
- pypi.yml: post-push scan of published Docker images

