### PR TITLE
docs: add Skills API to README, ARCHITECTURE, and provider docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,7 +115,7 @@ The full list of auto-routed pairs is defined in `builtin_automatically_routed_a
 
 The `ogx_api` package defines all public-facing types and protocols:
 
-- **Protocols** -- Python `Protocol` classes like `Inference`, `Responses` that define the API contract. HTTP routes are defined via FastAPI routers in `fastapi_routes.py` modules.
+- **Protocols** -- Python `Protocol` classes like `Inference`, `Responses`, `Skills` that define the API contract. HTTP routes are defined via FastAPI routers in `fastapi_routes.py` modules.
 - **Data Types** -- Pydantic models for requests, responses, and resources (e.g., `Model`, `VectorStore`, `ChatCompletionRequest`).
 - **Provider Specs** -- `InlineProviderSpec`, `RemoteProviderSpec`, and related types that define how providers are declared.
 - **Internal utilities** -- KVStore and SqlStore abstract interfaces live here so third-party providers can use them without depending on the full server.
@@ -152,7 +152,7 @@ storage:
 | PostgreSQL| `PostgresKVStoreConfig`  | Production deployments |
 | MongoDB   | `MongoDBKVStoreConfig`   | Document-oriented      |
 
-Used by: distribution registry, quota tracking, provider state.
+Used by: distribution registry, quota tracking, provider state, skills metadata.
 
 ### SqlStore
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ response = client.chat.completions.create(
 - **Responses API** — server-side agentic orchestration with tool calling, MCP server integration, and built-in file search (RAG) in a single API call ([learn more](https://ogx-ai.github.io/docs/api-openai))
 - **Vector Stores & Files** — `/v1/vector_stores` and `/v1/files` for managed document storage and search
 - **Batches** — `/v1/batches` for offline batch processing
+- **Skills** — `/v1alpha/skills` for managing versioned skill bundles (zip archives with SKILL.md manifests) that agents can invoke
 - **[Open Responses](https://www.openresponses.org/) conformant** — the Responses API implementation passes the Open Responses conformance test suite
 - **Multi-SDK support** — use the [Anthropic SDK](https://docs.anthropic.com/en/api/messages) (`/v1/messages`) or [Google GenAI SDK](https://ai.google.dev/gemini-api/docs/interactions) (`/v1alpha/interactions`) natively alongside the OpenAI API
 

--- a/src/ogx/providers/inline/README.md
+++ b/src/ogx/providers/inline/README.md
@@ -14,6 +14,7 @@ inline/
   tool_runtime/        # Tool runtime (RAG context retrieval)
   files/               # File storage and management
   file_processor/      # File processing (text extraction, etc.)
+  skills/              # Skills API (versioned skill bundle management)
   __init__.py
 ```
 
@@ -29,3 +30,4 @@ Their factory function is typically named `get_provider_impl()` and returns an i
 - **`inference/sentence_transformers`** -- Runs embedding models using the sentence-transformers library.
 - **`inference/transformers`** -- Runs Llama models locally using the transformers library.
 - **`vector_io/sqlite_vec`** -- SQLite-based vector storage using the sqlite-vec extension.
+- **`skills/builtin`** -- Manages versioned skill bundles (zip archives with SKILL.md manifests). Stores bundles via the Files API and metadata in KVStore.

--- a/src/ogx/providers/registry/README.md
+++ b/src/ogx/providers/registry/README.md
@@ -13,6 +13,7 @@ registry/
   inference.py         # Inference providers (20+ remote + 2 inline)
   interactions.py      # Interaction providers
   responses.py         # Responses API providers (inline::builtin)
+  skills.py            # Skills API providers (inline::builtin)
   tool_runtime.py      # Tool runtime providers
   vector_io.py         # Vector I/O providers
 ```


### PR DESCRIPTION
## Summary

- Add Skills (`/v1alpha/skills`) to the README "What you get" list
- Mention `Skills` protocol in ARCHITECTURE.md API layer section
- Add `skills/builtin` to inline providers README directory listing and key providers
- Add `skills.py` to registry README directory listing

Ref: https://github.com/ogx-ai/ogx/issues/5891

Signed-off-by: Varsha Prasad Narsing <varshaprasad96@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)