### PR TITLE
fix(vertexai): use structured logging key-value style

### DIFF
--- a/src/ogx/providers/remote/inference/vertexai/converters.py
+++ b/src/ogx/providers/remote/inference/vertexai/converters.py
@@ -236,8 +236,8 @@ def _convert_user_message(msg: dict[str, Any]) -> dict[str, Any]:
                     parts.append(inline)
             else:
                 logger.warning(
-                    "Unsupported content part type '%s' in user message; skipping",
-                    part_type,
+                    "Unsupported content part type in user message; skipping",
+                    part_type=part_type,
                 )
 
     return {"role": "user", "parts": parts}

--- a/src/ogx/providers/remote/inference/vertexai/vertexai.py
+++ b/src/ogx/providers/remote/inference/vertexai/vertexai.py
@@ -192,9 +192,9 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             # Don't create the client here - it will be created lazily on first use
             # This avoids calling _ensure_http_options() in the temporary startup event loop
             logger.info(
-                "VertexAI provider initialized for project=%s location=%s (client will be created on first use)",
-                self.config.project,
-                self.config.location,
+                "VertexAI provider initialized (client will be created on first use)",
+                project=self.config.project,
+                location=self.config.location,
             )
         except Exception:
             logger.warning(
@@ -265,8 +265,8 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             await self.list_models()
         except Exception:
             logger.warning(
-                "Failed to list VertexAI models for availability check; accepting model '%s' without validation.",
-                model,
+                "Failed to list VertexAI models for availability check; accepting model without validation.",
+                model=model,
                 exc_info=True,
             )
             return True
@@ -386,8 +386,8 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             provider_model_ids = await self.list_provider_model_ids()
         except Exception:
             logger.error(
-                "%s.list_provider_model_ids() failed",
-                self.__class__.__name__,
+                "Failed to list provider model IDs",
+                provider=self.__class__.__name__,
                 exc_info=True,
             )
             raise
@@ -907,8 +907,8 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         # passthrough. Log and ignore extra body parameters rather than silently dropping.
         if params.model_extra:
             logger.debug(
-                "VertexAI embeddings does not support extra body parameters; model_extra will be ignored: %s",
-                list(params.model_extra.keys()),
+                "VertexAI embeddings does not support extra body parameters; model_extra will be ignored",
+                ignored_keys=list(params.model_extra.keys()),
             )
 
         provider_model_id = await self._get_provider_model_id(params.model)


### PR DESCRIPTION
# What does this PR do?

Converts the printf-style `%s` logging calls in the VertexAI inference provider to the project's structured key-value logging style.

The `Block f-string logging` pre-commit hook and the repository logging conventions require key-value arguments (`logger.info("msg", key=value)`) rather than positional `%`-formatting. These five call sites in `vertexai.py` and `converters.py` were still using the old positional style.

No behavioral change: the same data is logged, just emitted through structlog key-value fields so the messages are machine-parseable and consistent with the rest of the codebase.

## Test Plan

No runtime behavior changes. Verified via pre-commit:

```
uv run pre-commit run --all-files
```

Relevant hooks passing on the changed files:

```
Ensure 'ogx.log' usage for logging...........................................Passed
Block f-string logging (use structlog key-value style).......................Passed
ruff format..................................................................Passed
mypy.........................................................................Passed
```
