### PR TITLE
fix: bump pillow to >=12.2.0 (CVE-2026-40192)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ starter = [
     "opentelemetry-exporter-otlp-proto-http",
     "opentelemetry-sdk",
     "pandas",
-    "pillow",
+    "pillow>=12.2.0",
     "psycopg2-binary",
     "pymilvus[milvus-lite]>=2.4.10",
     "pymongo",

--- a/src/llama_stack/providers/registry/responses.py
+++ b/src/llama_stack/providers/registry/responses.py
@@ -26,7 +26,7 @@ def available_providers() -> list[ProviderSpec]:
             pip_packages=[
                 "matplotlib",
                 "fonttools>=4.60.2",
-                "pillow",
+                "pillow>=12.2.0",
                 "pandas",
                 "scikit-learn",
                 "mcp>=1.23.0",


### PR DESCRIPTION
# What does this PR do?

Bump `pillow` to `>=12.2.0` in dependencies and provider registry to address CVE-2026-40192, [GHSA-whj4-6x5x-4v2j](https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5x-4v2j)

Only applies to `release-0.7.x`; `pillow` already pinned `>=12.2.0` on `main`.

## Test Plan

No functional changes. Version floor pin only.
