### PR TITLE
chore: Limit payload-bearing logs to debug (vector search, rerank, guardrails)

### DIFF
--- a/src/ogx/providers/inline/interactions/impl.py
+++ b/src/ogx/providers/inline/interactions/impl.py
@@ -298,7 +298,6 @@ class BuiltinInteractionsImpl(Interactions):
                 logger.error(
                     "Passthrough request failed",
                     status_code=resp.status_code,
-                    response_body=resp.text[:500],
                     url=url,
                 )
                 return JSONResponse(content=resp.json(), status_code=resp.status_code)

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -427,7 +427,7 @@ class StreamingResponseOrchestrator:
                 headers=self.moderation_headers,
             )
             if input_violation_message:
-                logger.info("Input guardrail violation", input_violation_message=input_violation_message)
+                logger.debug("Input guardrail violation", input_violation_message=input_violation_message)
                 yield await self._create_refusal_response(input_violation_message)
                 return
 
@@ -1260,7 +1260,7 @@ class StreamingResponseOrchestrator:
                     headers=self.moderation_headers,
                 )
                 if violation_message:
-                    logger.info("Output guardrail violation", violation_message=violation_message)
+                    logger.debug("Output guardrail violation", violation_message=violation_message)
                     pending_guardrail_events.clear()
                     yield await self._create_refusal_response(violation_message)
                     self.violation_detected = True
@@ -1279,7 +1279,7 @@ class StreamingResponseOrchestrator:
                 headers=self.moderation_headers,
             )
             if violation_message:
-                logger.info("Output guardrail violation", violation_message=violation_message)
+                logger.debug("Output guardrail violation", violation_message=violation_message)
                 pending_guardrail_events.clear()
                 yield await self._create_refusal_response(violation_message)
                 self.violation_detected = True

--- a/src/ogx/providers/remote/vector_io/infinispan/infinispan.py
+++ b/src/ogx/providers/remote/vector_io/infinispan/infinispan.py
@@ -88,7 +88,7 @@ class InfinispanIndex(EmbeddingIndex):
 
         if response.status_code != 404:
             # Unexpected error
-            log.error(f"Failed to check cache existence: {response.status_code} - {response.text}")
+            log.error("Failed to check cache existence", status_code=response.status_code)
             response.raise_for_status()
 
         # Cache doesn't exist, register schema first then create cache
@@ -112,7 +112,7 @@ class InfinispanIndex(EmbeddingIndex):
         )
 
         if create_response.status_code not in [200, 204]:
-            log.error(f"Failed to create cache: {create_response.status_code} - {create_response.text}")
+            log.error("Failed to create cache", status_code=create_response.status_code)
             create_response.raise_for_status()
 
         log.info(f"Cache '{self.cache_name}' created successfully")
@@ -134,7 +134,7 @@ class InfinispanIndex(EmbeddingIndex):
         )
 
         if schema_response.status_code not in [200, 204]:
-            log.error(f"Failed to register Protobuf schema: {schema_response.status_code} - {schema_response.text}")
+            log.error("Failed to register Protobuf schema", status_code=schema_response.status_code)
             schema_response.raise_for_status()
 
         log.info(f"Protobuf schema '{schema_name}' registered successfully")
@@ -174,7 +174,7 @@ class InfinispanIndex(EmbeddingIndex):
             }
 
             # Insert into Infinispan cache
-            log.debug(f"PUT request to insert chunk {key}: {vector_item}")
+            log.debug("PUT request to insert chunk", chunk_id=key, vector_item=vector_item)
             response = await self.client.put(
                 f"{self.base_url}/rest/v3/caches/{self.cache_name}/entries/{key}",
                 json=vector_item,
@@ -182,7 +182,7 @@ class InfinispanIndex(EmbeddingIndex):
             )
 
             if response.status_code not in [200, 204]:
-                log.error(f"Failed to insert chunk {key}: {response.status_code} - {response.text}")
+                log.error("Failed to insert chunk", chunk_id=key, status_code=response.status_code)
                 response.raise_for_status()
 
         log.info(f"Successfully inserted {len(chunks)} chunks")
@@ -210,7 +210,7 @@ class InfinispanIndex(EmbeddingIndex):
 
             if response.status_code not in [200, 204, 404]:
                 # 404 is acceptable - chunk may not exist
-                log.error(f"Failed to delete chunk {key}: {response.status_code} - {response.text}")
+                log.error("Failed to delete chunk", chunk_id=key, status_code=response.status_code)
                 response.raise_for_status()
 
         log.info(f"Successfully deleted {len(chunks_for_deletion)} chunks")
@@ -253,7 +253,7 @@ class InfinispanIndex(EmbeddingIndex):
         )
 
         if response.status_code != 200:
-            log.error(f"Vector search query failed: {response.status_code} - {response.text}")
+            log.error("Vector search query failed", status_code=response.status_code)
             response.raise_for_status()
 
         # Parse search results
@@ -281,7 +281,12 @@ class InfinispanIndex(EmbeddingIndex):
             embedding_model = hit_data.get("embeddingModel", "unknown")
 
             if not chunk_id or not float_vector:
-                log.warning(f"Skipping incomplete hit: {hit_data}")
+                log.warning(
+                    "Skipping incomplete hit",
+                    hit_id=hit_data.get("id"),
+                    has_text=bool(hit_data.get("text")),
+                    has_vector=bool(hit_data.get("floatVector")),
+                )
                 continue
 
             # Deserialize metadata
@@ -352,7 +357,7 @@ class InfinispanIndex(EmbeddingIndex):
         if filters is not None:
             raise NotImplementedError("Infinispan provider does not yet support native filtering")
 
-        log.info(f"Performing keyword search in cache '{self.cache_name}' with query: {query_string}")
+        log.debug("Performing keyword search", cache_name=self.cache_name, query=query_string)
 
         # Build Ickle query to search the text field
         # The text field has @Keyword annotation, so it's indexed for full-text search
@@ -369,7 +374,7 @@ class InfinispanIndex(EmbeddingIndex):
         )
 
         if response.status_code != 200:
-            log.error(f"Search query failed: {response.status_code} - {response.text}")
+            log.error("Search query failed", status_code=response.status_code)
             response.raise_for_status()
 
         # Parse search results
@@ -397,7 +402,12 @@ class InfinispanIndex(EmbeddingIndex):
             embedding_model = hit_data.get("embeddingModel", "unknown")
 
             if not chunk_id or not float_vector:
-                log.warning(f"Skipping incomplete hit: {hit_data}")
+                log.warning(
+                    "Skipping incomplete hit",
+                    hit_id=hit_data.get("id"),
+                    has_text=bool(hit_data.get("text")),
+                    has_vector=bool(hit_data.get("floatVector")),
+                )
                 continue
 
             # Deserialize metadata
@@ -428,8 +438,11 @@ class InfinispanIndex(EmbeddingIndex):
 
             try:
                 chunk = load_embedded_chunk_with_backward_compat(chunk_dict)
-                log.info(
-                    f"Hit content - ID: {chunk_id}, Text: {text[:100]}{'...' if len(text) > 100 else ''}, Vector dim: {len(float_vector)}"
+                log.debug(
+                    "Loaded search hit",
+                    chunk_id=chunk_id,
+                    text_preview=text[:100],
+                    vector_dimension=len(float_vector),
                 )
             except Exception as e:
                 log.error(f"Failed to load chunk {chunk_id}: {e}")
@@ -532,7 +545,7 @@ class InfinispanIndex(EmbeddingIndex):
         response = await self.client.delete(f"{self.base_url}/rest/v3/caches/{self.cache_name}")
 
         if response.status_code not in [200, 204]:
-            log.error(f"Failed to delete cache '{self.cache_name}': {response.status_code} - {response.text}")
+            log.error("Failed to delete cache", cache_name=self.cache_name, status_code=response.status_code)
             response.raise_for_status()
 
         log.info(f"Cache '{self.cache_name}' deleted successfully")

--- a/src/ogx/providers/remote/vector_io/weaviate/weaviate.py
+++ b/src/ogx/providers/remote/vector_io/weaviate/weaviate.py
@@ -131,7 +131,7 @@ class WeaviateIndex(EmbeddingIndex):
                 chunk_dict = json.loads(chunk_json)
                 chunk = load_embedded_chunk_with_backward_compat(chunk_dict)
             except Exception:
-                log.exception(f"Failed to parse document: {chunk_json}")
+                log.exception("Failed to parse document", chunk_content_length=len(chunk_json))
                 continue
 
             if doc.metadata.distance is None:
@@ -201,7 +201,7 @@ class WeaviateIndex(EmbeddingIndex):
                 chunk_dict = json.loads(chunk_json)
                 chunk = load_embedded_chunk_with_backward_compat(chunk_dict)
             except Exception:
-                log.exception(f"Failed to parse document: {chunk_json}")
+                log.exception("Failed to parse document", chunk_content_length=len(chunk_json))
                 continue
 
             score = doc.metadata.score if doc.metadata.score is not None else 0.0
@@ -275,7 +275,7 @@ class WeaviateIndex(EmbeddingIndex):
                 chunk_dict = json.loads(chunk_json)
                 chunk = load_embedded_chunk_with_backward_compat(chunk_dict)
             except Exception:
-                log.exception(f"Failed to parse document: {chunk_json}")
+                log.exception("Failed to parse document", chunk_content_length=len(chunk_json))
                 continue
 
             score = doc.metadata.score if doc.metadata.score is not None else 0.0

--- a/src/ogx/providers/utils/memory/vector_store.py
+++ b/src/ogx/providers/utils/memory/vector_store.py
@@ -360,7 +360,7 @@ class VectorStoreWithIndex:
             reranker_params["neural_weights"] = params["neural_weights"]
 
         query_string = interleaved_content_as_str(request.query)
-        log.info(f"query_chunks(): query={query_string!r}, mode={mode}, k={k}, reranker_type={reranker_type}")
+        log.debug("query_chunks", query=query_string, mode=mode, k=k, reranker_type=reranker_type)
 
         if mode == "keyword":
             response = await self.index.query_keyword(query_string, k, score_threshold, filters)
@@ -386,11 +386,15 @@ class VectorStoreWithIndex:
             else:
                 response = await self.index.query_vector(query_vector, k, score_threshold, filters)
 
-        log.info(f"query_chunks(): retrieved {len(response.chunks)} chunks before neural reranking")
+        log.debug("query_chunks retrieved chunks before neural reranking", chunks_count=len(response.chunks))
         for i, (chunk, score) in enumerate(zip(response.chunks, response.scores, strict=False)):
             preview = chunk.content[:120] if isinstance(chunk.content, str) else str(chunk.content)[:120]
-            log.info(
-                f"Chunk {i}: score={score:.4f} doc_id={chunk.metadata.get('document_id', 'N/A')} content={preview!r}"
+            log.debug(
+                "Retrieved chunk preview",
+                chunk_index=i,
+                score=f"{score:.4f}",
+                document_id=chunk.metadata.get("document_id", "N/A"),
+                content=preview,
             )
 
         # Apply neural reranking if enabled
@@ -445,7 +449,7 @@ class VectorStoreWithIndex:
             log.error(f"Neural reranking failed: {e}. Returning original results.")
             return response
 
-        log.info(f"Rerank Response: {rerank_response.data}")
+        log.debug("Rerank response", data=rerank_response.data)
 
         # Reorder chunks and scores based on neural rerank results
         reranked_chunks = []
@@ -458,8 +462,12 @@ class VectorStoreWithIndex:
         log.info(f"Neural rerank: reranked {len(reranked_chunks)} chunks using model={reranker_model}")
         for i, (chunk, score) in enumerate(zip(reranked_chunks, reranked_scores, strict=False)):
             preview = chunk.content[:120] if isinstance(chunk.content, str) else str(chunk.content)[:120]
-            log.info(
-                f"Chunk {i}: relevance_score={score:.4f} doc_id={chunk.metadata.get('document_id', 'N/A')} content={preview!r}"
+            log.debug(
+                "Reranked chunk preview",
+                chunk_index=i,
+                relevance_score=f"{score:.4f}",
+                document_id=chunk.metadata.get("document_id", "N/A"),
+                content=preview,
             )
 
         return QueryChunksResponse(chunks=reranked_chunks, scores=reranked_scores)


### PR DESCRIPTION
## Summary

- Moves payload-bearing vector search, rerank, and guardrail logs from info to debug.
- Removes provider response bodies from passthrough error logs and Infinispan error logs.
- Avoids logging full Weaviate chunk JSON and incomplete Infinispan hit payloads at warning/error levels.

## Why

OGX should support privacy-sensitive and zero-retention-style deployments where ordinary logs do not retain user queries, retrieved document text, provider error echoes, or guardrail violation payloads. Payload previews are now only emitted at debug level where they remain useful for explicit troubleshooting.

## Validation

- `uv run ruff check src/ogx/providers/utils/memory/vector_store.py src/ogx/providers/remote/vector_io/infinispan/infinispan.py src/ogx/providers/remote/vector_io/weaviate/weaviate.py src/ogx/providers/inline/interactions/impl.py src/ogx/providers/inline/responses/builtin/responses/streaming.py`
- Commit hook suite passed, including ruff, ruff format, mypy, logging hooks, and API/codegen checks that applied to the touched files.