### PR TITLE
chore: update ogx-client to ^1.1.0 in UI lockfile

### DIFF
--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -26,7 +26,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.0.2",
+        "ogx-client": "^1.1.0",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.2.tgz",
-      "integrity": "sha512-wlgUV/4ROjBP6yI2zc+kUwk1JpdV8M/D+D08sv3tJ4Y9c2qzGDmnqCvnNUXqfOBPEzxN/oRG3MgtSzdrEb4jFQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.0.tgz",
+      "integrity": "sha512-qRfpWms8Bbq8eKr25IibX1r0GTp28vmpmIr5y1ELyQ0QAIAdHB87V3PsDMi/Ub4FWmmaaCPp6bV+shwZp1m40A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -50,7 +50,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.0.2",
+    "ogx-client": "^1.1.0",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4256,7 +4256,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.0.2" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.0" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4324,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = ">=1.0.2" },
+    { name = "ogx-client", specifier = "==1.1.0" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4417,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=1.0.2" },
+    { name = "ogx-client", specifier = "==1.1.0" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4485,7 +4485,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.0.2"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4504,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/74/3edc7a8f396137741d9b29a728bcf45afd4a8266b40f1080ec0118c52065/ogx_client-1.0.2.tar.gz", hash = "sha256:4f5d0a5285fdbfcd3c260c291d70d325cf44b743a67c51e65d8a0c5f5cd76177", size = 435217, upload-time = "2026-05-13T22:52:04.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/df/34b1895ca3d608434347db103c3711b158feea3db9f091366ac93ee126cf/ogx_client-1.1.0.tar.gz", hash = "sha256:b51d945544a59212e960b692ee2832f7c59c683f997f33d9f7ea55ef63de68e4", size = 440837, upload-time = "2026-06-11T13:10:30.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/fc/4bf0216fd6e13943837f30164937d6db78dd8743424984ce22c763491c22/ogx_client-1.0.2-py3-none-any.whl", hash = "sha256:167ad9f36ec632cd579bb6451dc8137d90d755d78cd7073d8fc9dcc9bf622fa5", size = 309278, upload-time = "2026-05-13T22:52:03.149Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d3/19cd05d73b8c4ac6402fe73d74fdcd30a6072889a4a2a4f476957c333aa9/ogx_client-1.1.0-py3-none-any.whl", hash = "sha256:fd09360e39dd0ff142f7a9cde417318c25e3b68ce44f0e061d1de4fd24e2bce8", size = 314014, upload-time = "2026-06-11T13:10:28.843Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release npm lockfile update after v1.1.0.

Updates ogx-client to ^1.1.0 in the UI package lockfile.

This PR was created automatically by the post-release workflow.