### PR TITLE
fix(ci): make ci-status wait for flaky test re-runs

### DIFF
--- a/.github/workflows/ci-status.yml
+++ b/.github/workflows/ci-status.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   ci-status:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
     permissions:
       checks: read
     steps:
@@ -92,10 +92,12 @@ jobs:
 
               if (failed.length > 0) {
                 for (const cr of failed) {
-                  core.error(`${cr.name} concluded with: ${cr.conclusion}`);
+                  core.warning(`${cr.name} concluded with: ${cr.conclusion} — waiting for re-run`);
                 }
-                core.setFailed(`${failed.length} CI check(s) failed.`);
-                return;
+                core.info(`${failed.length} check(s) failed. Waiting 30s for re-runs before giving up...`);
+                core.info('Re-run the failed job(s) and ci-status will pick up the result automatically.');
+                await new Promise(r => setTimeout(r, 30000));
+                continue;
               }
 
               const succeeded = completed.filter(cr => successConclusions.has(cr.conclusion));


### PR DESCRIPTION
# What does this PR do?

Makes the `ci-status` aggregator job wait indefinitely (up to the 3-hour timeout) for failed checks to be re-run, instead of failing immediately when it sees a failure. This means you only need to restart the flaky job itself, not both the flaky job and `ci-status`.

**Before:** A flaky test fails -> `ci-status` immediately fails -> you restart the flaky job AND `ci-status`.
**After:** A flaky test fails -> `ci-status` keeps polling -> you restart just the flaky job -> `ci-status` picks up the green result automatically.

Changes:
- Replace `core.error` + `core.setFailed` + `return` with `core.warning` + `continue` so the polling loop keeps running
- Increase timeout from 60 to 180 minutes to accommodate re-run wait times

## Test Plan

1. Open a PR that triggers CI
2. If a flaky job fails, observe that `ci-status` logs warnings but keeps polling
3. Re-run only the failed job
4. Verify `ci-status` detects the re-run and eventually reports success