### PR TITLE
feat(benchmarking): add API latency comparison experiment pipeline

### DIFF
--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/benchmarking/api_latency_comparison/README.md
+++ b/benchmarking/api_latency_comparison/README.md
@@ -1,0 +1,80 @@
+# API Latency Comparison Benchmark
+
+Measures per-request latency of two OGX versions under a controlled
+agentic workload. Compares an older release against a newer commit by
+running both through a mocked agentic workload and recording
+per-request response times.
+
+Analysis and model fitting are added in a follow-up PR.
+
+## Overview
+
+The experiment is a randomized complete block design with three trials
+(treatment combinations). Each trial is replicated multiple times, and
+each replicate is a **run**: one row in the design matrix. The design
+matrix generator randomizes run order to guard against temporal
+confounding.
+
+The three trials are:
+
+- **Baseline**: the older version (e.g., latest release tag)
+- **Comparison**: the newer version under test
+- **Comparison control**: same commit as comparison, run independently as
+  a negative control for false positive detection
+
+Each run starts a fresh OGX server against a mock backend, sends
+agentic requests (with web_search tool calls) via Locust for a fixed
+duration, and records per-request latencies. The false positive
+detection runs the negative control (same code as comparison, run
+independently) to verify the experiment isn't producing spurious
+differences.
+
+Components:
+
+- **Mock server** (`experiment/mock_server.py`): canned OpenAI + Brave Search responses
+- **Locust** (`experiment/locustfile_responses.py`): load generator, 1 concurrent user
+- **Experiment orchestrator** (`experiment/benchmark.py`): run execution with CPU pinning
+- **Worktree setup** (`experiment/setup-worktree.sh`): isolated git worktrees per version
+- **Design matrix** (`experiment/generate_design_matrix.py`): randomized experiment design
+
+## Prerequisites
+
+```bash
+# Benchmark experiment dependencies (Locust, mirakuru)
+uv sync --group api-latency-comparison
+```
+
+## Quick Start
+
+The orchestrator handles worktree setup, matrix generation, and
+experiment execution in one command:
+
+```bash
+uv run python -m benchmarking.api_latency_comparison.experiment.benchmark \
+  --baseline-ref v1.1.0 --comparison-ref HEAD --replicates 5
+```
+
+Output lands in an auto-timestamped directory under `results/`.
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `RESULTS_DIR` | auto-timestamped | Where to write results |
+| `MATRIX_CSV` | `$RESULTS_DIR/experiment-matrix.csv` | Experiment matrix |
+| `RUN_DURATION` | 10 | Seconds per run |
+| `MOCK_PORT` | 8080 | Mock server port |
+| `STACK_PORT` | 8321 | OGX server port |
+| `CPU_OGX` | 0 | Core for OGX server |
+| `CPU_LOCUST` | 1 | Core for Locust |
+| `CPU_MOCK` | 2 | Core for mock server |
+
+## Implementation Notes
+
+**CPU pinning**: Processes are pinned via `os.sched_setaffinity()` in
+`preexec_fn` callbacks, applied at fork before exec. Pinning is verified
+per run via `os.sched_getaffinity(pid)` after each server start.
+
+**Brave Search patching**: Older OGX versions don't have the `base_url`
+field on `BraveSearchToolConfig`. The setup script patches it via `sed`
+so the mock server can serve search results locally.

--- a/benchmarking/api_latency_comparison/configs/stack-config-benchmark.yaml
+++ b/benchmarking/api_latency_comparison/configs/stack-config-benchmark.yaml
@@ -1,0 +1,70 @@
+version: 2
+distro_name: vertical-scaling-responses-agentic
+apis:
+- inference
+- responses
+- vector_io
+- tool_runtime
+- files
+providers:
+  inference:
+  - provider_id: openai
+    provider_type: remote::openai
+    config:
+      api_key: ${env.OPENAI_API_KEY:=fake-token}
+      base_url: ${env.OPENAI_BASE_URL:=http://localhost:8080/v1}
+  responses:
+  - provider_id: builtin
+    provider_type: inline::builtin
+    config:
+      persistence:
+        agent_state:
+          namespace: agents
+          backend: kv_default
+        responses:
+          table_name: responses
+          backend: sql_default
+  vector_io:
+  - provider_id: faiss
+    provider_type: inline::faiss
+    config:
+      kvstore:
+        namespace: vector_io::faiss
+        backend: kv_default
+      persistence:
+        namespace: vector_io::faiss_persistence
+        backend: kv_default
+  tool_runtime:
+  - provider_id: brave-search
+    provider_type: remote::brave-search
+    config:
+      api_key: "fake-benchmark-key"
+      max_results: 1
+      base_url: ${env.MOCK_SEARCH_URL:=http://localhost:8080}
+  files:
+  - provider_id: builtin-files
+    provider_type: inline::localfs
+    config:
+      storage_dir: /tmp/ogx-benchmark/files
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
+storage:
+  backends:
+    kv_default:
+      type: kv_sqlite
+      db_path: /tmp/ogx-benchmark/kvstore.db
+    sql_default:
+      type: sql_sqlite
+      db_path: /tmp/ogx-benchmark/sql_store.db
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+registered_resources:
+  models:
+  - model_id: mock-model
+    provider_id: openai
+    model_type: llm
+server:
+  port: 8321

--- a/benchmarking/api_latency_comparison/experiment/__init__.py
+++ b/benchmarking/api_latency_comparison/experiment/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/benchmarking/api_latency_comparison/experiment/benchmark.py
+++ b/benchmarking/api_latency_comparison/experiment/benchmark.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Benchmark experiment orchestrator.
+
+Iterates a design matrix, starts servers per run, runs Locust,
+collects latency data. Each run is fully independent.
+
+Usage:
+  uv run python experiment/benchmark.py --baseline-ref v1.0.2 --comparison-ref HEAD
+"""
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import traceback
+import urllib.request
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from mirakuru import HTTPExecutor
+
+from benchmarking.api_latency_comparison.experiment.generate_design_matrix import (
+    find_latest_release_tag,
+    generate_matrix,
+    resolve_version_hash,
+)
+from benchmarking.api_latency_comparison.experiment.preflight import (
+    PreflightError,
+    log,
+    record_environment,
+    run_all_checks,
+)
+from benchmarking.api_latency_comparison.experiment.runlog import RunLogEntry, append_run_log, load_completed_runs
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+PROJECT_DIR = SCRIPT_DIR.parent
+REPO_ROOT = (PROJECT_DIR / ".." / "..").resolve()
+BASELINE_LABEL = "baseline"
+COMPARISON_LABEL = "comparison"
+
+
+class PinnedHTTPExecutor(HTTPExecutor):
+    def __init__(self, *args: Any, cpu_affinity: set[int] | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._cpu_affinity = cpu_affinity
+
+    @property
+    def _popen_kwargs(self) -> dict[str, Any]:
+        kwargs = super()._popen_kwargs
+        if self._cpu_affinity is not None:
+            affinity = self._cpu_affinity
+
+            def pinned_preexec():
+                os.setsid()
+                os.sched_setaffinity(0, affinity)
+
+            kwargs["preexec_fn"] = pinned_preexec
+        return kwargs
+
+
+def _get_worktree_dir(cfg: dict[str, Any], version_label: str) -> Path:
+    if version_label == BASELINE_LABEL:
+        return Path(cfg["worktree_base"]) / BASELINE_LABEL
+    return Path(cfg["worktree_base"]) / COMPARISON_LABEL
+
+
+def _clear_ogx_state() -> None:
+    """Remove SQLite DBs and file cache from /tmp/ogx-benchmark."""
+    for f in ["/tmp/ogx-benchmark/kvstore.db", "/tmp/ogx-benchmark/sql_store.db"]:  # noqa: S108
+        try:
+            os.unlink(f)
+        except FileNotFoundError:
+            pass
+    shutil.rmtree("/tmp/ogx-benchmark/files", ignore_errors=True)  # noqa: S108
+
+
+def _verify_cpu_pinning(pid: int, expected_core: int, name: str) -> None:
+    try:
+        actual = os.sched_getaffinity(pid)
+        if actual == {expected_core}:
+            log(f"  {name} (PID {pid}) pinned to core {expected_core}")
+        else:
+            log(f"  WARNING: {name} (PID {pid}) expected core {{{expected_core}}}, got {actual}")
+    except OSError:
+        pass
+
+
+@contextmanager
+def _servers(cfg: dict[str, Any], version: str, ogx_log_path: Path) -> Generator[None, None, None]:
+    """Context manager that starts mock + OGX servers for one run."""
+    with _mock_server_executor(cfg, version) as mock_exec:
+        if cfg["taskset_available"] and mock_exec.process is not None:
+            _verify_cpu_pinning(mock_exec.process.pid, cfg["cpu_mock"], "mock")
+        with _ogx_server_executor(cfg, version, ogx_log_path) as ogx_exec:  # noqa: SIM117
+            if cfg["taskset_available"] and ogx_exec.process is not None:
+                _verify_cpu_pinning(ogx_exec.process.pid, cfg["cpu_ogx"], "OGX")
+            _reset_mock(cfg)
+            yield
+
+
+def _make_executor(cmd: list[str], kwargs: dict[str, Any], cfg: dict[str, Any], cpu_key: str) -> HTTPExecutor:
+    """Create an HTTPExecutor, optionally with CPU pinning."""
+    if cfg["taskset_available"]:
+        return PinnedHTTPExecutor(cmd, cpu_affinity={cfg[cpu_key]}, **kwargs)
+    return HTTPExecutor(cmd, **kwargs)
+
+
+def _mock_server_executor(cfg: dict[str, Any], version_label: str) -> HTTPExecutor:
+    wt_dir = _get_worktree_dir(cfg, version_label)
+    cmd = [sys.executable, str(SCRIPT_DIR / "mock_server.py"), str(cfg["mock_port"])]
+    kwargs = dict(
+        url=f"http://localhost:{cfg['mock_port']}/v1/health",
+        method="GET",
+        timeout=10,
+        cwd=str(wt_dir),
+        expected_returncode=-signal.SIGTERM,
+    )
+    return _make_executor(cmd, kwargs, cfg, "cpu_mock")
+
+
+@contextmanager
+def _ogx_server_executor(
+    cfg: dict[str, Any], version_label: str, log_path: Path
+) -> Generator[HTTPExecutor, None, None]:
+    wt_dir = _get_worktree_dir(cfg, version_label)
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "ogx.core.server.server:create_app",
+        "--port",
+        str(cfg["stack_port"]),
+        "--factory",
+    ]
+    with open(log_path, "a") as log_file:
+        kwargs = dict(
+            url=f"http://localhost:{cfg['stack_port']}/v1/health",
+            method="GET",
+            timeout=30,
+            cwd=str(wt_dir),
+            envvars={
+                "OPENAI_BASE_URL": f"http://localhost:{cfg['mock_port']}/v1",
+                "OPENAI_API_KEY": "fake-token",
+                "OGX_CONFIG": str(PROJECT_DIR / "configs" / "stack-config-benchmark.yaml"),
+            },
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            expected_returncode=-signal.SIGTERM,
+        )
+        with _make_executor(cmd, kwargs, cfg, "cpu_ogx") as executor:
+            yield executor
+
+
+def _reset_mock(cfg: dict[str, Any]) -> None:
+    """POST /reset to the mock server to zero its counters."""
+    req = urllib.request.Request(f"http://localhost:{cfg['mock_port']}/reset", method="POST")
+    try:
+        urllib.request.urlopen(req, timeout=2)  # noqa: S310
+    except Exception:
+        time.sleep(0.5)
+        urllib.request.urlopen(req, timeout=2)  # noqa: S310
+
+
+def _run_locust(cfg: dict[str, Any], row: dict[str, Any], results_dir: Path) -> tuple[int, Path]:
+    """Run a single Locust session, return (exit_code, request_csv_path)."""
+    run_id = row["run"]
+    rd = results_dir / "runs" / str(run_id)
+    rd.mkdir(parents=True, exist_ok=True)
+    request_csv = rd / "requests.csv"
+    locust_log = rd / "locust.log"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "locust",
+        "-f",
+        str(SCRIPT_DIR / "locustfile_responses.py"),
+        "--headless",
+        "-u",
+        "1",
+        "-r",
+        "1",
+        "--run-time",
+        f"{cfg['run_duration']}s",
+        "--host",
+        f"http://localhost:{cfg['stack_port']}",
+    ]
+
+    env = os.environ.copy()
+    env["BENCHMARK_MODE"] = row.get("benchmark_mode", "agentic")
+    env["REQUEST_LOG"] = str(request_csv)
+
+    run_kwargs = {}
+    if cfg["taskset_available"]:
+        affinity = {cfg["cpu_locust"]}
+
+        def pinned_preexec():
+            os.sched_setaffinity(0, affinity)
+
+        run_kwargs["preexec_fn"] = pinned_preexec
+
+    with open(locust_log, "w") as lf:
+        result = subprocess.run(cmd, env=env, stdout=lf, stderr=subprocess.STDOUT, **run_kwargs)  # noqa: S603
+
+    return result.returncode, request_csv
+
+
+def _validate_agentic_loop(cfg: dict[str, Any]) -> None:
+    """Verify the agentic loop fires (web_search_call in response)."""
+    log("Validating agentic loop...")
+    _reset_mock(cfg)
+
+    payload = json.dumps(
+        {
+            "model": "openai/mock-model",
+            "input": "agentic loop check",
+            "tools": [{"type": "web_search"}],
+            "stream": False,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"http://localhost:{cfg['stack_port']}/v1/responses",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    resp = urllib.request.urlopen(req, timeout=30)  # noqa: S310
+    data = json.loads(resp.read())
+    types = [item.get("type") for item in data.get("output", [])]
+    if "web_search_call" not in types:
+        raise RuntimeError(f"Agentic loop not firing: output types = {types}")
+
+    stats = json.loads(urllib.request.urlopen(f"http://localhost:{cfg['mock_port']}/stats", timeout=2).read())
+    search_count = stats.get("get_search_count", 0)
+    if search_count >= 1:
+        log(f"  Agentic loop validated: search_count={search_count}")
+    else:
+        log(f"WARNING: Mock search endpoint not called (search_count={search_count})")
+
+
+def run_preflight_benchmark(cfg: dict[str, Any], results_dir: Path) -> None:
+    """Start servers, run a short benchmark, validate agentic loop."""
+    log("=== Pre-Flight Benchmark ===")
+
+    baseline = BASELINE_LABEL
+    _clear_ogx_state()
+
+    preflight_dir = results_dir / "runs" / "preflight"
+    preflight_dir.mkdir(parents=True, exist_ok=True)
+    with _servers(cfg, baseline, preflight_dir / "ogx.log"):
+        _validate_agentic_loop(cfg)
+        log("  Pre-flight benchmark passed")
+
+
+def _record_run(
+    results_dir: Path,
+    row: dict[str, Any],
+    run_id: int,
+    version: str,
+    start: int,
+    end: int,
+    n_requests: int,
+    status: str,
+) -> None:
+    entry = RunLogEntry(
+        run=run_id,
+        version_label=version,
+        version_hash=row["version_hash"],
+        replicate=row["replicate"],
+        benchmark_mode=row.get("benchmark_mode", "agentic"),
+        mock_tool_call_count=row.get("mock_tool_call_count", 1),
+        start_time=start,
+        end_time=end,
+        duration_s=end - start,
+        requests_completed=n_requests,
+        status=status,
+    )
+    append_run_log(results_dir / "run-log.csv", entry)
+
+
+def run_experiment(cfg: dict[str, Any], results_dir: Path | str, matrix_csv: Path) -> None:
+    """Main experiment loop."""
+    results_dir = Path(results_dir)
+    (results_dir / "runs").mkdir(parents=True, exist_ok=True)
+    taskset = run_all_checks(
+        str(results_dir),
+        str(matrix_csv),
+        cfg["worktree_base"],
+        BASELINE_LABEL,
+        COMPARISON_LABEL,
+        cfg["mock_port"],
+        cfg["stack_port"],
+    )
+    cfg["taskset_available"] = taskset
+
+    cfg["repo_root"] = str(REPO_ROOT)
+    cfg["baseline_label"] = BASELINE_LABEL
+    cfg["comparison_label"] = COMPARISON_LABEL
+    record_environment(cfg, str(results_dir))
+
+    run_preflight_benchmark(cfg, results_dir)
+
+    matrix = pd.read_csv(matrix_csv).to_dict("records")
+    run_log = results_dir / "run-log.csv"
+    completed = load_completed_runs(run_log) if run_log.exists() else set()
+    total_runs = len(matrix)
+    failed_runs = 0
+    start_time = time.time()
+
+    log(f"Matrix: {total_runs} runs ({len(completed)} already completed)")
+
+    interrupted = False
+
+    def handle_signal(signum: int, frame: Any) -> None:
+        nonlocal interrupted
+        interrupted = True
+        log("\n=== INTERRUPTED ===")
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    for i, row in enumerate(matrix, 1):
+        if interrupted:
+            break
+
+        run_id = row["run"]
+        if run_id in completed:
+            continue
+
+        version = row["version_label"]
+        log(f"--- Run {i}/{total_runs}: run={run_id} version={version} rep={row['replicate']} ---")
+
+        _clear_ogx_state()
+        run_start = int(time.time())
+
+        try:
+            rd = results_dir / "runs" / str(run_id)
+            rd.mkdir(parents=True, exist_ok=True)
+            with _servers(cfg, version, rd / "ogx.log"):
+                exit_code, request_csv = _run_locust(cfg, row, results_dir)
+                if request_csv.exists():
+                    with open(request_csv) as f:
+                        n_requests = sum(1 for _ in f) - 1
+                else:
+                    n_requests = 0
+
+            run_end = int(time.time())
+
+            if n_requests == 0:
+                status = "locust_crash" if exit_code != 0 else "error"
+                log(f"  WARNING: {status} (exit={exit_code}, 0 requests)")
+                failed_runs += 1
+            else:
+                status = "ok"
+                if exit_code != 0:
+                    log(f"  WARNING: Locust exited {exit_code} but produced {n_requests} requests")
+
+            _record_run(results_dir, row, run_id, version, run_start, run_end, n_requests, status)
+            log(f"  Result: {n_requests} reqs, status={status}")
+
+        except Exception as e:
+            run_end = int(time.time())
+            log(f"  ERROR: {e}\n{traceback.format_exc()}")
+            failed_runs += 1
+            _record_run(results_dir, row, run_id, version, run_start, run_end, 0, "error")
+
+    total_duration = int(time.time() - start_time)
+    total_ok = len(load_completed_runs(run_log) if run_log.exists() else set())
+
+    log("")
+    log("=== Benchmark Complete ===")
+    log(f"  Total elapsed: {total_duration // 60}m {total_duration % 60}s")
+    log(f"  Runs: {total_ok} ok, {failed_runs} error")
+
+    if interrupted:
+        log("\nExperiment was interrupted. Resume with the same command.")
+        raise KeyboardInterrupt
+
+
+def setup_and_generate(results_dir: Path, baseline_ref: str | None, comparison_ref: str, replicates: int) -> Path:
+    """Resolve refs, setup worktrees, generate design matrix. Returns matrix CSV path."""
+    baseline_ref = baseline_ref or find_latest_release_tag()
+
+    log("Setting up worktrees...")
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "bash",
+            str(SCRIPT_DIR / "setup-worktree.sh"),
+            "--repo",
+            str(REPO_ROOT),
+            "--baseline",
+            baseline_ref,
+            "--baseline-label",
+            BASELINE_LABEL,
+            "--comparison",
+            comparison_ref,
+            "--comparison-label",
+            COMPARISON_LABEL,
+        ],
+        check=True,
+    )
+
+    log("Generating design matrix...")
+    baseline_hash = resolve_version_hash(baseline_ref)
+    comparison_hash = resolve_version_hash(comparison_ref)
+    versions = [
+        {"label": BASELINE_LABEL, "hash": baseline_hash},
+        {"label": COMPARISON_LABEL, "hash": comparison_hash},
+        {"label": f"{COMPARISON_LABEL}_ctrl", "hash": comparison_hash},
+    ]
+    rows = generate_matrix(versions, replicates, seed=42)
+    matrix_path = results_dir / "experiment-matrix.csv"
+    pd.DataFrame(rows).to_csv(matrix_path, index=False)
+    log(f"  Wrote: {matrix_path} ({len(rows)} runs)")
+
+    return matrix_path
+
+
+def cleanup_worktrees(cfg: dict[str, Any]) -> None:
+    for label in [BASELINE_LABEL, COMPARISON_LABEL]:
+        shutil.rmtree(f"{cfg['worktree_base']}/{label}", ignore_errors=True)
+    subprocess.run(["git", "-C", str(REPO_ROOT), "worktree", "prune"], capture_output=True)  # noqa: S603, S607
+
+
+def run_benchmark(
+    cfg: dict[str, Any], results_dir: Path | str, baseline_ref: str | None, comparison_ref: str, replicates: int
+) -> None:
+    results_dir = Path(results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    matrix_csv = setup_and_generate(results_dir, baseline_ref, comparison_ref, replicates)
+    run_experiment(cfg, results_dir, matrix_csv)
+
+
+def _default_config() -> dict[str, Any]:
+    return {
+        "worktree_base": os.environ.get("WORKTREE_BASE", "/tmp/ci-validation"),  # noqa: S108
+        "run_duration": int(os.environ.get("RUN_DURATION", "10")),
+        "mock_port": int(os.environ.get("MOCK_PORT", "8080")),
+        "stack_port": int(os.environ.get("STACK_PORT", "8321")),
+        "seed": os.environ.get("SEED", "42"),
+        "cpu_ogx": int(os.environ.get("CPU_OGX", "0")),
+        "cpu_locust": int(os.environ.get("CPU_LOCUST", "1")),
+        "cpu_mock": int(os.environ.get("CPU_MOCK", "2")),
+        "taskset_available": True,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark experiment orchestrator")
+    parser.add_argument("--baseline-ref", default=None, help="Baseline git ref (default: latest release tag)")
+    parser.add_argument("--comparison-ref", default="HEAD", help="Comparison git ref (default: HEAD)")
+    parser.add_argument("--replicates", type=int, default=3, help="Replicates per group (default: 3)")
+    parser.add_argument("--run-duration", type=int, default=10, help="Seconds per run (default: 10)")
+    parser.add_argument("--results-dir", help="Results directory (default: auto-timestamped)")
+    args = parser.parse_args()
+
+    cfg = _default_config()
+    cfg["run_duration"] = args.run_duration
+
+    if args.results_dir:
+        results_dir = Path(args.results_dir)
+    else:
+        ts = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+        results_dir = REPO_ROOT / "results" / f"api-latency-{ts}"
+
+    log("=== Benchmark Experiment ===")
+    log(f"  Results: {results_dir}")
+    log(f"  Duration: {cfg['run_duration']}s per run")
+
+    try:
+        run_benchmark(cfg, results_dir, args.baseline_ref, args.comparison_ref, args.replicates)
+    except (PreflightError, ValueError) as e:
+        log(f"ERROR: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+    finally:
+        cleanup_worktrees(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/api_latency_comparison/experiment/generate_design_matrix.py
+++ b/benchmarking/api_latency_comparison/experiment/generate_design_matrix.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Generate randomized experiment matrices for CI regression benchmarking.
+
+Generates a CSV with one row per run, randomized across version groups.
+Each version group gets the specified number of replicates.
+"""
+
+import argparse
+import os
+import random
+import subprocess
+import sys
+from typing import Any
+
+import pandas as pd
+
+
+def _git(args: list[str], git_dir: str | None = None) -> subprocess.CompletedProcess[str]:
+    cmd = ["git"]
+    if git_dir:
+        cmd.extend(["-C", git_dir])
+    cmd.extend(args)
+    return subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+
+
+def find_latest_release_tag(git_dir: str | None = None) -> str:
+    result = _git(["tag", "--sort=-v:refname"], git_dir)
+    for line in result.stdout.splitlines():
+        tag = line.strip()
+        if tag and tag[0] == "v" and tag.count(".") == 2:
+            print(f"  Latest release tag: {tag}", flush=True)
+            return tag
+    raise ValueError("no release tags found (vX.Y.Z)")
+
+
+def resolve_version_hash(label: str, git_dir: str | None = None) -> str:
+    """Use git rev-parse to turn a tag, branch, or short hash into a full SHA for immutable experiment metadata."""
+    result = _git(["rev-parse", label], git_dir)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    result = _git(["rev-parse", f"origin/{label}"], git_dir)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    msg = f"could not resolve git ref '{label}'"
+    if git_dir:
+        msg += f" (in repo: {git_dir})"
+    raise ValueError(msg)
+
+
+def generate_matrix(versions: list[dict[str, str]], replicates: int, seed: int) -> list[dict[str, Any]]:
+    """Generate RCBD experiment design matrix.
+
+    Randomized Complete Block Design: each block contains exactly one
+    run of each version in a random order. Blocks are in temporal
+    sequence (block 1 runs first). Within-block randomization prevents
+    position effects from aliasing with treatment effects.
+
+    Args:
+        versions: list of {"label": str, "hash": str}
+        replicates: number of blocks (one replicate per version per block)
+        seed: random seed for within-block randomization
+    """
+    rng = random.Random(seed)
+    all_rows = []
+    for block in range(1, replicates + 1):
+        block_rows = []
+        for ver in versions:
+            block_rows.append(
+                {
+                    "version_hash": ver["hash"],
+                    "version_label": ver["label"],
+                    "run": 0,
+                    "replicate": block,
+                    "block": block,
+                    "benchmark_mode": "agentic",
+                    "mock_tool_call_count": 1,
+                }
+            )
+        rng.shuffle(block_rows)
+        all_rows.extend(block_rows)
+
+    for i, row in enumerate(all_rows):
+        row["run"] = i
+
+    return all_rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate experiment matrices for CI regression benchmarking")
+    parser.add_argument(
+        "--versions", default=None, help="Comma-separated version labels (omit to use --baseline-ref/--comparison-ref)"
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    parser.add_argument("--replicates", type=int, default=1, help="Replicates per cell (default: 1)")
+    parser.add_argument("--output-dir", default=".", help="Output directory (default: .)")
+    parser.add_argument("--repo", default=None, help="Path to OGX git repo for resolving git refs")
+    parser.add_argument("--baseline-ref", default=None, help="Baseline git ref (empty or omitted = latest release tag)")
+    parser.add_argument("--comparison-ref", default="HEAD", help="Comparison git ref (default: HEAD)")
+    args = parser.parse_args()
+
+    hash_map = {}
+
+    if args.replicates < 1:
+        print("WARNING: --replicates < 1, using 1", file=sys.stderr)
+        args.replicates = 1
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.versions:
+        labels = [v.strip() for v in args.versions.split(",")]
+    else:
+        baseline_ref = args.baseline_ref or find_latest_release_tag(args.repo)
+        comparison_ref = args.comparison_ref
+        labels = ["baseline", "comparison", "comparison_ctrl"]
+        baseline_hash = resolve_version_hash(baseline_ref, git_dir=args.repo)
+        comparison_hash = resolve_version_hash(comparison_ref, git_dir=args.repo)
+        hash_map = {
+            "baseline": baseline_hash,
+            "comparison": comparison_hash,
+            "comparison_ctrl": comparison_hash,
+        }
+
+    versions = []
+    for label in labels:
+        if label in hash_map:
+            version_hash = hash_map[label]
+        else:
+            version_hash = resolve_version_hash(label, git_dir=args.repo)
+        versions.append({"label": label, "hash": version_hash})
+
+    all_rows = generate_matrix(versions, args.replicates, args.seed)
+    matrix_path = os.path.join(args.output_dir, "experiment-matrix.csv")
+    pd.DataFrame(all_rows).to_csv(matrix_path, index=False)
+    print(f"  Wrote: {matrix_path} ({len(all_rows)} runs)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/benchmarking/api_latency_comparison/experiment/locustfile_responses.py
+++ b/benchmarking/api_latency_comparison/experiment/locustfile_responses.py
@@ -1,0 +1,84 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+import os
+import sys
+
+from locust import HttpUser, events, task
+from locust.contrib.csv_request_logger import CsvRequestLogger
+
+BENCHMARK_MODE = os.environ.get("BENCHMARK_MODE", "straight-through")
+if BENCHMARK_MODE not in ("straight-through", "agentic"):
+    print(f"Error: BENCHMARK_MODE must be 'straight-through' or 'agentic', got '{BENCHMARK_MODE}'")
+    sys.exit(1)
+
+_request_log_path = os.environ.get("REQUEST_LOG")
+if not _request_log_path:
+    print("Error: REQUEST_LOG environment variable is required")
+    sys.exit(1)
+_request_logger = CsvRequestLogger(_request_log_path)
+
+
+@events.init.add_listener
+def on_locust_init(environment, **kwargs):
+    _request_logger.register(environment)
+
+
+class ResponsesAPIUser(HttpUser):
+    """Benchmarks /v1/responses with optional tool calls (set BENCHMARK_MODE=agentic)."""
+
+    def on_start(self):
+        self.model_id = "openai/mock-model"
+        self.headers = {"Content-Type": "application/json"}
+
+    @task
+    def responses_api(self):
+        payload = {
+            "model": self.model_id,
+            "input": "Hello, how are you?",
+            "store": True,
+            "stream": False,
+        }
+
+        if BENCHMARK_MODE == "agentic":
+            payload["tools"] = [{"type": "web_search"}]
+
+        with self.client.post(
+            "/v1/responses",
+            data=json.dumps(payload),
+            headers=self.headers,
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"HTTP {response.status_code}: {response.text}")
+                return
+            try:
+                data = response.json()
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+                return
+            if data.get("status") != "completed":
+                response.failure(f"Expected status 'completed', got '{data.get('status')}'")
+                return
+            output = data.get("output", [])
+            if not output:
+                response.failure("Empty output array")
+                return
+            has_assistant = any(
+                item.get("role") == "assistant" and item.get("content")
+                for item in output
+                if item.get("type") == "message"
+            )
+            if not has_assistant:
+                response.failure("No assistant message with content in output")
+                return
+            if BENCHMARK_MODE == "agentic":
+                has_tool_output = any(item.get("type") in ("web_search_call", "function_call") for item in output)
+                if not has_tool_output:
+                    response.failure("No tool call output in agentic response")
+                    return
+            response.success()

--- a/benchmarking/api_latency_comparison/experiment/mock_server.py
+++ b/benchmarking/api_latency_comparison/experiment/mock_server.py
@@ -1,0 +1,225 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+MOCK_TOOL_CALL_COUNT = int(os.environ.get("MOCK_TOOL_CALL_COUNT", "1"))
+
+MOCK_CONTENT = "This is a mock response from the benchmark server."
+
+MOCK_RESPONSE = {
+    "id": "chatcmpl-mock123",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "mock-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": MOCK_CONTENT,
+            },
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    },
+}
+MOCK_RESPONSE_BYTES = json.dumps(MOCK_RESPONSE).encode()
+
+
+MOCK_SEARCH_RESPONSE = {
+    "mixed": {"main": [{"type": "web", "index": 0}]},
+    "web": {
+        "results": [
+            {
+                "type": "web",
+                "title": "Mock search result",
+                "url": "https://example.com/mock-benchmark",
+                "description": "Mock search result for benchmarking.",
+                "date": "2026-01-01",
+                "extra_snippets": [],
+            }
+        ]
+    },
+}
+MOCK_SEARCH_RESPONSE_BYTES = json.dumps(MOCK_SEARCH_RESPONSE).encode()
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    _counter_lock = threading.Lock()
+    call_counter = 0
+    search_count = 0
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/v1/chat/completions":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length else b""
+            stream = False
+            if body:
+                try:
+                    stream = json.loads(body).get("stream", False)
+                except (json.JSONDecodeError, AttributeError):
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(b'{"error":"invalid JSON body"}')
+                    return
+
+            if stream:
+                self._handle_streaming()
+            else:
+                self._handle_non_streaming()
+        elif self.path == "/reset":
+            with MockHandler._counter_lock:
+                prev_calls = MockHandler.call_counter
+                prev_searches = MockHandler.search_count
+                MockHandler.call_counter = 0
+                MockHandler.search_count = 0
+            self._json_response({"reset": True, "prev_post_count": prev_calls, "prev_search_count": prev_searches})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _json_response(self, data: dict[str, Any] | bytes, code: int = 200) -> None:
+        body = json.dumps(data).encode() if isinstance(data, dict) else data
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _should_return_tool_call(self) -> bool:
+        """Cycle tool calls: return True for the first N requests, then reset. Simulates a multi-turn agentic loop."""
+        if MOCK_TOOL_CALL_COUNT <= 0:
+            return False
+        with MockHandler._counter_lock:
+            MockHandler.call_counter += 1
+            if MockHandler.call_counter <= MOCK_TOOL_CALL_COUNT:
+                return True
+            MockHandler.call_counter = 0
+            return False
+
+    def _handle_non_streaming(self) -> None:
+        self._json_response(MOCK_RESPONSE_BYTES)
+
+    def _handle_streaming(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        chunk_id = "chatcmpl-mock-stream"
+        created = int(time.time())
+        model = "mock-model"
+
+        if self._should_return_tool_call():
+            self._stream_tool_call(chunk_id, created, model)
+        else:
+            self._stream_text(chunk_id, created, model)
+
+    def _send_chunk(self, chunk_id: str, created: int, model: str, choices: list[dict[str, Any]]) -> None:
+        chunk = {
+            "id": chunk_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": choices,
+        }
+        self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+
+    def _finish_stream(self) -> None:
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def _stream_text(self, chunk_id: str, created: int, model: str) -> None:
+        self._send_chunk(chunk_id, created, model, [{"index": 0, "delta": {"role": "assistant", "content": ""}}])
+        self._send_chunk(chunk_id, created, model, [{"index": 0, "delta": {"content": MOCK_CONTENT}}])
+        self._send_chunk(
+            chunk_id,
+            created,
+            model,
+            [
+                {"index": 0, "delta": {"content": ""}, "finish_reason": "stop"},
+            ],
+        )
+        self._finish_stream()
+
+    def _stream_tool_call(self, chunk_id: str, created: int, model: str) -> None:
+        with MockHandler._counter_lock:
+            counter_val = MockHandler.call_counter
+        self._send_chunk(chunk_id, created, model, [{"index": 0, "delta": {"role": "assistant", "content": ""}}])
+        self._send_chunk(
+            chunk_id,
+            created,
+            model,
+            [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": f"call_benchmark_{counter_val}",
+                                "type": "function",
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query": "benchmark test"}',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+        )
+        self._send_chunk(
+            chunk_id,
+            created,
+            model,
+            [
+                {"index": 0, "delta": {}, "finish_reason": "tool_calls"},
+            ],
+        )
+        self._finish_stream()
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/v1/health":
+            self._json_response(b'{"status":"ok"}')
+        elif self.path == "/v1/models":
+            self._json_response(
+                {"object": "list", "data": [{"id": "mock-model", "object": "model", "owned_by": "mock"}]}
+            )
+        elif self.path.startswith("/res/v1/web/search"):
+            with MockHandler._counter_lock:
+                MockHandler.search_count += 1
+            self._json_response(MOCK_SEARCH_RESPONSE_BYTES)
+        elif self.path == "/stats":
+            with MockHandler._counter_lock:
+                stats = {"post_count": MockHandler.call_counter, "get_search_count": MockHandler.search_count}
+            self._json_response(stats)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    import sys
+
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    server = ThreadingHTTPServer(("127.0.0.1", port), MockHandler)
+    print(f"Mock server listening on port {port} (MOCK_TOOL_CALL_COUNT={MOCK_TOOL_CALL_COUNT})")
+    server.serve_forever()

--- a/benchmarking/api_latency_comparison/experiment/preflight.py
+++ b/benchmarking/api_latency_comparison/experiment/preflight.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Pre-flight checks for the benchmark experiment."""
+
+import csv
+import os
+import shutil
+import socket
+import subprocess
+from datetime import UTC
+from pathlib import Path
+from typing import Any
+
+
+class PreflightError(RuntimeError):
+    pass
+
+
+def log(msg: str) -> None:
+    from datetime import datetime
+
+    ts = datetime.now(tz=UTC).strftime("%H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def check_ports(ports: list[int]) -> None:
+    log("Checking port availability...")
+    for port in ports:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if s.connect_ex(("localhost", port)) == 0:
+                raise PreflightError(f"Port {port} already in use")
+
+
+def check_disk_space(results_dir: str) -> None:
+    usage = shutil.disk_usage(results_dir)
+    avail_mb = usage.free // (1024 * 1024)
+    if avail_mb < 500:
+        raise PreflightError(f"Insufficient disk space: {avail_mb}MB (need 500MB)")
+    log(f"  Disk space: {avail_mb}MB available")
+
+
+def check_cpu_pinning() -> bool:
+    log("Checking CPU pinning...")
+    try:
+        os.sched_setaffinity(0, {0})
+        actual = os.sched_getaffinity(0)
+        os.sched_setaffinity(0, set(range(os.cpu_count() or 1)))
+        if actual == {0}:
+            log("  CPU pinning verified (sched_setaffinity works)")
+            return True
+    except (OSError, AttributeError):
+        pass
+    log("WARNING: CPU pinning unavailable, running without pinning")
+    return False
+
+
+def check_matrix(matrix_csv: str) -> None:
+    log("Checking experiment matrix...")
+    if not Path(matrix_csv).exists():
+        raise PreflightError(f"Matrix CSV not found: {matrix_csv}")
+    with open(matrix_csv) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        n_cols = len(header)
+        n_runs = sum(1 for _ in reader)
+    log(f"  Matrix: {n_runs} runs, {n_cols} columns")
+    if n_cols != 7:
+        raise PreflightError(f"Expected 7 columns, got {n_cols}")
+
+
+def check_worktrees(worktree_base: str, baseline_label: str, comparison_label: str) -> None:
+    log("Checking worktrees...")
+    for label in [baseline_label, comparison_label]:
+        wt = Path(worktree_base) / label
+        if not (wt / ".git").exists():
+            raise PreflightError(f"Worktree not found: {wt}. Run experiment/setup-worktree.sh first")
+    log(f"  Worktrees OK ({baseline_label}, {comparison_label})")
+
+
+def run_all_checks(
+    results_dir: str,
+    matrix_csv: str,
+    worktree_base: str,
+    baseline_label: str,
+    comparison_label: str,
+    mock_port: int,
+    stack_port: int,
+) -> bool:
+    """Run all pre-flight checks. Returns taskset_available bool.
+
+    Raises PreflightError on any failure.
+    """
+    log("=== Pre-Flight Checks ===")
+
+    check_ports([mock_port, stack_port])
+    check_disk_space(results_dir)
+    taskset_available = check_cpu_pinning()
+    check_matrix(matrix_csv)
+    check_worktrees(worktree_base, baseline_label, comparison_label)
+
+    log("=== Pre-Flight Complete ===")
+
+    return taskset_available
+
+
+def _read_proc(path: str, prefix: str) -> str:
+    """Read a colon-delimited value from a /proc file by prefix."""
+    try:
+        with open(path) as f:
+            for line in f:
+                if line.startswith(prefix):
+                    return line.split(":", 1)[1].strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _cmd(cmd: list[str]) -> str:
+    try:
+        return subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL).strip()  # noqa: S603
+    except Exception:
+        return "unknown"
+
+
+def record_environment(cfg: dict[str, Any], results_dir: str) -> None:
+    """Write hardware and software environment details to environment.txt."""
+    from datetime import datetime
+
+    wb = cfg["worktree_base"]
+    bl, cl = cfg["baseline_label"], cfg["comparison_label"]
+    env = {
+        "date": datetime.now(tz=UTC).isoformat(),
+        "hostname": socket.gethostname(),
+        "kernel": os.uname().release,
+        "python": _cmd(["uv", "run", "--project", cfg["repo_root"], "python", "--version"]),
+        "baseline_label": bl,
+        "baseline_hash": _cmd(["git", "-C", str(Path(wb) / bl), "rev-parse", "HEAD"]),
+        "comparison_label": cl,
+        "comparison_hash": _cmd(["git", "-C", str(Path(wb) / cl), "rev-parse", "HEAD"]),
+        "cpu_model": _read_proc("/proc/cpuinfo", "model name"),
+        "cpu_cores": os.cpu_count(),
+        "memory_mb": int(_read_proc("/proc/meminfo", "MemTotal").split()[0]) // 1024
+        if _read_proc("/proc/meminfo", "MemTotal") != "unknown"
+        else "unknown",
+        "seed": cfg["seed"],
+        "run_duration": cfg["run_duration"],
+        "cpu_pinning": f"ogx={cfg['cpu_ogx']} locust={cfg['cpu_locust']} mock={cfg['cpu_mock']}"
+        if cfg["taskset_available"]
+        else "disabled",
+    }
+    env_file = Path(results_dir) / "environment.txt"
+    log(f"Recording environment to {env_file}")
+    env_file.write_text("\n".join(f"{k}: {v}" for k, v in env.items()) + "\n")

--- a/benchmarking/api_latency_comparison/experiment/runlog.py
+++ b/benchmarking/api_latency_comparison/experiment/runlog.py
@@ -1,0 +1,48 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Run log and design matrix I/O."""
+
+import csv
+import dataclasses
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class RunLogEntry:
+    run: int
+    version_label: str
+    version_hash: str
+    replicate: int
+    benchmark_mode: str
+    mock_tool_call_count: int
+    start_time: int
+    end_time: int
+    duration_s: int
+    requests_completed: int
+    status: str
+
+
+RUN_LOG_FIELDS = [f.name for f in dataclasses.fields(RunLogEntry)]
+
+
+def load_completed_runs(run_log: Path | str) -> set[int]:
+    df = pd.read_csv(run_log)
+    return set(df.loc[df["status"] == "ok", "run"].astype(int))
+
+
+def append_run_log(run_log: Path | str, entry: RunLogEntry) -> None:
+    """Append a run log entry to the CSV, writing the header if needed."""
+    path = Path(run_log)
+    write_header = not path.exists() or path.stat().st_size == 0
+    with open(path, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=RUN_LOG_FIELDS, lineterminator="\n")
+        if write_header:
+            writer.writeheader()
+        writer.writerow(dataclasses.asdict(entry))

--- a/benchmarking/api_latency_comparison/experiment/setup-worktree.sh
+++ b/benchmarking/api_latency_comparison/experiment/setup-worktree.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+set -euo pipefail
+
+# Sets up OGX worktrees for the CI regression benchmark.
+# Creates isolated worktrees for baseline and comparison versions,
+# applies the brave-search base_url patch so the mock server can
+# serve search results locally.
+#
+# Usage:
+#   ./setup-worktree.sh --baseline v1.0.2 --baseline-label baseline \
+#     --comparison HEAD --comparison-label comparison
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_BASE="/tmp/ci-validation"
+SKIP_DEPS=false
+MOCK_PORT=8080
+STACK_PORT=8321
+
+log_msg() {
+    echo "[$(date +%H:%M:%S)] $*"
+}
+
+REPO=""
+BASELINE_REF=""
+BASELINE_LABEL=""
+COMPARISON_REF=""
+COMPARISON_LABEL=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Sets up OGX worktrees for the CI benchmark experiment.
+
+Required:
+    --baseline REF          Git ref for baseline (tag, branch, or commit)
+    --baseline-label NAME   Label for baseline (e.g., v1.0.2)
+    --comparison REF        Git ref for comparison (tag, branch, or commit)
+    --comparison-label NAME Label for comparison (e.g., HEAD)
+
+Options:
+    --repo DIR              Path to OGX git repository (default: auto-detect)
+    --worktree-base DIR     Base directory for worktrees (default: $WORKTREE_BASE)
+    --skip-deps             Skip dependency install
+    --mock-port PORT        Mock server port (default: $MOCK_PORT)
+    --stack-port PORT       OGX server port (default: $STACK_PORT)
+    --help                  Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)              REPO="$2"; shift 2 ;;
+        --baseline)          BASELINE_REF="$2"; shift 2 ;;
+        --baseline-label)    BASELINE_LABEL="$2"; shift 2 ;;
+        --comparison)        COMPARISON_REF="$2"; shift 2 ;;
+        --comparison-label)  COMPARISON_LABEL="$2"; shift 2 ;;
+        --worktree-base)     WORKTREE_BASE="$2"; shift 2 ;;
+        --skip-deps)         SKIP_DEPS=true; shift ;;
+        --mock-port)         MOCK_PORT="$2"; shift 2 ;;
+        --stack-port)        STACK_PORT="$2"; shift 2 ;;
+        --help)              usage; exit 0 ;;
+        *) echo "Error: unknown option $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$REPO" ]]; then
+    REPO="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+
+if [[ ! -d "$REPO/.git" ]]; then
+    echo "Error: $REPO is not a git repository" >&2
+    echo "Use --repo to specify the OGX repo path" >&2
+    exit 1
+fi
+
+if [[ -z "$BASELINE_REF" || -z "$BASELINE_LABEL" || -z "$COMPARISON_REF" || -z "$COMPARISON_LABEL" ]]; then
+    echo "Error: --baseline, --baseline-label, --comparison, and --comparison-label are required" >&2
+    usage >&2
+    exit 1
+fi
+
+log_msg "=== CI Regression Worktree Setup ==="
+log_msg "  Repo: $REPO"
+log_msg "  Worktree base: $WORKTREE_BASE"
+echo ""
+
+BASELINE_DIR="$WORKTREE_BASE/$BASELINE_LABEL"
+COMPARISON_DIR="$WORKTREE_BASE/$COMPARISON_LABEL"
+
+resolve_ref() {
+    local ref="$1"
+    # Resolve a user-supplied ref (tag, branch, remote branch, or SHA)
+    # to a form that git worktree add --detach can use.
+    if git rev-parse --verify "$ref^{commit}" >/dev/null 2>&1; then
+        echo "$ref"
+        return
+    fi
+    # Bare branch name (e.g., "main") with no local branch but origin/main exists.
+    # actions/checkout only creates a local branch for the checked-out ref.
+    if git rev-parse --verify "origin/$ref^{commit}" >/dev/null 2>&1; then
+        echo "origin/$ref"
+        return
+    fi
+    echo "Error: cannot resolve git ref '$ref'" >&2
+    echo "  Tried: '$ref', 'origin/$ref'" >&2
+    return 1
+}
+
+setup_worktree() {
+    local version="$1"
+    local git_ref="$2"
+    local wt_dir="$3"
+
+    log_msg "Setting up worktree: $version (ref: $git_ref) -> $wt_dir"
+
+    if [[ -d "$wt_dir" ]]; then
+        log_msg "  Worktree exists, resetting to clean state..."
+        cd "$wt_dir"
+        git checkout HEAD -- .
+    else
+        cd "$REPO"
+        git worktree prune
+        local resolved
+        resolved=$(resolve_ref "$git_ref")
+        log_msg "  Resolved ref: $git_ref -> $resolved"
+        git worktree add "$wt_dir" "$resolved" --detach
+    fi
+
+    cd "$wt_dir"
+
+    if [[ "$SKIP_DEPS" == false ]]; then
+        log_msg "  Installing dependencies..."
+        uv sync 2>&1 | tail -3
+    fi
+
+    # Patch brave-search provider to accept a configurable base_url.
+    # Uses sed instead of git apply because the surrounding context lines
+    # differ between versions (e.g., type annotations added in later releases).
+    local bs_impl="$wt_dir/src/ogx/providers/remote/tool_runtime/brave_search/brave_search.py"
+    local bs_conf="$wt_dir/src/ogx/providers/remote/tool_runtime/brave_search/config.py"
+
+    if ! grep -q 'self.config.base_url' "$bs_impl" 2>/dev/null; then
+        if grep -q 'url = "https://api.search.brave.com/res/v1/web/search"' "$bs_impl"; then
+            log_msg "  Patching brave-search base_url..."
+            sed -i 's|url = "https://api.search.brave.com/res/v1/web/search"|url = (self.config.base_url or "https://api.search.brave.com") + "/res/v1/web/search"|' "$bs_impl"
+            sed -i '/^    max_results.*Field(/,/^    )/{/^    )/a\    base_url: str | None = Field(\n        default=None,\n        description="Override base URL for the search API (e.g., http://localhost:8080 for mock)",\n    )
+            }' "$bs_conf"
+        else
+            log_msg "ERROR: Cannot find brave-search URL line to patch in $version"
+            log_msg "  Expected: url = \"https://api.search.brave.com/res/v1/web/search\""
+            exit 1
+        fi
+    else
+        log_msg "  brave-search base_url already patched"
+    fi
+
+    # Verify the patch took effect
+    if ! grep -q 'self.config.base_url' "$bs_impl"; then
+        log_msg "ERROR: brave-search patch verification failed for $version"
+        exit 1
+    fi
+
+    local commit_hash
+    commit_hash=$(git rev-parse HEAD)
+    log_msg "  OK: $version at $commit_hash"
+
+    cat > "$wt_dir/.benchmark-env" <<ENVEOF
+export WORKTREE_DIR="$wt_dir"
+export OPENAI_API_KEY="fake-token"
+export MOCK_PORT=$MOCK_PORT
+export STACK_PORT=$STACK_PORT
+ENVEOF
+}
+
+# Step 1: Baseline worktree
+setup_worktree "$BASELINE_LABEL" "$BASELINE_REF" "$BASELINE_DIR"
+echo ""
+
+# Step 2: Comparison worktree
+setup_worktree "$COMPARISON_LABEL" "$COMPARISON_REF" "$COMPARISON_DIR"
+echo ""
+
+# Verify worktree hashes match expected refs
+BASELINE_HASH=$(cd "$BASELINE_DIR" && git rev-parse HEAD)
+COMPARISON_HASH=$(cd "$COMPARISON_DIR" && git rev-parse HEAD)
+
+log_msg "=== Setup Complete ==="
+echo ""
+echo "  $BASELINE_LABEL:    $BASELINE_DIR ($BASELINE_HASH)"
+echo "  $COMPARISON_LABEL:  $COMPARISON_DIR ($COMPARISON_HASH)"
+echo ""
+echo "Cleanup:"
+echo "  git -C $REPO worktree remove $BASELINE_DIR"
+echo "  git -C $REPO worktree remove $COMPARISON_DIR"

--- a/benchmarking/api_latency_comparison/experiment/test_benchmark.py
+++ b/benchmarking/api_latency_comparison/experiment/test_benchmark.py
@@ -1,0 +1,125 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""End-to-end benchmark self-test.
+
+Runs the experiment pipeline (setup → generate → experiment) with
+2 replicates and 3s runs, then asserts artifacts were produced.
+
+Run with:
+  uv run python -m pytest benchmarking/api_latency_comparison/experiment/test_benchmark.py -v -s
+"""
+
+import csv
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from benchmarking.api_latency_comparison.experiment.benchmark import _default_config, cleanup_worktrees, run_benchmark
+from benchmarking.api_latency_comparison.experiment.generate_design_matrix import generate_matrix, resolve_version_hash
+from benchmarking.api_latency_comparison.experiment.preflight import PreflightError, check_ports
+
+
+@pytest.fixture(scope="class")
+def benchmark_results():
+    results_dir = Path(tempfile.mkdtemp(prefix="benchmark-test-"))
+    cfg = _default_config()
+    cfg["run_duration"] = 3
+
+    run_benchmark(cfg, results_dir, baseline_ref="", comparison_ref="HEAD", replicates=2)
+
+    yield results_dir
+
+    cleanup_worktrees(cfg)
+
+
+class TestRCBDInvariant:
+    VERSIONS = [
+        {"label": "baseline", "hash": "aaa"},
+        {"label": "comparison", "hash": "bbb"},
+        {"label": "comparison_ctrl", "hash": "bbb"},
+    ]
+
+    def test_each_block_has_all_versions(self):
+        rows = generate_matrix(self.VERSIONS, replicates=5, seed=42)
+        labels = [v["label"] for v in self.VERSIONS]
+        for block in range(1, 6):
+            block_labels = sorted(r["version_label"] for r in rows if r["block"] == block)
+            assert block_labels == sorted(labels), f"Block {block}: {block_labels}"
+
+
+class TestErrorPaths:
+    def test_bad_ref_raises_valueerror(self):
+        with pytest.raises(ValueError, match="could not resolve git ref"):
+            resolve_version_hash("nonexistent-ref-abc123")
+
+    def test_port_conflict_raises_preflight_error(self):
+        s = socket.socket()
+        s.bind(("localhost", 0))
+        port = s.getsockname()[1]
+        s.listen(1)
+        try:
+            with pytest.raises(PreflightError, match=f"Port {port} already in use"):
+                check_ports([port])
+        finally:
+            s.close()
+
+
+class TestExperimentPipeline:
+    EXPECTED_COLUMNS = {
+        "version_hash",
+        "version_label",
+        "run",
+        "replicate",
+        "block",
+        "benchmark_mode",
+        "mock_tool_call_count",
+    }
+
+    def test_experiment_matrix_has_correct_schema(self, benchmark_results):
+        results_dir = benchmark_results
+        with open(results_dir / "experiment-matrix.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 6
+        assert reader.fieldnames is not None
+        assert set(reader.fieldnames) == self.EXPECTED_COLUMNS
+        versions = {r["version_label"] for r in rows}
+        assert versions == {"baseline", "comparison", "comparison_ctrl"}
+
+    def test_run_log_records_all_runs(self, benchmark_results):
+        results_dir = benchmark_results
+        with open(results_dir / "run-log.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 6
+        assert all(r["status"] == "ok" for r in rows)
+        assert all(int(r["requests_completed"]) > 0 for r in rows)
+
+    def test_each_run_has_request_data(self, benchmark_results):
+        results_dir = benchmark_results
+        run_dirs = [d for d in (results_dir / "runs").iterdir() if d.name != "preflight" and d.is_dir()]
+        assert len(run_dirs) == 6
+        for rd in run_dirs:
+            req_csv = rd / "requests.csv"
+            assert req_csv.exists(), f"Missing {req_csv}"
+            with open(req_csv) as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+            assert len(rows) >= 3, f"Expected >= 3 requests in {req_csv}, got {len(rows)}"
+            assert reader.fieldnames is not None
+            assert "response_time_ms" in reader.fieldnames
+
+    def test_environment_recorded(self, benchmark_results):
+        results_dir = benchmark_results
+        env_file = results_dir / "environment.txt"
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "hostname:" in content
+        assert "cpu_pinning:" in content
+        assert "seed:" in content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,6 +265,11 @@ docs = [
 ]
 codegen = ["rich", "pydantic>=2.11.9", "jinja2>=3.1.6"]
 benchmark = ["locust>=2.39.1"]
+api-latency-comparison = [
+    {include-group = "benchmark"},
+    "mirakuru>=3.0",
+    "pandas",
+]
 
 [project.urls]
 Homepage = "https://github.com/ogx-ai/ogx"

--- a/uv.lock
+++ b/uv.lock
@@ -785,11 +785,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.1"
+version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
@@ -3535,6 +3535,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psutil", marker = "sys_platform != 'cygwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/23/db9034ba28c7d89a540ffb8ca789f70dc12079108ece1cd1762295d5c807/mirakuru-3.0.2.tar.gz", hash = "sha256:21192186a8680ea7567ca68170261df3785768b12962dd19fe8cccab15ad3441", size = 29338, upload-time = "2026-02-11T19:41:15.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/5f/a3f1a7f1f6e55de9285b03ae7e0d3c2a15e044b6e3f9b53bef5609ca05f2/mirakuru-3.0.2-py3-none-any.whl", hash = "sha256:10e5dac4a8f26872c63e9cdfdc01b775aaa2beb3ced98abc497279d2dc525b8f", size = 27583, upload-time = "2026-02-11T19:41:13.578Z" },
+]
+
+[[package]]
 name = "mistune"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4181,6 +4193,11 @@ starter = [
 ]
 
 [package.dev-dependencies]
+api-latency-comparison = [
+    { name = "locust" },
+    { name = "mirakuru" },
+    { name = "pandas" },
+]
 benchmark = [
     { name = "locust" },
 ]
@@ -4427,6 +4444,11 @@ requires-dist = [
 provides-extras = ["client", "openclient", "starter"]
 
 [package.metadata.requires-dev]
+api-latency-comparison = [
+    { name = "locust", specifier = ">=2.39.1" },
+    { name = "mirakuru", specifier = ">=3.0" },
+    { name = "pandas" },
+]
 benchmark = [{ name = "locust", specifier = ">=2.39.1" }]
 codegen = [
     { name = "jinja2", specifier = ">=3.1.6" },


### PR DESCRIPTION
# What does this PR do?

Adds a data collection pipeline under `benchmarking/api_latency_comparison/` for comparing per-request API latency between two OGX versions.

The orchestrator (`experiment/benchmark.py`) sets up git worktrees for each version, generates a randomized complete block design experiment matrix, starts servers with CPU pinning via mirakuru, runs Locust against each version, and records per-request response times. A third "comparison control" group runs the same code as comparison to catch false positives from environmental noise.

Each run sends agentic requests to `/v1/responses` with `web_search` tool use, so latency measurements capture the full agentic loop (request -> tool call -> mock search -> final response).

- `experiment/benchmark.py` — orchestrator: worktree setup, server lifecycle, run loop
- `experiment/mock_server.py` — canned OpenAI chat completions + Brave Search backend with tool call cycling for agentic workloads
- `experiment/setup-worktree.sh` — creates isolated git worktrees per version, patches older releases for mock compatibility
- `experiment/preflight.py` — port, disk, CPU pinning checks and computing environment recording
- `experiment/generate_design_matrix.py` — RCBD matrix generator with version hash resolution
- `experiment/locustfile_responses.py` — Locust user targeting `/v1/responses`
- `experiment/runlog.py` — CSV run log I/O
- `configs/stack-config-benchmark.yaml` — OGX server config pointed at the mock backend

First of two PRs. Follow-up adds Bayesian model fitting and a CI workflow.

## Test Plan

```bash
uv sync --group api-latency-comparison
uv run python -m pytest benchmarking/api_latency_comparison/experiment/test_benchmark.py -v -s
```

`test_benchmark.py` has 5 tests: 1 RCBD matrix invariant (unit) and 4 end-to-end pipeline tests that run 2 replicates with 3s runs, then verify experiment matrix schema, run log completeness, per-run request data, and environment recording.