### PR TITLE
feat(benchmarking): add Bayesian model fitting and CI workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,6 +32,7 @@ OGX uses GitHub Actions for Continuous Integration (CI). Below is a table detail
 | Integration Tests (Record) | [record-integration-tests.yml](record-integration-tests.yml) | Auto-record missing test recordings for PR |
 | vLLM GPU Recording | [record-vllm-gpu-tests.yml](record-vllm-gpu-tests.yml) | GPU recording for gpt-oss:20b (${{ inputs.suite }} suite) |
 | Release Branch Scheduled CI | [release-branch-scheduled-ci.yml](release-branch-scheduled-ci.yml) | Scheduled CI checks for active release branches |
+| Response Latency Regression Benchmark | [response-latency-regression-benchmark.yml](response-latency-regression-benchmark.yml) | Benchmark ${{ inputs.comparison_ref }} vs ${{ inputs.baseline_ref }} |
 | Check semantic PR titles | [semantic-pr.yml](semantic-pr.yml) | Ensure that PR titles follow the conventional commit spec |
 | Close stale issues and PRs | [stale_bot.yml](stale_bot.yml) | Run the Stale Bot action |
 | Test External Providers Installed via Module | [test-external-provider-module.yml](test-external-provider-module.yml) | Test External Provider installation via Python module |

--- a/.github/workflows/response-latency-regression-benchmark.yml
+++ b/.github/workflows/response-latency-regression-benchmark.yml
@@ -1,0 +1,78 @@
+name: Response Latency Regression Benchmark
+
+run-name: Benchmark ${{ inputs.comparison_ref }} vs ${{ inputs.baseline_ref }}
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC
+  workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: 'Baseline git ref (default: latest release tag)'
+        required: false
+        type: string
+        default: ''
+      comparison_ref:
+        description: 'Comparison git ref (default: main)'
+        required: false
+        type: string
+        default: 'main'
+      replicates:
+        description: 'Number of replicates per group'
+        required: false
+        type: number
+        default: 3
+      run_duration:
+        description: 'Run duration in seconds'
+        required: false
+        type: number
+        default: 10
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: benchmark-${{ inputs.baseline_ref || 'latest' }}-${{ inputs.comparison_ref || 'main' }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+        with:
+          python-version: '3.12'
+
+      - name: Install Rust toolchain (for nutpie)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install dependencies
+        run: uv sync --group benchmark-regression
+
+      - name: Run benchmark
+        run: |
+          uv run python -m benchmarking.api_latency_comparison.experiment.benchmark \
+            --baseline-ref "${{ inputs.baseline_ref }}" \
+            --comparison-ref "${{ inputs.comparison_ref || 'main' }}" \
+            --replicates "${{ inputs.replicates || 3 }}" \
+            --run-duration "${{ inputs.run_duration || 10 }}" \
+            --results-dir ${{ runner.temp }}/benchmark-results
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-results-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/benchmark-results/analysis/
+            ${{ runner.temp }}/benchmark-results/runs/
+            ${{ runner.temp }}/benchmark-results/experiment-matrix.csv
+            ${{ runner.temp }}/benchmark-results/environment.txt
+            ${{ runner.temp }}/benchmark-results/run-log.csv

--- a/.github/workflows/response-latency-regression-benchmark.yml
+++ b/.github/workflows/response-latency-regression-benchmark.yml
@@ -21,7 +21,7 @@ on:
         description: 'Number of replicates per group'
         required: false
         type: number
-        default: 3
+        default: 10
       run_duration:
         description: 'Run duration in seconds'
         required: false
@@ -61,7 +61,7 @@ jobs:
           uv run python -m benchmarking.api_latency_comparison.experiment.benchmark \
             --baseline-ref "${{ inputs.baseline_ref }}" \
             --comparison-ref "${{ inputs.comparison_ref || 'main' }}" \
-            --replicates "${{ inputs.replicates || 3 }}" \
+            --replicates "${{ inputs.replicates || 10 }}" \
             --run-duration "${{ inputs.run_duration || 10 }}" \
             --results-dir ${{ runner.temp }}/benchmark-results
 

--- a/benchmarking/__init__.py
+++ b/benchmarking/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/benchmarking/api_latency_comparison/README.md
+++ b/benchmarking/api_latency_comparison/README.md
@@ -1,11 +1,9 @@
 # API Latency Comparison Benchmark
 
-Measures per-request latency of two OGX versions under a controlled
-agentic workload. Compares an older release against a newer commit by
-running both through a mocked agentic workload and recording
-per-request response times.
-
-Analysis and model fitting are added in a follow-up PR.
+Detects latency regressions between two OGX versions using a Bayesian
+hierarchical model. Compares an older release against a newer commit by
+running both through a mocked agentic workload and fitting a Wald
+(Inverse Gaussian) latency model to the per-request response times.
 
 ## Overview
 
@@ -24,10 +22,10 @@ The three trials are:
 
 Each run starts a fresh OGX server against a mock backend, sends
 agentic requests (with web_search tool calls) via Locust for a fixed
-duration, and records per-request latencies. The false positive
-detection runs the negative control (same code as comparison, run
-independently) to verify the experiment isn't producing spurious
-differences.
+duration, and records per-request latencies. A Bayesian model estimates
+the version effect on mean latency. The false positive detection runs
+a negative control (same code as comparison, run independently) to
+verify the experiment isn't producing spurious differences.
 
 Components:
 
@@ -36,18 +34,22 @@ Components:
 - **Experiment orchestrator** (`experiment/benchmark.py`): run execution with CPU pinning
 - **Worktree setup** (`experiment/setup-worktree.sh`): isolated git worktrees per version
 - **Design matrix** (`experiment/generate_design_matrix.py`): randomized experiment design
+- **Model fitting** (`analysis/fit_resp_latency_model.py`): Wald (Inverse Gaussian) model + diagnostics
 
 ## Prerequisites
 
 ```bash
-# Benchmark experiment dependencies (Locust, mirakuru)
-uv sync --group api-latency-comparison
+# Full benchmark dependencies (experiment + analysis)
+uv sync --group benchmark-regression
+
+# Rust toolchain (required for nutpie compilation)
+rustup show  # or: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 ## Quick Start
 
-The orchestrator handles worktree setup, matrix generation, and
-experiment execution in one command:
+The orchestrator handles worktree setup, matrix generation, experiment
+execution, and model fitting in one command:
 
 ```bash
 uv run python -m benchmarking.api_latency_comparison.experiment.benchmark \
@@ -55,6 +57,46 @@ uv run python -m benchmarking.api_latency_comparison.experiment.benchmark \
 ```
 
 Output lands in an auto-timestamped directory under `results/`.
+
+## GitHub Actions
+
+The workflow at `.github/workflows/response-latency-regression-benchmark.yml`
+runs daily comparing the latest release tag against main. Manual dispatch
+accepts custom refs, replicates, and run duration.
+
+```bash
+gh workflow run response-latency-regression-benchmark.yml \
+  -f replicates=10 \
+  -f run_duration=10
+```
+
+## Interpreting Results
+
+The fit script prints parameter estimates, diagnostics, and a summary:
+
+```text
+============================================================
+RESULTS (regression threshold: 1.0ms)
+============================================================
+comparison vs baseline
+  mean latency: +1.7ms  [+1.5, +2.0]
+  p50:  +1.7ms  [+1.4, +2.1]  REGRESSION
+  p95:  +2.0ms  [+1.3, +2.7]  REGRESSION
+  p99:  +2.0ms  [+0.7, +3.3]  no regression
+============================================================
+```
+
+- **mean latency**: posterior mean shift with 99% HDI
+- **p50/p95/p99**: posterior predictive quantile contrasts
+- **REGRESSION**: P(contrast <= 1ms) < 0.05
+- **False positive check**: same-code control must show no difference
+
+Diagnostics include MCMC health (divergences, E-BFMI, ESS), posterior
+correlations, prior-to-posterior contraction, Pareto k analysis, and
+residual autocorrelation checks.
+
+Output files: `decisions.csv`, `fp-results.json`, and `idata.nc`
+(full InferenceData for offline analysis).
 
 ## Configuration
 
@@ -70,6 +112,10 @@ Output lands in an auto-timestamped directory under `results/`.
 | `CPU_MOCK` | 2 | Core for mock server |
 
 ## Implementation Notes
+
+**Data filtering**: The first and last observation of each run are
+dropped before fitting. The first is a client warmup artifact (Locust
+connection setup). The last is frequently elevated (edge-of-window effect).
 
 **CPU pinning**: Processes are pinned via `os.sched_setaffinity()` in
 `preexec_fn` callbacks, applied at fork before exec. Pinning is verified

--- a/benchmarking/api_latency_comparison/README.md
+++ b/benchmarking/api_latency_comparison/README.md
@@ -1,0 +1,80 @@
+# API Latency Comparison Benchmark
+
+Measures per-request latency of two OGX versions under a controlled
+agentic workload. Compares an older release against a newer commit by
+running both through a mocked agentic workload and recording
+per-request response times.
+
+Analysis and model fitting are added in a follow-up PR.
+
+## Overview
+
+The experiment is a randomized complete block design with three trials
+(treatment combinations). Each trial is replicated multiple times, and
+each replicate is a **run**: one row in the design matrix. The design
+matrix generator randomizes run order to guard against temporal
+confounding.
+
+The three trials are:
+
+- **Baseline**: the older version (e.g., latest release tag)
+- **Comparison**: the newer version under test
+- **Comparison control**: same commit as comparison, run independently as
+  a negative control for false positive detection
+
+Each run starts a fresh OGX server against a mock backend, sends
+agentic requests (with web_search tool calls) via Locust for a fixed
+duration, and records per-request latencies. The false positive
+detection runs the negative control (same code as comparison, run
+independently) to verify the experiment isn't producing spurious
+differences.
+
+Components:
+
+- **Mock server** (`experiment/mock_server.py`): canned OpenAI + Brave Search responses
+- **Locust** (`experiment/locustfile_responses.py`): load generator, 1 concurrent user
+- **Experiment orchestrator** (`experiment/benchmark.py`): run execution with CPU pinning
+- **Worktree setup** (`experiment/setup-worktree.sh`): isolated git worktrees per version
+- **Design matrix** (`experiment/generate_design_matrix.py`): randomized experiment design
+
+## Prerequisites
+
+```bash
+# Benchmark experiment dependencies (Locust, mirakuru)
+uv sync --group api-latency-comparison
+```
+
+## Quick Start
+
+The orchestrator handles worktree setup, matrix generation, and
+experiment execution in one command:
+
+```bash
+uv run python -m benchmarking.api_latency_comparison.experiment.benchmark \
+  --baseline-ref v1.1.0 --comparison-ref HEAD --replicates 5
+```
+
+Output lands in an auto-timestamped directory under `results/`.
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `RESULTS_DIR` | auto-timestamped | Where to write results |
+| `MATRIX_CSV` | `$RESULTS_DIR/experiment-matrix.csv` | Experiment matrix |
+| `RUN_DURATION` | 10 | Seconds per run |
+| `MOCK_PORT` | 8080 | Mock server port |
+| `STACK_PORT` | 8321 | OGX server port |
+| `CPU_OGX` | 0 | Core for OGX server |
+| `CPU_LOCUST` | 1 | Core for Locust |
+| `CPU_MOCK` | 2 | Core for mock server |
+
+## Implementation Notes
+
+**CPU pinning**: Processes are pinned via `os.sched_setaffinity()` in
+`preexec_fn` callbacks, applied at fork before exec. Pinning is verified
+per run via `os.sched_getaffinity(pid)` after each server start.
+
+**Brave Search patching**: Older OGX versions don't have the `base_url`
+field on `BraveSearchToolConfig`. The setup script patches it via `sed`
+so the mock server can serve search results locally.

--- a/benchmarking/api_latency_comparison/analysis/MODEL.md
+++ b/benchmarking/api_latency_comparison/analysis/MODEL.md
@@ -1,0 +1,149 @@
+# Response Latency Model
+
+[Wald (Inverse Gaussian)](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution)
+hierarchical model with Hilbert Space Gaussian Process (HSGP) temporal
+adjustment. Detects mean latency shifts between OGX versions at a 1ms
+threshold.
+
+Response times are strictly positive and right-skewed (occasional slow
+requests). The Wald (Inverse Gaussian) captures this naturally, while a Normal would allow
+impossible negative times.
+
+## Likelihood
+
+```text
+y_i ~ Wald/InvGaussian(mu_i, lambda_i)
+```
+
+## Mean (Location) Structure
+
+```text
+mu_i = mu_version[g_i] + beta_drift * d_i + delta_run[t_i] + f(x_i)
+```
+
+## Shape Structure
+
+Lambda is the Wald (Inverse Gaussian) shape parameter: higher values produce a narrower
+peak and lighter tails. Spread scales as mu^3 / lambda, so higher
+lambda means more consistent response times at the same mean latency.
+
+```text
+lambda_i = exp(log_lambda_run[t_i])
+log_lambda_run[t] ~ Normal(log_lambda_bar, sigma_lambda)
+```
+
+## Run Intercepts
+
+Each run gets its own intercept (delta_run) to account for
+run-to-run variation (e.g., different thermal state, background load).
+Within each version group, the intercepts are independently constrained
+to sum to zero via [ZeroSumNormal](https://www.pymc.io/projects/docs/en/stable/api/distributions/generated/pymc.ZeroSumNormal.html)
+so that the version mean latency (mu_version) cleanly represents
+each version's average response time.
+
+## Experimental Design (RCBD)
+
+The run order follows a Randomized Complete Block Design. Each block
+contains exactly one run of each version (baseline, comparison,
+comparison_ctrl) in a randomly permuted order. Blocks execute in
+temporal sequence (block 1 first, block N last).
+
+Blocking prevents temporal drift from aliasing with the treatment
+effect: any monotonic trend affects all three versions within a block
+approximately equally. Within-block randomization prevents position
+effects (e.g., cold-start penalty for the first run in a block)
+from systematically favoring one version.
+
+beta_drift operates on the global chronological run position d_i,
+scaled to [0, 1] across the full experiment. It captures smooth
+linear drift that the block structure does not resolve (e.g.,
+gradual thermal ramp within a block). The two mechanisms are
+complementary: blocking removes arbitrary between-block shifts,
+beta_drift removes smooth within-experiment trends.
+
+## Gaussian Process Temporal Adjustment
+
+Sequential observations within a run share transient system state
+(GC pressure, connection pool warm-up, event loop saturation),
+producing temporal autocorrelation. The GP captures this within-run
+dependence so that credible intervals on the version effect (beta_v)
+reflect the true effective sample size. Run intercepts (delta_run)
+capture between-run level shifts; the GP captures within-run
+temporal structure by operating on the sequence number of each
+request within a run (1st request, 2nd request, ...).
+
+The [HSGP (Hilbert Space Gaussian Process)](https://www.pymc.io/projects/docs/en/stable/api/gp/generated/pymc.gp.HSGP.html)
+is an approximation to a full Gaussian Process that scales
+linearly in the number of observations, making it practical for
+the large datasets typical of automated performance experiments.
+[Matern 3/2](https://en.wikipedia.org/wiki/Mat%C3%A9rn_covariance_function)
+kernel: nearby observations are correlated, correlation decays
+smoothly with distance.
+
+```text
+f ~ HSGP(Matern32, m=20, c=1.5, noncentered, drop_first=True)
+```
+
+## Priors
+
+```text
+mu_version[g]     ~ Normal(25, 10),       for each version group
+beta_drift        ~ Normal(0, 2)
+sigma_run       ~ Exponential(1)
+delta_run[t]    ~ ZeroSumNormal(sigma_run),  independently per group
+log_lambda_bar    ~ Normal(7, 2)
+sigma_lambda      ~ Exponential(1)
+eta_gp            ~ HalfNormal(0.25)
+ell_gp            ~ InverseGamma(mu=6, sigma=3)
+```
+
+## Derived Quantities
+
+```text
+beta_v[g] = mu_version[g] - mu_version[baseline]
+```
+
+## Definitions
+
+A bare index like `g` or `t` ranges over all values (used in priors).
+A subscripted index like `g_i` or `t_i` is a lookup: it maps
+observation `i` to its group or run.
+
+The `_bar` suffix denotes a population average: the center of the
+distribution that individual values are drawn from.
+
+| Symbol | Known/Estimated | Code variable | Description |
+|---|---|---|---|
+| i | index | — | Observation index |
+| g | index | — | Version group index (baseline, comparison, comparison_ctrl) |
+| t | index | — | Run index |
+| y_i | known | `y` | Response time for observation i (ms, positive) |
+| g_i | known | `x_group` | Version group that observation i belongs to |
+| t_i | known | `x_run` | Run that observation i belongs to |
+| d_i | known | `x_drift` | Run's chronological position in the experiment, scaled to [0, 1] |
+| x_i | known | `x_time` | Observation sequence number within a run |
+| mu_version[g] | estimated | `mu_version` | Mean latency for version group g (baseline, comparison, comparison_ctrl) (ms) |
+| beta_drift | estimated | `beta_drift` | Linear drift over run ordering (ms) |
+| sigma_run | estimated | `sigma_run` | Hierarchical standard deviation for run intercepts (ms) |
+| delta_run[t] | estimated | `delta_run_full` | Run-level deviation from group mean (ms), ZeroSumNormal within each group |
+| log_lambda_bar | estimated | `log_lambda_bar` | Population average log shape across runs |
+| sigma_lambda | estimated | `sigma_lambda` | Between-run standard deviation in log shape |
+| log_lambda_run[t] | estimated | `log_lambda_run` | Per-run log shape (centered parameterization) |
+| lambda_i | deterministic | `lambda_obs` | exp(log_lambda_run[t_i]). Wald (Inverse Gaussian) shape parameter |
+| eta_gp | estimated | `eta_gp` | How far the GP can shift latency within a run (ms) |
+| ell_gp | estimated | `ell_gp` | How many observations the GP effect stays correlated over |
+| f(x) | estimated | `f` | HSGP Matern32 within-run temporal adjustment |
+| beta_v[g] | deterministic | `beta_v` | How much slower (positive) or faster (negative) version g is compared to baseline, in ms |
+
+## Data Filtering
+
+First and last observation per run are dropped. The first is a
+Locust client warmup artifact (+20ms). The last is an edge-of-window
+effect.
+
+## Code Reference
+
+| What | File | Function |
+|---|---|---|
+| Model definition and data filtering | `fit_resp_latency_model.py` | `build_model()` |
+| Fitting and LOO | `fit_resp_latency_model.py` | `fit_and_diagnose()` |

--- a/benchmarking/api_latency_comparison/analysis/__init__.py
+++ b/benchmarking/api_latency_comparison/analysis/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/benchmarking/api_latency_comparison/analysis/decisions.py
+++ b/benchmarking/api_latency_comparison/analysis/decisions.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Posterior predictive quantile decisions and false positive checks."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import arviz as az
+import numpy as np
+import pymc as pm
+from tabulate import tabulate
+
+QUANTILES = [50, 95, 99]
+THRESHOLD_MS = 1.0
+
+
+def compute_hdi(samples: np.ndarray, prob: float = 0.99) -> tuple[float, float]:
+    result = az.hdi(np.asarray(samples), prob=prob)
+    return float(result[0]), float(result[1])
+
+
+def _make_decision(contrast: np.ndarray, block: str, q: int, version: str) -> dict[str, Any]:
+    """Build a single quantile decision dict from posterior contrast draws."""
+    pr_below = float(np.mean(contrast <= THRESHOLD_MS))
+    hdi_lo, hdi_hi = compute_hdi(contrast, 0.99)
+    return {
+        "block": block,
+        "quantile": q,
+        "version": version,
+        "diff_ms": float(np.mean(contrast)),
+        "sd": float(np.std(contrast)),
+        "pr_below_threshold": pr_below,
+        "detected": pr_below < 0.05,
+        "hdi_lo": float(hdi_lo),
+        "hdi_hi": float(hdi_hi),
+    }
+
+
+def _format_decisions_table(decs: list[dict[str, Any]]) -> str:
+    """Format a list of decision dicts as a tabulate table string."""
+    rows = []
+    for d in decs:
+        verdict = "YES" if d["detected"] else "no"
+        interval = f"[{d['hdi_lo']:+.1f}, {d['hdi_hi']:+.1f}]"
+        rows.append(
+            [
+                d["version"],
+                f"p{d['quantile']}",
+                f"{d['diff_ms']:+.2f}",
+                f"{d['sd']:.2f}",
+                f"{d['pr_below_threshold']:.4f}",
+                verdict,
+                interval,
+            ]
+        )
+    return tabulate(
+        rows,
+        headers=["Version", "Quantile", "Diff(ms)", "SD(ms)", "P(<=1ms)", "Verdict", "99% interval"],
+        colalign=("left", "left", "right", "right", "right", "right", "left"),
+    )
+
+
+def _check_false_positive(
+    pp: np.ndarray,
+    group_masks: dict[str, np.ndarray],
+    fp_base: str | None,
+    fp_ctrl: str | None,
+    decisions: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Run false positive check via negative control (two same-code groups).
+
+    Returns (fp_decisions, fp_results) where fp_results is the JSON-serializable
+    dict written to fp-results.json.
+    """
+    print(f"  === False Positive Check: {fp_ctrl} vs {fp_base} ===", flush=True)
+    fp_results = {"false_positive_detected": False, "quantiles": {}}
+    if not (fp_base and fp_ctrl and fp_base in group_masks and fp_ctrl in group_masks):
+        print("  WARNING: Cannot run false positive check — no matching version_hash pair found", flush=True)
+        return [], fp_results
+
+    any_fp = False
+    fp_decs = []
+    for q in QUANTILES:
+        contrast = np.percentile(pp[:, group_masks[fp_ctrl]], q, axis=1) - np.percentile(
+            pp[:, group_masks[fp_base]], q, axis=1
+        )
+        dec = _make_decision(contrast, "false_positive", q, fp_ctrl)
+        if dec["detected"]:
+            any_fp = True
+        decisions.append(dec)
+        fp_decs.append(dec)
+        fp_results["quantiles"][str(q)] = {
+            "diff_ms": dec["diff_ms"],
+            "pr_below_threshold": dec["pr_below_threshold"],
+            "detected": dec["detected"],
+        }
+    print(_format_decisions_table(fp_decs), flush=True)
+    fp_results["false_positive_detected"] = any_fp
+    if any_fp:
+        print("  RESULT: FALSE POSITIVE DETECTED — experiment apparatus is unreliable for this run", flush=True)
+    else:
+        print("  RESULT: clean", flush=True)
+    return fp_decs, fp_results
+
+
+def compute_decisions(
+    model: pm.Model, idata: az.InferenceData, data: dict[str, Any]
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Compute posterior predictive quantile decisions and save results."""
+    y = data["y"]
+    group_labels = data["group_labels"]
+    groups = data["groups"]
+    baseline = data["baseline"]
+
+    ts = datetime.now(tz=UTC).strftime("%H:%M:%S")
+    print(f"[{ts}] --- Posterior Predictive Quantile Decisions ---", flush=True)
+
+    with model:
+        pm.sample_posterior_predictive(idata, extend_inferencedata=True)
+    pp = idata.posterior_predictive["y"].values.reshape(-1, len(y))
+
+    group_masks = {g: (group_labels == g) for g in groups}
+    fp_base = "comparison" if "comparison" in groups else None
+    fp_ctrl = "comparison_ctrl" if "comparison_ctrl" in groups else None
+    non_ref = [g for g in groups if g != baseline]
+    comparison_groups = [g for g in non_ref if g != fp_ctrl]
+    beta_v_draws = idata.posterior["beta_v"].values.reshape(-1, len(groups))
+    beta_v_summaries = {}
+
+    for j, name in enumerate(groups):
+        if name == baseline or name == fp_ctrl:
+            continue
+        draws = beta_v_draws[:, j]
+        mean_val = float(np.mean(draws))
+        hdi_lo, hdi_hi = compute_hdi(draws, 0.99)
+        beta_v_summaries[name] = (mean_val, hdi_lo, hdi_hi)
+
+    decisions = []
+
+    for name in comparison_groups:
+        for q in QUANTILES:
+            contrast = np.percentile(pp[:, group_masks[name]], q, axis=1) - np.percentile(
+                pp[:, group_masks[baseline]], q, axis=1
+            )
+            decisions.append(_make_decision(contrast, "comparison", q, name))
+
+    _, fp_results = _check_false_positive(pp, group_masks, fp_base, fp_ctrl, decisions)
+
+    print(f"  {'=' * 60}", flush=True)
+    print(f"  RESULTS (regression threshold: {THRESHOLD_MS}ms)", flush=True)
+    print(f"  {'=' * 60}", flush=True)
+    if fp_results.get("false_positive_detected"):
+        print("  FALSE POSITIVE DETECTED — results are unreliable", flush=True)
+    summary_rows = []
+    for name in comparison_groups:
+        mean_shift, mean_hdi_lo, mean_hdi_hi = beta_v_summaries[name]
+        summary_rows.append(
+            [f"{name} vs {baseline}", "mean", f"{mean_shift:+.1f}", f"[{mean_hdi_lo:+.1f}, {mean_hdi_hi:+.1f}]", ""]
+        )
+        for dec in decisions:
+            if dec["block"] == "comparison" and dec["version"] == name:
+                verdict = "REGRESSION" if dec["detected"] else "no regression"
+                summary_rows.append(
+                    [
+                        "",
+                        f"p{dec['quantile']}",
+                        f"{dec['diff_ms']:+.1f}",
+                        f"[{dec['hdi_lo']:+.1f}, {dec['hdi_hi']:+.1f}]",
+                        verdict,
+                    ]
+                )
+    print(
+        tabulate(summary_rows, headers=["Comparison", "Quantile", "Diff(ms)", "99% interval", ""], tablefmt="plain"),
+        flush=True,
+    )
+    print(f"  {'=' * 60}", flush=True)
+
+    return decisions, fp_results

--- a/benchmarking/api_latency_comparison/analysis/diagnostics.py
+++ b/benchmarking/api_latency_comparison/analysis/diagnostics.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Post-fit diagnostics for the latency model.
+
+Organized into three categories (Betancourt/Gelman Bayesian workflow):
+  1. Computational faithfulness: did the sampler work?
+  2. Calibration: are the priors well-specified?
+  3. Retrodictive adequacy: does the model fit the data?
+"""
+
+from typing import Any
+
+import arviz as az
+import numpy as np
+import pandas as pd
+from tabulate import tabulate
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def run_all_diagnostics(
+    idata: az.InferenceData,
+    y: np.ndarray,
+    run: np.ndarray,
+    group_idx: np.ndarray,
+    groups: list[str],
+    n_runs: int,
+    run_to_version: dict[int, str],
+    summary: pd.DataFrame | None = None,
+    loo_result: Any = None,
+) -> None:
+    run_computational(idata, summary)
+    run_calibration(idata, groups)
+    run_retrodictive(idata, y, run, group_idx, groups, n_runs, run_to_version, loo_result)
+
+
+# ---------------------------------------------------------------------------
+# 1. Computational faithfulness: did the sampler work?
+# ---------------------------------------------------------------------------
+
+
+def run_computational(idata: az.InferenceData, summary: pd.DataFrame | None = None) -> None:
+    """MCMC health checks and effective sample size analysis."""
+    print("\n  === Computational Diagnostics ===", flush=True)
+
+    print("\n  --- MCMC Health ---", flush=True)
+    _, diag = az.diagnose(idata, show_diagnostics=False, return_diagnostics=True)
+
+    print(f"    Divergences: {diag['divergent']['n_divergent']}", flush=True)
+
+    for c, val in enumerate(diag["bfmi"]["bfmi_values"]):
+        status = "OK" if val > 0.2 else "LOW"
+        print(f"    Chain {c} E-BFMI: {val:.3f} [{status}]", flush=True)
+
+    try:
+        ns = idata.sample_stats["n_steps"].values
+        for c in range(ns.shape[0]):
+            l2 = np.log2(ns[c] + 1)
+            print(f"    Chain {c} log2(n_steps): mean={l2.mean():.1f}, max={l2.max():.0f}", flush=True)
+    except Exception:
+        pass
+
+    print("\n  --- ESS Ratio ---", flush=True)
+    if summary is None:
+        var_names = ["mu_version", "beta_drift", "sigma_run", "log_lambda_bar", "sigma_lambda", "eta_gp", "ell_gp"]
+        present = [v for v in var_names if v in idata.posterior]
+        if not present:
+            return
+        summary = az.summary(idata, var_names=present, kind="diagnostics")
+
+    best_ess = summary["ess_bulk"].max()
+    rows = []
+    for idx, row in summary.iterrows():
+        if "ess_bulk" not in row or pd.isna(row["ess_bulk"]):
+            continue
+        ratio = row["ess_bulk"] / best_ess
+        flag = "<-- LOW" if ratio < 0.1 else ""
+        rows.append([str(idx), f"{row['ess_bulk']:.0f}", f"{ratio:.3f}", flag])
+    print(tabulate(rows, headers=["Parameter", "ESS", "Ratio", ""], tablefmt="plain"), flush=True)
+
+
+# ---------------------------------------------------------------------------
+# 2. Calibration: are the priors well-specified?
+# ---------------------------------------------------------------------------
+
+PRIOR_WIDTHS = {
+    "mu_version": 4 * 10,
+    "beta_drift": 4 * 2,
+    "sigma_run": 3 / 1,
+    "log_lambda_bar": 4 * 2,
+    "sigma_lambda": 3 / 1,
+    "eta_gp": 2.5 * 0.25,
+    "ell_gp": 20,
+}
+
+
+def _extract_draws(idata: az.InferenceData, var_names: list[str], groups: list[str]) -> dict[str, np.ndarray]:
+    """Extract flattened posterior draws, expanding vectorized params."""
+    draws = {}
+    for v in var_names:
+        try:
+            d = idata.posterior[v].values
+        except KeyError:
+            continue
+        if d.ndim == 3:
+            for i in range(d.shape[2]):
+                label = groups[i] if v == "mu_version" else str(i)
+                draws[f"{v}[{label}]"] = d[:, :, i].flatten()
+        else:
+            draws[v] = d.flatten()
+    return draws
+
+
+def run_calibration(idata: az.InferenceData, groups: list[str]) -> None:
+    """Prior-to-posterior contraction and posterior correlations."""
+    print("\n  === Calibration Diagnostics ===", flush=True)
+
+    draws = _extract_draws(idata, list(PRIOR_WIDTHS.keys()), groups)
+
+    print("\n  --- Prior-to-Posterior Contraction ---", flush=True)
+    rows = []
+    for name, flat in draws.items():
+        base_var = name.split("[")[0]
+        prior_w = PRIOR_WIDTHS.get(base_var)
+        if prior_w is None:
+            continue
+        c = 1 - (np.percentile(flat, 97.5) - np.percentile(flat, 2.5)) / prior_w
+        status = "GOOD" if c > 0.5 else "WEAK" if c > 0.1 else "UNINFORMATIVE"
+        rows.append([name, f"{c:.3f}", status])
+    print(tabulate(rows, headers=["Parameter", "Contraction", "Status"], tablefmt="plain"), flush=True)
+
+    print("\n  --- Posterior Correlations (|r| > 0.3) ---", flush=True)
+    if len(draws) < 2:
+        print("    None", flush=True)
+        return
+
+    corr = pd.DataFrame(draws).corr()
+    cols = list(corr.columns)
+    rows = []
+    for i in range(len(cols)):
+        for j in range(i + 1, len(cols)):
+            r = corr.iloc[i, j]
+            if abs(r) > 0.3:
+                flag = "***" if abs(r) > 0.7 else "**" if abs(r) > 0.5 else "*"
+                rows.append([cols[i], cols[j], f"{r:+.3f}", flag])
+    if rows:
+        print(tabulate(rows, headers=["Parameter A", "Parameter B", "r", ""], tablefmt="plain"), flush=True)
+    else:
+        print("    None", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# 3. Retrodictive adequacy: does the model fit the data?
+# ---------------------------------------------------------------------------
+
+
+def run_retrodictive(
+    idata: az.InferenceData,
+    y: np.ndarray,
+    run: np.ndarray,
+    group_idx: np.ndarray,
+    groups: list[str],
+    n_runs: int,
+    run_to_version: dict[int, str],
+    loo_result: Any = None,
+) -> None:
+    """Pareto k analysis and residual autocorrelation checks."""
+    print("\n  === Retrodictive Diagnostics ===", flush=True)
+    _report_pareto_k(y, run, loo_result)
+    _report_residual_acf(idata, y, run, group_idx, groups, n_runs, run_to_version)
+
+
+def _report_pareto_k(y: np.ndarray, run: np.ndarray, loo_result: Any) -> None:
+    print("\n  --- Pareto k ---", flush=True)
+
+    pk = loo_result.pareto_k.values
+    high_k = np.where(pk > 0.7)[0]
+    p95 = np.percentile(y, 95)
+    p99 = np.percentile(y, 99)
+
+    print(f"    k > 0.7: {len(high_k)}/{len(pk)}", flush=True)
+    print(f"    Max k: {pk.max():.3f}", flush=True)
+    if len(high_k) > 0:
+        above_p95 = sum(y[i] > p95 for i in high_k)
+        above_p99 = sum(y[i] > p99 for i in high_k)
+        print(f"    Above p95 ({p95:.1f}ms): {above_p95}/{len(high_k)}", flush=True)
+        print(f"    Above p99 ({p99:.1f}ms): {above_p99}/{len(high_k)}", flush=True)
+        n_runs_affected = len({run[i] for i in high_k})
+        print(f"    Spread across {n_runs_affected} runs", flush=True)
+
+
+def _acf_per_run(resid: np.ndarray, run: np.ndarray, n_runs: int, max_lag: int = 5) -> dict[int, list[float]]:
+    """Per-run ACF at lags 1..max_lag. Returns {lag: [values]}."""
+    acfs = {lag: [] for lag in range(1, max_lag + 1)}
+    for t in range(n_runs):
+        mask = run == t
+        r = resid[mask]
+        if len(r) < 10:
+            continue
+        r = r - r.mean()
+        n = len(r)
+        c0 = np.sum(r**2) / n
+        if c0 == 0:
+            continue
+        for lag in range(1, max_lag + 1):
+            acfs[lag].append(np.sum(r[:-lag] * r[lag:]) / (n * c0))
+    return acfs
+
+
+def _compute_standardized_residuals(
+    idata: az.InferenceData,
+    y: np.ndarray,
+    run: np.ndarray,
+    group_idx: np.ndarray,
+    groups: list[str],
+    n_runs: int,
+    run_to_version: dict[int, str],
+) -> np.ndarray:
+    """Compute (y - mu_hat) / sqrt(Var_Wald) using posterior means.  Wald = Inverse Gaussian."""
+    mu_version_mean = idata.posterior["mu_version"].values.mean(axis=(0, 1))
+    beta_drift_mean = idata.posterior["beta_drift"].values.mean()
+    run_order_scaled = run.astype(float) / max(n_runs - 1, 1)
+
+    delta_run_mean = np.zeros(n_runs)
+    for g in groups:
+        delta_g = idata.posterior[f"delta_{g}"].values.mean(axis=(0, 1))
+        run_indices = sorted([t for t, v in run_to_version.items() if v == g])
+        for pos, t in enumerate(run_indices):
+            delta_run_mean[t] = delta_g[pos]
+
+    log_lambda_run_mean = idata.posterior["log_lambda_run"].values.mean(axis=(0, 1))
+    mu_hat = mu_version_mean[group_idx] + beta_drift_mean * run_order_scaled + delta_run_mean[run]
+    lambda_hat = np.exp(log_lambda_run_mean[run])
+    inverse_gaussian_variance = mu_hat**3 / lambda_hat
+    return (y - mu_hat) / np.sqrt(inverse_gaussian_variance)
+
+
+def _report_residual_acf(
+    idata: az.InferenceData,
+    y: np.ndarray,
+    run: np.ndarray,
+    group_idx: np.ndarray,
+    groups: list[str],
+    n_runs: int,
+    run_to_version: dict[int, str],
+) -> None:
+    print("\n  --- Residual Autocorrelation ---", flush=True)
+
+    std_resid = _compute_standardized_residuals(idata, y, run, group_idx, groups, n_runs, run_to_version)
+
+    acf_std = _acf_per_run(std_resid, run, n_runs)
+    print("    Standardized residual ACF:", flush=True)
+    for lag in range(1, 4):
+        vals = acf_std[lag]
+        if vals:
+            print(f"      ACF({lag}): mean={np.mean(vals):.3f}, median={np.median(vals):.3f}", flush=True)
+
+    acf_sq = _acf_per_run(std_resid**2, run, n_runs)
+    n_obs_typical = int(np.median([np.sum(run == t) for t in range(n_runs)]))
+    threshold = 2 / np.sqrt(max(n_obs_typical, 1))
+    print("    Squared residual ACF (volatility):", flush=True)
+    for lag in range(1, 4):
+        vals = acf_sq[lag]
+        if vals:
+            v = np.mean(vals)
+            sig = "SIGNIFICANT" if abs(v) > threshold else "ok"
+            print(f"      ACF({lag}): mean={v:.3f} [{sig}]", flush=True)

--- a/benchmarking/api_latency_comparison/analysis/fit_resp_latency_model.py
+++ b/benchmarking/api_latency_comparison/analysis/fit_resp_latency_model.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Fit Wald (Inverse Gaussian) latency model with GP temporal adjustment.
+
+HSGP(m=20, c=1.5) Gaussian process absorbs within-run autocorrelation.
+Matern32 kernel. Per-group ZeroSumNormal run intercepts. Centered
+run-level lambda. mu_version parameterization with beta_v derived as contrast.
+
+Usage:
+  python fit_resp_latency_model.py \
+    --data-dirs results/my-experiment \
+    --baseline baseline
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import arviz as az
+import numpy as np
+import nutpie
+import pandas as pd
+import pymc as pm
+import pytensor.tensor as pt
+
+from benchmarking.api_latency_comparison.analysis import (
+    wald_numba,  # noqa: F401 — registers numba dispatch for Wald (Inverse Gaussian) RV
+)
+from benchmarking.api_latency_comparison.analysis.decisions import compute_decisions
+from benchmarking.api_latency_comparison.analysis.diagnostics import run_all_diagnostics
+
+
+def load_data(data_dirs: list[str], baseline: str) -> dict[str, Any]:
+    """Load experiment data from one or more result directories.
+
+    Returns a dict with arrays and metadata needed by build_model and
+    compute_decisions.
+    """
+    all_dfs = []
+    all_meta = []
+
+    for data_dir in data_dirs:
+        data_dir = Path(data_dir)
+        meta = pd.read_csv(data_dir / "experiment-matrix.csv")
+        meta["group"] = meta["version_label"]
+        all_meta.append(meta)
+
+        for _, row in meta.iterrows():
+            f = data_dir / "runs" / str(row["run"]) / "requests.csv"
+            if not f.exists():
+                f = data_dir / "requests" / f"run-{row['run']}.csv"
+            df = pd.read_csv(
+                f, usecols=["timestamp", "response_time_ms", "status_code", "exception"], dtype={"exception": str}
+            )
+            df = df[
+                (df["response_time_ms"] > 0)
+                & (df["status_code"] == 200)
+                & (df["exception"].str.strip().eq("") | df["exception"].isna())
+            ]
+            df["run"] = row["run"]
+            df["group"] = row["group"]
+            all_dfs.append(df)
+
+    meta_combined = pd.concat(all_meta, ignore_index=True)
+    requests_all = pd.concat(all_dfs, ignore_index=True)
+    requests_all = requests_all.sort_values(["run", "timestamp"]).reset_index(drop=True)
+    requests_all["time_idx"] = requests_all.groupby("run").cumcount() + 1
+    groups = sorted(requests_all["group"].unique())
+    n_runs = int(requests_all["run"].nunique())
+
+    if baseline not in groups:
+        raise ValueError(f"baseline '{baseline}' not found in groups {groups}")
+
+    run_to_version = {row["run"]: row["group"] for _, row in meta_combined.iterrows()}
+
+    return {
+        "requests": requests_all,
+        "meta_combined": meta_combined,
+        "groups": groups,
+        "n_runs": n_runs,
+        "run_to_version": run_to_version,
+        "baseline": baseline,
+    }
+
+
+def _filter_observations(requests: pd.DataFrame) -> pd.DataFrame:
+    """Drop first and last observation per run (see MODEL.md Data Filtering)."""
+    max_idx = requests.groupby("run")["time_idx"].transform("max")
+    filtered = requests[(requests["time_idx"] > 1) & (requests["time_idx"] < max_idx)].copy()
+    filtered["time_idx"] = filtered.groupby("run").cumcount() + 1
+    n_dropped = len(requests) - len(filtered)
+    print(f"  Dropped {n_dropped} observations (first + last per run)", flush=True)
+    return filtered
+
+
+def _prepare_arrays(
+    requests: pd.DataFrame, groups: list[str], n_runs: int, run_to_version: dict[int, str], baseline: str
+) -> dict[str, Any]:
+    """Convert filtered DataFrame to arrays for model building."""
+    y = requests["response_time_ms"].values.astype(np.float64)
+    group_labels = requests["group"].values
+    time_idx = requests["time_idx"].values
+    run = requests["run"].values.astype(int)
+    group_to_idx = {g: i for i, g in enumerate(groups)}
+    group_idx = np.array([group_to_idx[g] for g in group_labels])
+
+    group_run_indices = {}
+    for g in groups:
+        group_run_indices[g] = sorted([t for t, v in run_to_version.items() if v == g])
+
+    run_counts = requests.groupby("run").size()
+    print(
+        f"  Observations per run: min={run_counts.min()}, median={int(run_counts.median())}, mean={run_counts.mean():.0f}, max={run_counts.max()}",
+        flush=True,
+    )
+    for g in groups:
+        mask = group_labels == g
+        n_t = requests.loc[mask, "run"].nunique()
+        print(f"    {g}: {n_t} runs, {mask.sum()} obs, median={np.median(y[mask]):.1f}ms", flush=True)
+
+    return {
+        "y": y,
+        "group_labels": group_labels,
+        "time_idx": time_idx,
+        "run": run,
+        "group_idx": group_idx,
+        "groups": groups,
+        "n_runs": n_runs,
+        "run_to_version": run_to_version,
+        "group_run_indices": group_run_indices,
+        "baseline": baseline,
+    }
+
+
+def build_model(raw_data: dict[str, Any]) -> tuple[pm.Model, dict[str, Any]]:
+    """Build the PyMC model. See MODEL.md for the full specification.
+
+    Filters observations (drops first/last per run) and builds the
+    model. Section comments match MODEL.md headings. The code defines
+    priors before assembling mu and the likelihood (bottom-up), while
+    MODEL.md presents likelihood first (top-down). Search by heading.
+    """
+    # Data Filtering (see MODEL.md)
+    filtered = _filter_observations(raw_data["requests"])
+    data = _prepare_arrays(
+        filtered,
+        raw_data["groups"],
+        raw_data["n_runs"],
+        raw_data["run_to_version"],
+        raw_data["baseline"],
+    )
+
+    groups = data["groups"]
+    n_runs = data["n_runs"]
+    y = data["y"]
+    group_run_indices = data["group_run_indices"]
+
+    # scale run order to [0, 1] for the drift covariate (global chronological position; RCBD blocking is in the design, not the model)
+    run_order_scaled = data["run"].astype(np.float64) / max(n_runs - 1, 1)
+
+    # coords label posterior output axes (e.g. mu_version[baseline] instead of mu_version[0])
+    coords = {"group": groups, "obs_id": np.arange(len(y)), "run": np.arange(n_runs)}
+    for g in groups:
+        coords[f"run_{g}"] = np.arange(len(group_run_indices[g]))
+
+    with pm.Model(coords=coords) as model:
+        x_time = pm.Data("x_time", data["time_idx"].astype(np.float64)[:, None])
+        x_drift = pm.Data("x_drift", run_order_scaled, dims="obs_id")
+        x_run = pm.Data("x_run", data["run"], dims="obs_id")
+        x_group = pm.Data("x_group", data["group_idx"], dims="obs_id")
+
+        # Mean Structure
+        mu_version = pm.Normal("mu_version", mu=25, sigma=10, dims="group")
+        beta_drift = pm.Normal("beta_drift", mu=0, sigma=2)
+
+        # Run Intercepts
+        sigma_run = pm.Exponential("sigma_run", lam=1)
+        delta_blocks = []
+        for _gidx, g in enumerate(groups):
+            delta_g = pm.ZeroSumNormal(f"delta_{g}", sigma=sigma_run, dims=f"run_{g}")
+            delta_blocks.append(delta_g)
+        delta_run_full = pt.zeros(n_runs)
+        for gidx, g in enumerate(groups):
+            for pos, t in enumerate(group_run_indices[g]):
+                delta_run_full = pt.set_subtensor(delta_run_full[t], delta_blocks[gidx][pos])
+
+        # Shape Structure
+        log_lambda_bar = pm.Normal("log_lambda_bar", mu=7, sigma=2)
+        sigma_lambda = pm.Exponential("sigma_lambda", lam=1)
+        log_lambda_run = pm.Normal("log_lambda_run", mu=log_lambda_bar, sigma=sigma_lambda, dims="run")
+        lambda_obs = pt.exp(log_lambda_run[x_run])
+
+        # GP Temporal Adjustment
+        eta_gp = pm.HalfNormal("eta_gp", sigma=0.25)
+        ell_gp = pm.InverseGamma("ell_gp", mu=6, sigma=3)
+        cov_func = eta_gp**2 * pm.gp.cov.Matern32(input_dim=1, ls=ell_gp)
+        gp = pm.gp.HSGP(m=[20], c=1.5, cov_func=cov_func, parametrization="noncentered", drop_first=True)
+        f = gp.prior("f", X=x_time)
+
+        # Likelihood
+        mu = mu_version[x_group] + beta_drift * x_drift + delta_run_full[x_run] + f
+        mu = pt.maximum(mu, 1e-6)  # Wald (Inverse Gaussian) requires mu > 0; clamp if GP/intercepts go negative
+        pm.Wald("y", mu=mu, lam=lambda_obs, observed=y, dims="obs_id")
+
+        # Derived Quantities
+        baseline_idx = groups.index(data["baseline"])
+        pm.Deterministic("beta_v", mu_version - mu_version[baseline_idx])
+
+    return model, data
+
+
+def fit_and_diagnose(model: pm.Model, data: dict[str, Any], out_dir: Path) -> az.InferenceData:
+    """Sample with nutpie, compute LOO-CV, run diagnostics, save idata to out_dir."""
+    ts = datetime.now(tz=UTC).strftime("%H:%M:%S")
+    print(f"[{ts}] --- Fitting (4 chains, 1000+1000, nutpie) ---", flush=True)
+
+    compiled = nutpie.compile_pymc_model(model)
+    t0 = time.time()
+    idata = nutpie.sample(
+        compiled,
+        draws=1000,
+        tune=1000,
+        chains=4,
+        target_accept=0.95,
+        seed=42,
+        progress_bar=True,
+    )
+    fit_time = time.time() - t0
+    ts = datetime.now(tz=UTC).strftime("%H:%M:%S")
+    print(f"[{ts}]   Fit time: {fit_time:.1f}s", flush=True)
+
+    summary = az.summary(
+        idata,
+        var_names=[
+            "mu_version",
+            "beta_v",
+            "beta_drift",
+            "sigma_run",
+            "log_lambda_bar",
+            "sigma_lambda",
+            "eta_gp",
+            "ell_gp",
+        ],
+        kind="all",
+        ci_kind="hdi",
+        ci_prob=0.89,
+    )
+    print(summary.to_string(), flush=True)
+
+    with model:
+        pm.compute_log_likelihood(idata)
+    loo_result = az.loo(idata, pointwise=True)
+
+    run_all_diagnostics(
+        idata,
+        data["y"],
+        data["run"],
+        data["group_idx"],
+        data["groups"],
+        data["n_runs"],
+        data["run_to_version"],
+        summary=summary,
+        loo_result=loo_result,
+    )
+
+    idata.to_netcdf(str(out_dir / "idata.nc"))
+    return idata
+
+
+def load_and_fit(data_dirs: list[str], baseline: str) -> dict[str, Any]:
+    raw_data = load_data(data_dirs, baseline)
+    model, data = build_model(raw_data)
+    out_dir = Path(data_dirs[0]) / "analysis" / "fits"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    idata = fit_and_diagnose(model, data, out_dir)
+    decisions, fp_results = compute_decisions(model, idata, data)
+
+    pd.DataFrame(decisions).to_csv(out_dir / "decisions.csv", index=False)
+    with open(out_dir / "fp-results.json", "w") as f:
+        json.dump(fp_results, f, indent=2)
+    print(f"  Saved: {out_dir}", flush=True)
+
+    return fp_results
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Fit Wald (Inverse Gaussian) latency model with GP temporal adjustment"
+    )
+    parser.add_argument("--data-dirs", required=True, help="Comma-separated experiment results directories")
+    parser.add_argument("--baseline", required=True, help="Baseline group label for contrasts (e.g., v1.0.2)")
+    args = parser.parse_args()
+    dirs = [d.strip() for d in args.data_dirs.split(",")]
+    try:
+        fp_results = load_and_fit(dirs, args.baseline)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    if fp_results.get("false_positive_detected"):
+        sys.exit(1)

--- a/benchmarking/api_latency_comparison/analysis/smoke_test.py
+++ b/benchmarking/api_latency_comparison/analysis/smoke_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Pre-flight smoke test for the analysis modeling stack.
+
+Validates the full chain used by fit_resp_latency_model.py:
+nutpie compile+sample, NetCDF save/reload, and LOO computation.
+"""
+
+import tempfile
+import time
+import traceback
+from pathlib import Path
+
+import arviz as az
+import numpy as np
+import nutpie
+import pymc as pm
+import wald_numba  # noqa: F401 — registers numba dispatch for Wald (Inverse Gaussian) RV
+
+if __name__ == "__main__":
+    print("[smoke_test] Starting analysis stack smoke test...", flush=True)
+    t0 = time.time()
+
+    try:
+        rng = np.random.default_rng(42)
+        y = rng.wald(mean=25, scale=9000, size=20)
+
+        with pm.Model() as model:
+            mu = pm.Normal("mu", mu=25, sigma=10)
+            lam = pm.HalfNormal("lam", sigma=100)
+            pm.Wald("y", mu=mu, lam=lam, observed=y)
+
+        compiled = nutpie.compile_pymc_model(model)
+        idata = nutpie.sample(compiled, draws=50, tune=50, chains=2, seed=42, progress_bar=False)
+        print(f"  nutpie sample: {idata.posterior.dims['draw'] * idata.posterior.dims['chain']} draws", flush=True)
+
+        with model:
+            pm.compute_log_likelihood(idata)
+
+        with tempfile.TemporaryDirectory(prefix="smoke-") as tmp:
+            nc = Path(tmp) / "smoke.nc"
+            idata.to_netcdf(str(nc))
+            reloaded = az.from_netcdf(str(nc))
+            assert hasattr(reloaded, "posterior")
+
+        print("  NetCDF save/reload: OK", flush=True)
+        loo = az.loo(idata, pointwise=True)
+        print(f"  LOO ELPD: {loo.elpd:.1f}", flush=True)
+        print(f"\n[smoke_test] PASSED in {time.time() - t0:.1f}s", flush=True)
+
+    except Exception as e:
+        print(f"\n[smoke_test] FAILED: {e}", flush=True)
+        traceback.print_exc()
+        raise SystemExit(1) from e

--- a/benchmarking/api_latency_comparison/analysis/wald_numba.py
+++ b/benchmarking/api_latency_comparison/analysis/wald_numba.py
@@ -1,0 +1,29 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Numba dispatch registration for PyMC's Wald (Inverse Gaussian) distribution.
+
+PyMC's Wald (Inverse Gaussian) RV lacks a numba dispatch, so nutpie
+compilation fails without this shim. Importing this module registers
+the dispatch once.
+"""
+
+from typing import Any
+
+from pymc.distributions.continuous import WaldRV as _PyMCWaldRV
+from pytensor.link.numba.dispatch import basic as _numba_basic
+from pytensor.link.numba.dispatch.random import numba_core_rv_funcify
+
+
+@numba_core_rv_funcify.register(_PyMCWaldRV)
+def _numba_wald_dispatch(op: Any, node: Any) -> Any:
+    """Return a numba-jitted Wald (Inverse Gaussian) sampler for nutpie compilation."""
+
+    @_numba_basic.numba_njit
+    def random(rng, mu, lam, alpha):
+        return rng.wald(mu, lam) + alpha
+
+    return random

--- a/benchmarking/api_latency_comparison/configs/stack-config-benchmark.yaml
+++ b/benchmarking/api_latency_comparison/configs/stack-config-benchmark.yaml
@@ -1,0 +1,70 @@
+version: 2
+distro_name: vertical-scaling-responses-agentic
+apis:
+- inference
+- responses
+- vector_io
+- tool_runtime
+- files
+providers:
+  inference:
+  - provider_id: openai
+    provider_type: remote::openai
+    config:
+      api_key: ${env.OPENAI_API_KEY:=fake-token}
+      base_url: ${env.OPENAI_BASE_URL:=http://localhost:8080/v1}
+  responses:
+  - provider_id: builtin
+    provider_type: inline::builtin
+    config:
+      persistence:
+        agent_state:
+          namespace: agents
+          backend: kv_default
+        responses:
+          table_name: responses
+          backend: sql_default
+  vector_io:
+  - provider_id: faiss
+    provider_type: inline::faiss
+    config:
+      kvstore:
+        namespace: vector_io::faiss
+        backend: kv_default
+      persistence:
+        namespace: vector_io::faiss_persistence
+        backend: kv_default
+  tool_runtime:
+  - provider_id: brave-search
+    provider_type: remote::brave-search
+    config:
+      api_key: "fake-benchmark-key"
+      max_results: 1
+      base_url: ${env.MOCK_SEARCH_URL:=http://localhost:8080}
+  files:
+  - provider_id: builtin-files
+    provider_type: inline::localfs
+    config:
+      storage_dir: /tmp/ogx-benchmark/files
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
+storage:
+  backends:
+    kv_default:
+      type: kv_sqlite
+      db_path: /tmp/ogx-benchmark/kvstore.db
+    sql_default:
+      type: sql_sqlite
+      db_path: /tmp/ogx-benchmark/sql_store.db
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+registered_resources:
+  models:
+  - model_id: mock-model
+    provider_id: openai
+    model_type: llm
+server:
+  port: 8321

--- a/benchmarking/api_latency_comparison/experiment/__init__.py
+++ b/benchmarking/api_latency_comparison/experiment/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/benchmarking/api_latency_comparison/experiment/benchmark.py
+++ b/benchmarking/api_latency_comparison/experiment/benchmark.py
@@ -33,6 +33,7 @@ from typing import Any
 import pandas as pd
 from mirakuru import HTTPExecutor
 
+from benchmarking.api_latency_comparison.analysis.fit_resp_latency_model import load_and_fit
 from benchmarking.api_latency_comparison.experiment.generate_design_matrix import (
     find_latest_release_tag,
     generate_matrix,
@@ -295,6 +296,7 @@ def run_experiment(cfg: dict[str, Any], results_dir: Path | str, matrix_csv: Pat
     """Main experiment loop."""
     results_dir = Path(results_dir)
     (results_dir / "runs").mkdir(parents=True, exist_ok=True)
+    (results_dir / "analysis" / "fits").mkdir(parents=True, exist_ok=True)
     taskset = run_all_checks(
         str(results_dir),
         str(matrix_csv),
@@ -429,6 +431,11 @@ def setup_and_generate(results_dir: Path, baseline_ref: str | None, comparison_r
     return matrix_path
 
 
+def fit_model(results_dir: Path, baseline_label: str) -> dict[str, Any]:
+    log("Fitting model...")
+    return load_and_fit([str(results_dir)], baseline_label)
+
+
 def cleanup_worktrees(cfg: dict[str, Any]) -> None:
     for label in [BASELINE_LABEL, COMPARISON_LABEL]:
         shutil.rmtree(f"{cfg['worktree_base']}/{label}", ignore_errors=True)
@@ -437,12 +444,13 @@ def cleanup_worktrees(cfg: dict[str, Any]) -> None:
 
 def run_benchmark(
     cfg: dict[str, Any], results_dir: Path | str, baseline_ref: str | None, comparison_ref: str, replicates: int
-) -> None:
+) -> dict[str, Any]:
     results_dir = Path(results_dir)
     results_dir.mkdir(parents=True, exist_ok=True)
 
     matrix_csv = setup_and_generate(results_dir, baseline_ref, comparison_ref, replicates)
     run_experiment(cfg, results_dir, matrix_csv)
+    return fit_model(results_dir, BASELINE_LABEL)
 
 
 def _default_config() -> dict[str, Any]:
@@ -481,8 +489,9 @@ def main() -> None:
     log(f"  Results: {results_dir}")
     log(f"  Duration: {cfg['run_duration']}s per run")
 
+    fp_results = {}
     try:
-        run_benchmark(cfg, results_dir, args.baseline_ref, args.comparison_ref, args.replicates)
+        fp_results = run_benchmark(cfg, results_dir, args.baseline_ref, args.comparison_ref, args.replicates)
     except (PreflightError, ValueError) as e:
         log(f"ERROR: {e}")
         sys.exit(1)
@@ -490,6 +499,9 @@ def main() -> None:
         sys.exit(130)
     finally:
         cleanup_worktrees(cfg)
+
+    if fp_results.get("false_positive_detected"):
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/benchmarking/api_latency_comparison/experiment/benchmark.py
+++ b/benchmarking/api_latency_comparison/experiment/benchmark.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Benchmark experiment orchestrator.
+
+Iterates a design matrix, starts servers per run, runs Locust,
+collects latency data. Each run is fully independent.
+
+Usage:
+  uv run python experiment/benchmark.py --baseline-ref v1.0.2 --comparison-ref HEAD
+"""
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import traceback
+import urllib.request
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from mirakuru import HTTPExecutor
+
+from benchmarking.api_latency_comparison.experiment.generate_design_matrix import (
+    find_latest_release_tag,
+    generate_matrix,
+    resolve_version_hash,
+)
+from benchmarking.api_latency_comparison.experiment.preflight import (
+    PreflightError,
+    log,
+    record_environment,
+    run_all_checks,
+)
+from benchmarking.api_latency_comparison.experiment.runlog import RunLogEntry, append_run_log, load_completed_runs
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+PROJECT_DIR = SCRIPT_DIR.parent
+REPO_ROOT = (PROJECT_DIR / ".." / "..").resolve()
+BASELINE_LABEL = "baseline"
+COMPARISON_LABEL = "comparison"
+
+
+class PinnedHTTPExecutor(HTTPExecutor):
+    def __init__(self, *args: Any, cpu_affinity: set[int] | None = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._cpu_affinity = cpu_affinity
+
+    @property
+    def _popen_kwargs(self) -> dict[str, Any]:
+        kwargs = super()._popen_kwargs
+        if self._cpu_affinity is not None:
+            affinity = self._cpu_affinity
+
+            def pinned_preexec():
+                os.setsid()
+                os.sched_setaffinity(0, affinity)
+
+            kwargs["preexec_fn"] = pinned_preexec
+        return kwargs
+
+
+def _get_worktree_dir(cfg: dict[str, Any], version_label: str) -> Path:
+    if version_label == BASELINE_LABEL:
+        return Path(cfg["worktree_base"]) / BASELINE_LABEL
+    return Path(cfg["worktree_base"]) / COMPARISON_LABEL
+
+
+def _clear_ogx_state() -> None:
+    """Remove SQLite DBs and file cache from /tmp/ogx-benchmark."""
+    for f in ["/tmp/ogx-benchmark/kvstore.db", "/tmp/ogx-benchmark/sql_store.db"]:  # noqa: S108
+        try:
+            os.unlink(f)
+        except FileNotFoundError:
+            pass
+    shutil.rmtree("/tmp/ogx-benchmark/files", ignore_errors=True)  # noqa: S108
+
+
+def _verify_cpu_pinning(pid: int, expected_core: int, name: str) -> None:
+    try:
+        actual = os.sched_getaffinity(pid)
+        if actual == {expected_core}:
+            log(f"  {name} (PID {pid}) pinned to core {expected_core}")
+        else:
+            log(f"  WARNING: {name} (PID {pid}) expected core {{{expected_core}}}, got {actual}")
+    except OSError:
+        pass
+
+
+@contextmanager
+def _servers(cfg: dict[str, Any], version: str, ogx_log_path: Path) -> Generator[None, None, None]:
+    """Context manager that starts mock + OGX servers for one run."""
+    with _mock_server_executor(cfg, version) as mock_exec:
+        if cfg["taskset_available"] and mock_exec.process is not None:
+            _verify_cpu_pinning(mock_exec.process.pid, cfg["cpu_mock"], "mock")
+        with _ogx_server_executor(cfg, version, ogx_log_path) as ogx_exec:  # noqa: SIM117
+            if cfg["taskset_available"] and ogx_exec.process is not None:
+                _verify_cpu_pinning(ogx_exec.process.pid, cfg["cpu_ogx"], "OGX")
+            _reset_mock(cfg)
+            yield
+
+
+def _make_executor(cmd: list[str], kwargs: dict[str, Any], cfg: dict[str, Any], cpu_key: str) -> HTTPExecutor:
+    """Create an HTTPExecutor, optionally with CPU pinning."""
+    if cfg["taskset_available"]:
+        return PinnedHTTPExecutor(cmd, cpu_affinity={cfg[cpu_key]}, **kwargs)
+    return HTTPExecutor(cmd, **kwargs)
+
+
+def _mock_server_executor(cfg: dict[str, Any], version_label: str) -> HTTPExecutor:
+    wt_dir = _get_worktree_dir(cfg, version_label)
+    cmd = [sys.executable, str(SCRIPT_DIR / "mock_server.py"), str(cfg["mock_port"])]
+    kwargs = dict(
+        url=f"http://localhost:{cfg['mock_port']}/v1/health",
+        method="GET",
+        timeout=10,
+        cwd=str(wt_dir),
+        expected_returncode=-signal.SIGTERM,
+    )
+    return _make_executor(cmd, kwargs, cfg, "cpu_mock")
+
+
+@contextmanager
+def _ogx_server_executor(
+    cfg: dict[str, Any], version_label: str, log_path: Path
+) -> Generator[HTTPExecutor, None, None]:
+    wt_dir = _get_worktree_dir(cfg, version_label)
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "ogx.core.server.server:create_app",
+        "--port",
+        str(cfg["stack_port"]),
+        "--factory",
+    ]
+    with open(log_path, "a") as log_file:
+        kwargs = dict(
+            url=f"http://localhost:{cfg['stack_port']}/v1/health",
+            method="GET",
+            timeout=30,
+            cwd=str(wt_dir),
+            envvars={
+                "OPENAI_BASE_URL": f"http://localhost:{cfg['mock_port']}/v1",
+                "OPENAI_API_KEY": "fake-token",
+                "OGX_CONFIG": str(PROJECT_DIR / "configs" / "stack-config-benchmark.yaml"),
+            },
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            expected_returncode=-signal.SIGTERM,
+        )
+        with _make_executor(cmd, kwargs, cfg, "cpu_ogx") as executor:
+            yield executor
+
+
+def _reset_mock(cfg: dict[str, Any]) -> None:
+    """POST /reset to the mock server to zero its counters."""
+    req = urllib.request.Request(f"http://localhost:{cfg['mock_port']}/reset", method="POST")
+    try:
+        urllib.request.urlopen(req, timeout=2)  # noqa: S310
+    except Exception:
+        time.sleep(0.5)
+        urllib.request.urlopen(req, timeout=2)  # noqa: S310
+
+
+def _run_locust(cfg: dict[str, Any], row: dict[str, Any], results_dir: Path) -> tuple[int, Path]:
+    """Run a single Locust session, return (exit_code, request_csv_path)."""
+    run_id = row["run"]
+    rd = results_dir / "runs" / str(run_id)
+    rd.mkdir(parents=True, exist_ok=True)
+    request_csv = rd / "requests.csv"
+    locust_log = rd / "locust.log"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "locust",
+        "-f",
+        str(SCRIPT_DIR / "locustfile_responses.py"),
+        "--headless",
+        "-u",
+        "1",
+        "-r",
+        "1",
+        "--run-time",
+        f"{cfg['run_duration']}s",
+        "--host",
+        f"http://localhost:{cfg['stack_port']}",
+    ]
+
+    env = os.environ.copy()
+    env["BENCHMARK_MODE"] = row.get("benchmark_mode", "agentic")
+    env["REQUEST_LOG"] = str(request_csv)
+
+    run_kwargs = {}
+    if cfg["taskset_available"]:
+        affinity = {cfg["cpu_locust"]}
+
+        def pinned_preexec():
+            os.sched_setaffinity(0, affinity)
+
+        run_kwargs["preexec_fn"] = pinned_preexec
+
+    with open(locust_log, "w") as lf:
+        result = subprocess.run(cmd, env=env, stdout=lf, stderr=subprocess.STDOUT, **run_kwargs)  # noqa: S603
+
+    return result.returncode, request_csv
+
+
+def _validate_agentic_loop(cfg: dict[str, Any]) -> None:
+    """Verify the agentic loop fires (web_search_call in response)."""
+    log("Validating agentic loop...")
+    _reset_mock(cfg)
+
+    payload = json.dumps(
+        {
+            "model": "openai/mock-model",
+            "input": "agentic loop check",
+            "tools": [{"type": "web_search"}],
+            "stream": False,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"http://localhost:{cfg['stack_port']}/v1/responses",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    resp = urllib.request.urlopen(req, timeout=30)  # noqa: S310
+    data = json.loads(resp.read())
+    types = [item.get("type") for item in data.get("output", [])]
+    if "web_search_call" not in types:
+        raise RuntimeError(f"Agentic loop not firing: output types = {types}")
+
+    stats = json.loads(urllib.request.urlopen(f"http://localhost:{cfg['mock_port']}/stats", timeout=2).read())
+    search_count = stats.get("get_search_count", 0)
+    if search_count >= 1:
+        log(f"  Agentic loop validated: search_count={search_count}")
+    else:
+        log(f"WARNING: Mock search endpoint not called (search_count={search_count})")
+
+
+def run_preflight_benchmark(cfg: dict[str, Any], results_dir: Path) -> None:
+    """Start servers, run a short benchmark, validate agentic loop."""
+    log("=== Pre-Flight Benchmark ===")
+
+    baseline = BASELINE_LABEL
+    _clear_ogx_state()
+
+    preflight_dir = results_dir / "runs" / "preflight"
+    preflight_dir.mkdir(parents=True, exist_ok=True)
+    with _servers(cfg, baseline, preflight_dir / "ogx.log"):
+        _validate_agentic_loop(cfg)
+        log("  Pre-flight benchmark passed")
+
+
+def _record_run(
+    results_dir: Path,
+    row: dict[str, Any],
+    run_id: int,
+    version: str,
+    start: int,
+    end: int,
+    n_requests: int,
+    status: str,
+) -> None:
+    entry = RunLogEntry(
+        run=run_id,
+        version_label=version,
+        version_hash=row["version_hash"],
+        replicate=row["replicate"],
+        benchmark_mode=row.get("benchmark_mode", "agentic"),
+        mock_tool_call_count=row.get("mock_tool_call_count", 1),
+        start_time=start,
+        end_time=end,
+        duration_s=end - start,
+        requests_completed=n_requests,
+        status=status,
+    )
+    append_run_log(results_dir / "run-log.csv", entry)
+
+
+def run_experiment(cfg: dict[str, Any], results_dir: Path | str, matrix_csv: Path) -> None:
+    """Main experiment loop."""
+    results_dir = Path(results_dir)
+    (results_dir / "runs").mkdir(parents=True, exist_ok=True)
+    taskset = run_all_checks(
+        str(results_dir),
+        str(matrix_csv),
+        cfg["worktree_base"],
+        BASELINE_LABEL,
+        COMPARISON_LABEL,
+        cfg["mock_port"],
+        cfg["stack_port"],
+    )
+    cfg["taskset_available"] = taskset
+
+    cfg["repo_root"] = str(REPO_ROOT)
+    cfg["baseline_label"] = BASELINE_LABEL
+    cfg["comparison_label"] = COMPARISON_LABEL
+    record_environment(cfg, str(results_dir))
+
+    run_preflight_benchmark(cfg, results_dir)
+
+    matrix = pd.read_csv(matrix_csv).to_dict("records")
+    run_log = results_dir / "run-log.csv"
+    completed = load_completed_runs(run_log) if run_log.exists() else set()
+    total_runs = len(matrix)
+    failed_runs = 0
+    start_time = time.time()
+
+    log(f"Matrix: {total_runs} runs ({len(completed)} already completed)")
+
+    interrupted = False
+
+    def handle_signal(signum: int, frame: Any) -> None:
+        nonlocal interrupted
+        interrupted = True
+        log("\n=== INTERRUPTED ===")
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    for i, row in enumerate(matrix, 1):
+        if interrupted:
+            break
+
+        run_id = row["run"]
+        if run_id in completed:
+            continue
+
+        version = row["version_label"]
+        log(f"--- Run {i}/{total_runs}: run={run_id} version={version} rep={row['replicate']} ---")
+
+        _clear_ogx_state()
+        run_start = int(time.time())
+
+        try:
+            rd = results_dir / "runs" / str(run_id)
+            rd.mkdir(parents=True, exist_ok=True)
+            with _servers(cfg, version, rd / "ogx.log"):
+                exit_code, request_csv = _run_locust(cfg, row, results_dir)
+                if request_csv.exists():
+                    with open(request_csv) as f:
+                        n_requests = sum(1 for _ in f) - 1
+                else:
+                    n_requests = 0
+
+            run_end = int(time.time())
+
+            if n_requests == 0:
+                status = "locust_crash" if exit_code != 0 else "error"
+                log(f"  WARNING: {status} (exit={exit_code}, 0 requests)")
+                failed_runs += 1
+            else:
+                status = "ok"
+                if exit_code != 0:
+                    log(f"  WARNING: Locust exited {exit_code} but produced {n_requests} requests")
+
+            _record_run(results_dir, row, run_id, version, run_start, run_end, n_requests, status)
+            log(f"  Result: {n_requests} reqs, status={status}")
+
+        except Exception as e:
+            run_end = int(time.time())
+            log(f"  ERROR: {e}\n{traceback.format_exc()}")
+            failed_runs += 1
+            _record_run(results_dir, row, run_id, version, run_start, run_end, 0, "error")
+
+    total_duration = int(time.time() - start_time)
+    total_ok = len(load_completed_runs(run_log) if run_log.exists() else set())
+
+    log("")
+    log("=== Benchmark Complete ===")
+    log(f"  Total elapsed: {total_duration // 60}m {total_duration % 60}s")
+    log(f"  Runs: {total_ok} ok, {failed_runs} error")
+
+    if interrupted:
+        log("\nExperiment was interrupted. Resume with the same command.")
+        raise KeyboardInterrupt
+
+
+def setup_and_generate(results_dir: Path, baseline_ref: str | None, comparison_ref: str, replicates: int) -> Path:
+    """Resolve refs, setup worktrees, generate design matrix. Returns matrix CSV path."""
+    baseline_ref = baseline_ref or find_latest_release_tag()
+
+    log("Setting up worktrees...")
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "bash",
+            str(SCRIPT_DIR / "setup-worktree.sh"),
+            "--repo",
+            str(REPO_ROOT),
+            "--baseline",
+            baseline_ref,
+            "--baseline-label",
+            BASELINE_LABEL,
+            "--comparison",
+            comparison_ref,
+            "--comparison-label",
+            COMPARISON_LABEL,
+        ],
+        check=True,
+    )
+
+    log("Generating design matrix...")
+    baseline_hash = resolve_version_hash(baseline_ref)
+    comparison_hash = resolve_version_hash(comparison_ref)
+    versions = [
+        {"label": BASELINE_LABEL, "hash": baseline_hash},
+        {"label": COMPARISON_LABEL, "hash": comparison_hash},
+        {"label": f"{COMPARISON_LABEL}_ctrl", "hash": comparison_hash},
+    ]
+    rows = generate_matrix(versions, replicates, seed=42)
+    matrix_path = results_dir / "experiment-matrix.csv"
+    pd.DataFrame(rows).to_csv(matrix_path, index=False)
+    log(f"  Wrote: {matrix_path} ({len(rows)} runs)")
+
+    return matrix_path
+
+
+def cleanup_worktrees(cfg: dict[str, Any]) -> None:
+    for label in [BASELINE_LABEL, COMPARISON_LABEL]:
+        shutil.rmtree(f"{cfg['worktree_base']}/{label}", ignore_errors=True)
+    subprocess.run(["git", "-C", str(REPO_ROOT), "worktree", "prune"], capture_output=True)  # noqa: S603, S607
+
+
+def run_benchmark(
+    cfg: dict[str, Any], results_dir: Path | str, baseline_ref: str | None, comparison_ref: str, replicates: int
+) -> None:
+    results_dir = Path(results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    matrix_csv = setup_and_generate(results_dir, baseline_ref, comparison_ref, replicates)
+    run_experiment(cfg, results_dir, matrix_csv)
+
+
+def _default_config() -> dict[str, Any]:
+    return {
+        "worktree_base": os.environ.get("WORKTREE_BASE", "/tmp/ci-validation"),  # noqa: S108
+        "run_duration": int(os.environ.get("RUN_DURATION", "10")),
+        "mock_port": int(os.environ.get("MOCK_PORT", "8080")),
+        "stack_port": int(os.environ.get("STACK_PORT", "8321")),
+        "seed": os.environ.get("SEED", "42"),
+        "cpu_ogx": int(os.environ.get("CPU_OGX", "0")),
+        "cpu_locust": int(os.environ.get("CPU_LOCUST", "1")),
+        "cpu_mock": int(os.environ.get("CPU_MOCK", "2")),
+        "taskset_available": True,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark experiment orchestrator")
+    parser.add_argument("--baseline-ref", default=None, help="Baseline git ref (default: latest release tag)")
+    parser.add_argument("--comparison-ref", default="HEAD", help="Comparison git ref (default: HEAD)")
+    parser.add_argument("--replicates", type=int, default=3, help="Replicates per group (default: 3)")
+    parser.add_argument("--run-duration", type=int, default=10, help="Seconds per run (default: 10)")
+    parser.add_argument("--results-dir", help="Results directory (default: auto-timestamped)")
+    args = parser.parse_args()
+
+    cfg = _default_config()
+    cfg["run_duration"] = args.run_duration
+
+    if args.results_dir:
+        results_dir = Path(args.results_dir)
+    else:
+        ts = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+        results_dir = REPO_ROOT / "results" / f"api-latency-{ts}"
+
+    log("=== Benchmark Experiment ===")
+    log(f"  Results: {results_dir}")
+    log(f"  Duration: {cfg['run_duration']}s per run")
+
+    try:
+        run_benchmark(cfg, results_dir, args.baseline_ref, args.comparison_ref, args.replicates)
+    except (PreflightError, ValueError) as e:
+        log(f"ERROR: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+    finally:
+        cleanup_worktrees(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/api_latency_comparison/experiment/generate_design_matrix.py
+++ b/benchmarking/api_latency_comparison/experiment/generate_design_matrix.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Generate randomized experiment matrices for CI regression benchmarking.
+
+Generates a CSV with one row per run, randomized across version groups.
+Each version group gets the specified number of replicates.
+"""
+
+import argparse
+import os
+import random
+import subprocess
+import sys
+from typing import Any
+
+import pandas as pd
+
+
+def _git(args: list[str], git_dir: str | None = None) -> subprocess.CompletedProcess[str]:
+    cmd = ["git"]
+    if git_dir:
+        cmd.extend(["-C", git_dir])
+    cmd.extend(args)
+    return subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+
+
+def find_latest_release_tag(git_dir: str | None = None) -> str:
+    result = _git(["tag", "--sort=-v:refname"], git_dir)
+    for line in result.stdout.splitlines():
+        tag = line.strip()
+        if tag and tag[0] == "v" and tag.count(".") == 2:
+            print(f"  Latest release tag: {tag}", flush=True)
+            return tag
+    raise ValueError("no release tags found (vX.Y.Z)")
+
+
+def resolve_version_hash(label: str, git_dir: str | None = None) -> str:
+    """Use git rev-parse to turn a tag, branch, or short hash into a full SHA for immutable experiment metadata."""
+    result = _git(["rev-parse", label], git_dir)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    result = _git(["rev-parse", f"origin/{label}"], git_dir)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    msg = f"could not resolve git ref '{label}'"
+    if git_dir:
+        msg += f" (in repo: {git_dir})"
+    raise ValueError(msg)
+
+
+def generate_matrix(versions: list[dict[str, str]], replicates: int, seed: int) -> list[dict[str, Any]]:
+    """Generate RCBD experiment design matrix.
+
+    Randomized Complete Block Design: each block contains exactly one
+    run of each version in a random order. Blocks are in temporal
+    sequence (block 1 runs first). Within-block randomization prevents
+    position effects from aliasing with treatment effects.
+
+    Args:
+        versions: list of {"label": str, "hash": str}
+        replicates: number of blocks (one replicate per version per block)
+        seed: random seed for within-block randomization
+    """
+    rng = random.Random(seed)
+    all_rows = []
+    for block in range(1, replicates + 1):
+        block_rows = []
+        for ver in versions:
+            block_rows.append(
+                {
+                    "version_hash": ver["hash"],
+                    "version_label": ver["label"],
+                    "run": 0,
+                    "replicate": block,
+                    "block": block,
+                    "benchmark_mode": "agentic",
+                    "mock_tool_call_count": 1,
+                }
+            )
+        rng.shuffle(block_rows)
+        all_rows.extend(block_rows)
+
+    for i, row in enumerate(all_rows):
+        row["run"] = i
+
+    return all_rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate experiment matrices for CI regression benchmarking")
+    parser.add_argument(
+        "--versions", default=None, help="Comma-separated version labels (omit to use --baseline-ref/--comparison-ref)"
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    parser.add_argument("--replicates", type=int, default=1, help="Replicates per cell (default: 1)")
+    parser.add_argument("--output-dir", default=".", help="Output directory (default: .)")
+    parser.add_argument("--repo", default=None, help="Path to OGX git repo for resolving git refs")
+    parser.add_argument("--baseline-ref", default=None, help="Baseline git ref (empty or omitted = latest release tag)")
+    parser.add_argument("--comparison-ref", default="HEAD", help="Comparison git ref (default: HEAD)")
+    args = parser.parse_args()
+
+    hash_map = {}
+
+    if args.replicates < 1:
+        print("WARNING: --replicates < 1, using 1", file=sys.stderr)
+        args.replicates = 1
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if args.versions:
+        labels = [v.strip() for v in args.versions.split(",")]
+    else:
+        baseline_ref = args.baseline_ref or find_latest_release_tag(args.repo)
+        comparison_ref = args.comparison_ref
+        labels = ["baseline", "comparison", "comparison_ctrl"]
+        baseline_hash = resolve_version_hash(baseline_ref, git_dir=args.repo)
+        comparison_hash = resolve_version_hash(comparison_ref, git_dir=args.repo)
+        hash_map = {
+            "baseline": baseline_hash,
+            "comparison": comparison_hash,
+            "comparison_ctrl": comparison_hash,
+        }
+
+    versions = []
+    for label in labels:
+        if label in hash_map:
+            version_hash = hash_map[label]
+        else:
+            version_hash = resolve_version_hash(label, git_dir=args.repo)
+        versions.append({"label": label, "hash": version_hash})
+
+    all_rows = generate_matrix(versions, args.replicates, args.seed)
+    matrix_path = os.path.join(args.output_dir, "experiment-matrix.csv")
+    pd.DataFrame(all_rows).to_csv(matrix_path, index=False)
+    print(f"  Wrote: {matrix_path} ({len(all_rows)} runs)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/benchmarking/api_latency_comparison/experiment/locustfile_responses.py
+++ b/benchmarking/api_latency_comparison/experiment/locustfile_responses.py
@@ -1,0 +1,84 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+import os
+import sys
+
+from locust import HttpUser, events, task
+from locust.contrib.csv_request_logger import CsvRequestLogger
+
+BENCHMARK_MODE = os.environ.get("BENCHMARK_MODE", "straight-through")
+if BENCHMARK_MODE not in ("straight-through", "agentic"):
+    print(f"Error: BENCHMARK_MODE must be 'straight-through' or 'agentic', got '{BENCHMARK_MODE}'")
+    sys.exit(1)
+
+_request_log_path = os.environ.get("REQUEST_LOG")
+if not _request_log_path:
+    print("Error: REQUEST_LOG environment variable is required")
+    sys.exit(1)
+_request_logger = CsvRequestLogger(_request_log_path)
+
+
+@events.init.add_listener
+def on_locust_init(environment, **kwargs):
+    _request_logger.register(environment)
+
+
+class ResponsesAPIUser(HttpUser):
+    """Benchmarks /v1/responses with optional tool calls (set BENCHMARK_MODE=agentic)."""
+
+    def on_start(self):
+        self.model_id = "openai/mock-model"
+        self.headers = {"Content-Type": "application/json"}
+
+    @task
+    def responses_api(self):
+        payload = {
+            "model": self.model_id,
+            "input": "Hello, how are you?",
+            "store": True,
+            "stream": False,
+        }
+
+        if BENCHMARK_MODE == "agentic":
+            payload["tools"] = [{"type": "web_search"}]
+
+        with self.client.post(
+            "/v1/responses",
+            data=json.dumps(payload),
+            headers=self.headers,
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"HTTP {response.status_code}: {response.text}")
+                return
+            try:
+                data = response.json()
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+                return
+            if data.get("status") != "completed":
+                response.failure(f"Expected status 'completed', got '{data.get('status')}'")
+                return
+            output = data.get("output", [])
+            if not output:
+                response.failure("Empty output array")
+                return
+            has_assistant = any(
+                item.get("role") == "assistant" and item.get("content")
+                for item in output
+                if item.get("type") == "message"
+            )
+            if not has_assistant:
+                response.failure("No assistant message with content in output")
+                return
+            if BENCHMARK_MODE == "agentic":
+                has_tool_output = any(item.get("type") in ("web_search_call", "function_call") for item in output)
+                if not has_tool_output:
+                    response.failure("No tool call output in agentic response")
+                    return
+            response.success()

--- a/benchmarking/api_latency_comparison/experiment/mock_server.py
+++ b/benchmarking/api_latency_comparison/experiment/mock_server.py
@@ -1,0 +1,225 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+MOCK_TOOL_CALL_COUNT = int(os.environ.get("MOCK_TOOL_CALL_COUNT", "1"))
+
+MOCK_CONTENT = "This is a mock response from the benchmark server."
+
+MOCK_RESPONSE = {
+    "id": "chatcmpl-mock123",
+    "object": "chat.completion",
+    "created": 0,
+    "model": "mock-model",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": MOCK_CONTENT,
+            },
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    },
+}
+MOCK_RESPONSE_BYTES = json.dumps(MOCK_RESPONSE).encode()
+
+
+MOCK_SEARCH_RESPONSE = {
+    "mixed": {"main": [{"type": "web", "index": 0}]},
+    "web": {
+        "results": [
+            {
+                "type": "web",
+                "title": "Mock search result",
+                "url": "https://example.com/mock-benchmark",
+                "description": "Mock search result for benchmarking.",
+                "date": "2026-01-01",
+                "extra_snippets": [],
+            }
+        ]
+    },
+}
+MOCK_SEARCH_RESPONSE_BYTES = json.dumps(MOCK_SEARCH_RESPONSE).encode()
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    _counter_lock = threading.Lock()
+    call_counter = 0
+    search_count = 0
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path == "/v1/chat/completions":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length else b""
+            stream = False
+            if body:
+                try:
+                    stream = json.loads(body).get("stream", False)
+                except (json.JSONDecodeError, AttributeError):
+                    self.send_response(400)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(b'{"error":"invalid JSON body"}')
+                    return
+
+            if stream:
+                self._handle_streaming()
+            else:
+                self._handle_non_streaming()
+        elif self.path == "/reset":
+            with MockHandler._counter_lock:
+                prev_calls = MockHandler.call_counter
+                prev_searches = MockHandler.search_count
+                MockHandler.call_counter = 0
+                MockHandler.search_count = 0
+            self._json_response({"reset": True, "prev_post_count": prev_calls, "prev_search_count": prev_searches})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _json_response(self, data: dict[str, Any] | bytes, code: int = 200) -> None:
+        body = json.dumps(data).encode() if isinstance(data, dict) else data
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _should_return_tool_call(self) -> bool:
+        """Cycle tool calls: return True for the first N requests, then reset. Simulates a multi-turn agentic loop."""
+        if MOCK_TOOL_CALL_COUNT <= 0:
+            return False
+        with MockHandler._counter_lock:
+            MockHandler.call_counter += 1
+            if MockHandler.call_counter <= MOCK_TOOL_CALL_COUNT:
+                return True
+            MockHandler.call_counter = 0
+            return False
+
+    def _handle_non_streaming(self) -> None:
+        self._json_response(MOCK_RESPONSE_BYTES)
+
+    def _handle_streaming(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        chunk_id = "chatcmpl-mock-stream"
+        created = int(time.time())
+        model = "mock-model"
+
+        if self._should_return_tool_call():
+            self._stream_tool_call(chunk_id, created, model)
+        else:
+            self._stream_text(chunk_id, created, model)
+
+    def _send_chunk(self, chunk_id: str, created: int, model: str, choices: list[dict[str, Any]]) -> None:
+        chunk = {
+            "id": chunk_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": choices,
+        }
+        self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+
+    def _finish_stream(self) -> None:
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def _stream_text(self, chunk_id: str, created: int, model: str) -> None:
+        self._send_chunk(chunk_id, created, model, [{"index": 0, "delta": {"role": "assistant", "content": ""}}])
+        self._send_chunk(chunk_id, created, model, [{"index": 0, "delta": {"content": MOCK_CONTENT}}])
+        self._send_chunk(
+            chunk_id,
+            created,
+            model,
+            [
+                {"index": 0, "delta": {"content": ""}, "finish_reason": "stop"},
+            ],
+        )
+        self._finish_stream()
+
+    def _stream_tool_call(self, chunk_id: str, created: int, model: str) -> None:
+        with MockHandler._counter_lock:
+            counter_val = MockHandler.call_counter
+        self._send_chunk(chunk_id, created, model, [{"index": 0, "delta": {"role": "assistant", "content": ""}}])
+        self._send_chunk(
+            chunk_id,
+            created,
+            model,
+            [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": f"call_benchmark_{counter_val}",
+                                "type": "function",
+                                "function": {
+                                    "name": "web_search",
+                                    "arguments": '{"query": "benchmark test"}',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+        )
+        self._send_chunk(
+            chunk_id,
+            created,
+            model,
+            [
+                {"index": 0, "delta": {}, "finish_reason": "tool_calls"},
+            ],
+        )
+        self._finish_stream()
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/v1/health":
+            self._json_response(b'{"status":"ok"}')
+        elif self.path == "/v1/models":
+            self._json_response(
+                {"object": "list", "data": [{"id": "mock-model", "object": "model", "owned_by": "mock"}]}
+            )
+        elif self.path.startswith("/res/v1/web/search"):
+            with MockHandler._counter_lock:
+                MockHandler.search_count += 1
+            self._json_response(MOCK_SEARCH_RESPONSE_BYTES)
+        elif self.path == "/stats":
+            with MockHandler._counter_lock:
+                stats = {"post_count": MockHandler.call_counter, "get_search_count": MockHandler.search_count}
+            self._json_response(stats)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    import sys
+
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    server = ThreadingHTTPServer(("127.0.0.1", port), MockHandler)
+    print(f"Mock server listening on port {port} (MOCK_TOOL_CALL_COUNT={MOCK_TOOL_CALL_COUNT})")
+    server.serve_forever()

--- a/benchmarking/api_latency_comparison/experiment/preflight.py
+++ b/benchmarking/api_latency_comparison/experiment/preflight.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Pre-flight checks for the benchmark experiment."""
+
+import csv
+import os
+import shutil
+import socket
+import subprocess
+from datetime import UTC
+from pathlib import Path
+from typing import Any
+
+
+class PreflightError(RuntimeError):
+    pass
+
+
+def log(msg: str) -> None:
+    from datetime import datetime
+
+    ts = datetime.now(tz=UTC).strftime("%H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def check_ports(ports: list[int]) -> None:
+    log("Checking port availability...")
+    for port in ports:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            if s.connect_ex(("localhost", port)) == 0:
+                raise PreflightError(f"Port {port} already in use")
+
+
+def check_disk_space(results_dir: str) -> None:
+    usage = shutil.disk_usage(results_dir)
+    avail_mb = usage.free // (1024 * 1024)
+    if avail_mb < 500:
+        raise PreflightError(f"Insufficient disk space: {avail_mb}MB (need 500MB)")
+    log(f"  Disk space: {avail_mb}MB available")
+
+
+def check_cpu_pinning() -> bool:
+    log("Checking CPU pinning...")
+    try:
+        os.sched_setaffinity(0, {0})
+        actual = os.sched_getaffinity(0)
+        os.sched_setaffinity(0, set(range(os.cpu_count() or 1)))
+        if actual == {0}:
+            log("  CPU pinning verified (sched_setaffinity works)")
+            return True
+    except (OSError, AttributeError):
+        pass
+    log("WARNING: CPU pinning unavailable, running without pinning")
+    return False
+
+
+def check_matrix(matrix_csv: str) -> None:
+    log("Checking experiment matrix...")
+    if not Path(matrix_csv).exists():
+        raise PreflightError(f"Matrix CSV not found: {matrix_csv}")
+    with open(matrix_csv) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        n_cols = len(header)
+        n_runs = sum(1 for _ in reader)
+    log(f"  Matrix: {n_runs} runs, {n_cols} columns")
+    if n_cols != 7:
+        raise PreflightError(f"Expected 7 columns, got {n_cols}")
+
+
+def check_worktrees(worktree_base: str, baseline_label: str, comparison_label: str) -> None:
+    log("Checking worktrees...")
+    for label in [baseline_label, comparison_label]:
+        wt = Path(worktree_base) / label
+        if not (wt / ".git").exists():
+            raise PreflightError(f"Worktree not found: {wt}. Run experiment/setup-worktree.sh first")
+    log(f"  Worktrees OK ({baseline_label}, {comparison_label})")
+
+
+def run_all_checks(
+    results_dir: str,
+    matrix_csv: str,
+    worktree_base: str,
+    baseline_label: str,
+    comparison_label: str,
+    mock_port: int,
+    stack_port: int,
+) -> bool:
+    """Run all pre-flight checks. Returns taskset_available bool.
+
+    Raises PreflightError on any failure.
+    """
+    log("=== Pre-Flight Checks ===")
+
+    check_ports([mock_port, stack_port])
+    check_disk_space(results_dir)
+    taskset_available = check_cpu_pinning()
+    check_matrix(matrix_csv)
+    check_worktrees(worktree_base, baseline_label, comparison_label)
+
+    log("=== Pre-Flight Complete ===")
+
+    return taskset_available
+
+
+def _read_proc(path: str, prefix: str) -> str:
+    """Read a colon-delimited value from a /proc file by prefix."""
+    try:
+        with open(path) as f:
+            for line in f:
+                if line.startswith(prefix):
+                    return line.split(":", 1)[1].strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _cmd(cmd: list[str]) -> str:
+    try:
+        return subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL).strip()  # noqa: S603
+    except Exception:
+        return "unknown"
+
+
+def record_environment(cfg: dict[str, Any], results_dir: str) -> None:
+    """Write hardware and software environment details to environment.txt."""
+    from datetime import datetime
+
+    wb = cfg["worktree_base"]
+    bl, cl = cfg["baseline_label"], cfg["comparison_label"]
+    env = {
+        "date": datetime.now(tz=UTC).isoformat(),
+        "hostname": socket.gethostname(),
+        "kernel": os.uname().release,
+        "python": _cmd(["uv", "run", "--project", cfg["repo_root"], "python", "--version"]),
+        "baseline_label": bl,
+        "baseline_hash": _cmd(["git", "-C", str(Path(wb) / bl), "rev-parse", "HEAD"]),
+        "comparison_label": cl,
+        "comparison_hash": _cmd(["git", "-C", str(Path(wb) / cl), "rev-parse", "HEAD"]),
+        "cpu_model": _read_proc("/proc/cpuinfo", "model name"),
+        "cpu_cores": os.cpu_count(),
+        "memory_mb": int(_read_proc("/proc/meminfo", "MemTotal").split()[0]) // 1024
+        if _read_proc("/proc/meminfo", "MemTotal") != "unknown"
+        else "unknown",
+        "seed": cfg["seed"],
+        "run_duration": cfg["run_duration"],
+        "cpu_pinning": f"ogx={cfg['cpu_ogx']} locust={cfg['cpu_locust']} mock={cfg['cpu_mock']}"
+        if cfg["taskset_available"]
+        else "disabled",
+    }
+    env_file = Path(results_dir) / "environment.txt"
+    log(f"Recording environment to {env_file}")
+    env_file.write_text("\n".join(f"{k}: {v}" for k, v in env.items()) + "\n")

--- a/benchmarking/api_latency_comparison/experiment/runlog.py
+++ b/benchmarking/api_latency_comparison/experiment/runlog.py
@@ -1,0 +1,48 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Run log and design matrix I/O."""
+
+import csv
+import dataclasses
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class RunLogEntry:
+    run: int
+    version_label: str
+    version_hash: str
+    replicate: int
+    benchmark_mode: str
+    mock_tool_call_count: int
+    start_time: int
+    end_time: int
+    duration_s: int
+    requests_completed: int
+    status: str
+
+
+RUN_LOG_FIELDS = [f.name for f in dataclasses.fields(RunLogEntry)]
+
+
+def load_completed_runs(run_log: Path | str) -> set[int]:
+    df = pd.read_csv(run_log)
+    return set(df.loc[df["status"] == "ok", "run"].astype(int))
+
+
+def append_run_log(run_log: Path | str, entry: RunLogEntry) -> None:
+    """Append a run log entry to the CSV, writing the header if needed."""
+    path = Path(run_log)
+    write_header = not path.exists() or path.stat().st_size == 0
+    with open(path, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=RUN_LOG_FIELDS, lineterminator="\n")
+        if write_header:
+            writer.writeheader()
+        writer.writerow(dataclasses.asdict(entry))

--- a/benchmarking/api_latency_comparison/experiment/setup-worktree.sh
+++ b/benchmarking/api_latency_comparison/experiment/setup-worktree.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+set -euo pipefail
+
+# Sets up OGX worktrees for the CI regression benchmark.
+# Creates isolated worktrees for baseline and comparison versions,
+# applies the brave-search base_url patch so the mock server can
+# serve search results locally.
+#
+# Usage:
+#   ./setup-worktree.sh --baseline v1.0.2 --baseline-label baseline \
+#     --comparison HEAD --comparison-label comparison
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKTREE_BASE="/tmp/ci-validation"
+SKIP_DEPS=false
+MOCK_PORT=8080
+STACK_PORT=8321
+
+log_msg() {
+    echo "[$(date +%H:%M:%S)] $*"
+}
+
+REPO=""
+BASELINE_REF=""
+BASELINE_LABEL=""
+COMPARISON_REF=""
+COMPARISON_LABEL=""
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Sets up OGX worktrees for the CI benchmark experiment.
+
+Required:
+    --baseline REF          Git ref for baseline (tag, branch, or commit)
+    --baseline-label NAME   Label for baseline (e.g., v1.0.2)
+    --comparison REF        Git ref for comparison (tag, branch, or commit)
+    --comparison-label NAME Label for comparison (e.g., HEAD)
+
+Options:
+    --repo DIR              Path to OGX git repository (default: auto-detect)
+    --worktree-base DIR     Base directory for worktrees (default: $WORKTREE_BASE)
+    --skip-deps             Skip dependency install
+    --mock-port PORT        Mock server port (default: $MOCK_PORT)
+    --stack-port PORT       OGX server port (default: $STACK_PORT)
+    --help                  Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --repo)              REPO="$2"; shift 2 ;;
+        --baseline)          BASELINE_REF="$2"; shift 2 ;;
+        --baseline-label)    BASELINE_LABEL="$2"; shift 2 ;;
+        --comparison)        COMPARISON_REF="$2"; shift 2 ;;
+        --comparison-label)  COMPARISON_LABEL="$2"; shift 2 ;;
+        --worktree-base)     WORKTREE_BASE="$2"; shift 2 ;;
+        --skip-deps)         SKIP_DEPS=true; shift ;;
+        --mock-port)         MOCK_PORT="$2"; shift 2 ;;
+        --stack-port)        STACK_PORT="$2"; shift 2 ;;
+        --help)              usage; exit 0 ;;
+        *) echo "Error: unknown option $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$REPO" ]]; then
+    REPO="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+
+if [[ ! -d "$REPO/.git" ]]; then
+    echo "Error: $REPO is not a git repository" >&2
+    echo "Use --repo to specify the OGX repo path" >&2
+    exit 1
+fi
+
+if [[ -z "$BASELINE_REF" || -z "$BASELINE_LABEL" || -z "$COMPARISON_REF" || -z "$COMPARISON_LABEL" ]]; then
+    echo "Error: --baseline, --baseline-label, --comparison, and --comparison-label are required" >&2
+    usage >&2
+    exit 1
+fi
+
+log_msg "=== CI Regression Worktree Setup ==="
+log_msg "  Repo: $REPO"
+log_msg "  Worktree base: $WORKTREE_BASE"
+echo ""
+
+BASELINE_DIR="$WORKTREE_BASE/$BASELINE_LABEL"
+COMPARISON_DIR="$WORKTREE_BASE/$COMPARISON_LABEL"
+
+resolve_ref() {
+    local ref="$1"
+    # Resolve a user-supplied ref (tag, branch, remote branch, or SHA)
+    # to a form that git worktree add --detach can use.
+    if git rev-parse --verify "$ref^{commit}" >/dev/null 2>&1; then
+        echo "$ref"
+        return
+    fi
+    # Bare branch name (e.g., "main") with no local branch but origin/main exists.
+    # actions/checkout only creates a local branch for the checked-out ref.
+    if git rev-parse --verify "origin/$ref^{commit}" >/dev/null 2>&1; then
+        echo "origin/$ref"
+        return
+    fi
+    echo "Error: cannot resolve git ref '$ref'" >&2
+    echo "  Tried: '$ref', 'origin/$ref'" >&2
+    return 1
+}
+
+setup_worktree() {
+    local version="$1"
+    local git_ref="$2"
+    local wt_dir="$3"
+
+    log_msg "Setting up worktree: $version (ref: $git_ref) -> $wt_dir"
+
+    if [[ -d "$wt_dir" ]]; then
+        log_msg "  Worktree exists, resetting to clean state..."
+        cd "$wt_dir"
+        git checkout HEAD -- .
+    else
+        cd "$REPO"
+        git worktree prune
+        local resolved
+        resolved=$(resolve_ref "$git_ref")
+        log_msg "  Resolved ref: $git_ref -> $resolved"
+        git worktree add "$wt_dir" "$resolved" --detach
+    fi
+
+    cd "$wt_dir"
+
+    if [[ "$SKIP_DEPS" == false ]]; then
+        log_msg "  Installing dependencies..."
+        uv sync 2>&1 | tail -3
+    fi
+
+    # Patch brave-search provider to accept a configurable base_url.
+    # Uses sed instead of git apply because the surrounding context lines
+    # differ between versions (e.g., type annotations added in later releases).
+    local bs_impl="$wt_dir/src/ogx/providers/remote/tool_runtime/brave_search/brave_search.py"
+    local bs_conf="$wt_dir/src/ogx/providers/remote/tool_runtime/brave_search/config.py"
+
+    if ! grep -q 'self.config.base_url' "$bs_impl" 2>/dev/null; then
+        if grep -q 'url = "https://api.search.brave.com/res/v1/web/search"' "$bs_impl"; then
+            log_msg "  Patching brave-search base_url..."
+            sed -i 's|url = "https://api.search.brave.com/res/v1/web/search"|url = (self.config.base_url or "https://api.search.brave.com") + "/res/v1/web/search"|' "$bs_impl"
+            sed -i '/^    max_results.*Field(/,/^    )/{/^    )/a\    base_url: str | None = Field(\n        default=None,\n        description="Override base URL for the search API (e.g., http://localhost:8080 for mock)",\n    )
+            }' "$bs_conf"
+        else
+            log_msg "ERROR: Cannot find brave-search URL line to patch in $version"
+            log_msg "  Expected: url = \"https://api.search.brave.com/res/v1/web/search\""
+            exit 1
+        fi
+    else
+        log_msg "  brave-search base_url already patched"
+    fi
+
+    # Verify the patch took effect
+    if ! grep -q 'self.config.base_url' "$bs_impl"; then
+        log_msg "ERROR: brave-search patch verification failed for $version"
+        exit 1
+    fi
+
+    local commit_hash
+    commit_hash=$(git rev-parse HEAD)
+    log_msg "  OK: $version at $commit_hash"
+
+    cat > "$wt_dir/.benchmark-env" <<ENVEOF
+export WORKTREE_DIR="$wt_dir"
+export OPENAI_API_KEY="fake-token"
+export MOCK_PORT=$MOCK_PORT
+export STACK_PORT=$STACK_PORT
+ENVEOF
+}
+
+# Step 1: Baseline worktree
+setup_worktree "$BASELINE_LABEL" "$BASELINE_REF" "$BASELINE_DIR"
+echo ""
+
+# Step 2: Comparison worktree
+setup_worktree "$COMPARISON_LABEL" "$COMPARISON_REF" "$COMPARISON_DIR"
+echo ""
+
+# Verify worktree hashes match expected refs
+BASELINE_HASH=$(cd "$BASELINE_DIR" && git rev-parse HEAD)
+COMPARISON_HASH=$(cd "$COMPARISON_DIR" && git rev-parse HEAD)
+
+log_msg "=== Setup Complete ==="
+echo ""
+echo "  $BASELINE_LABEL:    $BASELINE_DIR ($BASELINE_HASH)"
+echo "  $COMPARISON_LABEL:  $COMPARISON_DIR ($COMPARISON_HASH)"
+echo ""
+echo "Cleanup:"
+echo "  git -C $REPO worktree remove $BASELINE_DIR"
+echo "  git -C $REPO worktree remove $COMPARISON_DIR"

--- a/benchmarking/api_latency_comparison/experiment/test_benchmark.py
+++ b/benchmarking/api_latency_comparison/experiment/test_benchmark.py
@@ -6,7 +6,7 @@
 
 """End-to-end benchmark self-test.
 
-Runs the experiment pipeline (setup → generate → experiment) with
+Runs the full pipeline (setup → generate → experiment → fit) with
 2 replicates and 3s runs, then asserts artifacts were produced.
 
 Run with:
@@ -14,6 +14,7 @@ Run with:
 """
 
 import csv
+import json
 import socket
 import tempfile
 from pathlib import Path
@@ -31,9 +32,9 @@ def benchmark_results():
     cfg = _default_config()
     cfg["run_duration"] = 3
 
-    run_benchmark(cfg, results_dir, baseline_ref="", comparison_ref="HEAD", replicates=2)
+    fp_results = run_benchmark(cfg, results_dir, baseline_ref="", comparison_ref="HEAD", replicates=2)
 
-    yield results_dir
+    yield results_dir, fp_results
 
     cleanup_worktrees(cfg)
 
@@ -82,7 +83,7 @@ class TestExperimentPipeline:
     }
 
     def test_experiment_matrix_has_correct_schema(self, benchmark_results):
-        results_dir = benchmark_results
+        results_dir, _ = benchmark_results
         with open(results_dir / "experiment-matrix.csv") as f:
             reader = csv.DictReader(f)
             rows = list(reader)
@@ -93,7 +94,7 @@ class TestExperimentPipeline:
         assert versions == {"baseline", "comparison", "comparison_ctrl"}
 
     def test_run_log_records_all_runs(self, benchmark_results):
-        results_dir = benchmark_results
+        results_dir, _ = benchmark_results
         with open(results_dir / "run-log.csv") as f:
             reader = csv.DictReader(f)
             rows = list(reader)
@@ -102,7 +103,7 @@ class TestExperimentPipeline:
         assert all(int(r["requests_completed"]) > 0 for r in rows)
 
     def test_each_run_has_request_data(self, benchmark_results):
-        results_dir = benchmark_results
+        results_dir, _ = benchmark_results
         run_dirs = [d for d in (results_dir / "runs").iterdir() if d.name != "preflight" and d.is_dir()]
         assert len(run_dirs) == 6
         for rd in run_dirs:
@@ -116,10 +117,36 @@ class TestExperimentPipeline:
             assert "response_time_ms" in reader.fieldnames
 
     def test_environment_recorded(self, benchmark_results):
-        results_dir = benchmark_results
+        results_dir, _ = benchmark_results
         env_file = results_dir / "environment.txt"
         assert env_file.exists()
         content = env_file.read_text()
         assert "hostname:" in content
         assert "cpu_pinning:" in content
         assert "seed:" in content
+
+
+class TestAnalysisPipeline:
+    def test_fp_results_returned(self, benchmark_results):
+        _, fp_results = benchmark_results
+        assert "false_positive_detected" in fp_results
+
+    def test_decisions_csv_exists(self, benchmark_results):
+        results_dir, _ = benchmark_results
+        decisions = results_dir / "analysis" / "fits" / "decisions.csv"
+        assert decisions.exists()
+        with open(decisions) as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) >= 6
+
+    def test_fp_results_json_valid(self, benchmark_results):
+        results_dir, _ = benchmark_results
+        fp_path = results_dir / "analysis" / "fits" / "fp-results.json"
+        assert fp_path.exists()
+        fp = json.loads(fp_path.read_text())
+        assert "false_positive_detected" in fp
+
+    def test_idata_exists(self, benchmark_results):
+        results_dir, _ = benchmark_results
+        assert (results_dir / "analysis" / "fits" / "idata.nc").exists()

--- a/benchmarking/api_latency_comparison/experiment/test_benchmark.py
+++ b/benchmarking/api_latency_comparison/experiment/test_benchmark.py
@@ -1,0 +1,125 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""End-to-end benchmark self-test.
+
+Runs the experiment pipeline (setup → generate → experiment) with
+2 replicates and 3s runs, then asserts artifacts were produced.
+
+Run with:
+  uv run python -m pytest benchmarking/api_latency_comparison/experiment/test_benchmark.py -v -s
+"""
+
+import csv
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from benchmarking.api_latency_comparison.experiment.benchmark import _default_config, cleanup_worktrees, run_benchmark
+from benchmarking.api_latency_comparison.experiment.generate_design_matrix import generate_matrix, resolve_version_hash
+from benchmarking.api_latency_comparison.experiment.preflight import PreflightError, check_ports
+
+
+@pytest.fixture(scope="class")
+def benchmark_results():
+    results_dir = Path(tempfile.mkdtemp(prefix="benchmark-test-"))
+    cfg = _default_config()
+    cfg["run_duration"] = 3
+
+    run_benchmark(cfg, results_dir, baseline_ref="", comparison_ref="HEAD", replicates=2)
+
+    yield results_dir
+
+    cleanup_worktrees(cfg)
+
+
+class TestRCBDInvariant:
+    VERSIONS = [
+        {"label": "baseline", "hash": "aaa"},
+        {"label": "comparison", "hash": "bbb"},
+        {"label": "comparison_ctrl", "hash": "bbb"},
+    ]
+
+    def test_each_block_has_all_versions(self):
+        rows = generate_matrix(self.VERSIONS, replicates=5, seed=42)
+        labels = [v["label"] for v in self.VERSIONS]
+        for block in range(1, 6):
+            block_labels = sorted(r["version_label"] for r in rows if r["block"] == block)
+            assert block_labels == sorted(labels), f"Block {block}: {block_labels}"
+
+
+class TestErrorPaths:
+    def test_bad_ref_raises_valueerror(self):
+        with pytest.raises(ValueError, match="could not resolve git ref"):
+            resolve_version_hash("nonexistent-ref-abc123")
+
+    def test_port_conflict_raises_preflight_error(self):
+        s = socket.socket()
+        s.bind(("localhost", 0))
+        port = s.getsockname()[1]
+        s.listen(1)
+        try:
+            with pytest.raises(PreflightError, match=f"Port {port} already in use"):
+                check_ports([port])
+        finally:
+            s.close()
+
+
+class TestExperimentPipeline:
+    EXPECTED_COLUMNS = {
+        "version_hash",
+        "version_label",
+        "run",
+        "replicate",
+        "block",
+        "benchmark_mode",
+        "mock_tool_call_count",
+    }
+
+    def test_experiment_matrix_has_correct_schema(self, benchmark_results):
+        results_dir = benchmark_results
+        with open(results_dir / "experiment-matrix.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 6
+        assert reader.fieldnames is not None
+        assert set(reader.fieldnames) == self.EXPECTED_COLUMNS
+        versions = {r["version_label"] for r in rows}
+        assert versions == {"baseline", "comparison", "comparison_ctrl"}
+
+    def test_run_log_records_all_runs(self, benchmark_results):
+        results_dir = benchmark_results
+        with open(results_dir / "run-log.csv") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == 6
+        assert all(r["status"] == "ok" for r in rows)
+        assert all(int(r["requests_completed"]) > 0 for r in rows)
+
+    def test_each_run_has_request_data(self, benchmark_results):
+        results_dir = benchmark_results
+        run_dirs = [d for d in (results_dir / "runs").iterdir() if d.name != "preflight" and d.is_dir()]
+        assert len(run_dirs) == 6
+        for rd in run_dirs:
+            req_csv = rd / "requests.csv"
+            assert req_csv.exists(), f"Missing {req_csv}"
+            with open(req_csv) as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+            assert len(rows) >= 3, f"Expected >= 3 requests in {req_csv}, got {len(rows)}"
+            assert reader.fieldnames is not None
+            assert "response_time_ms" in reader.fieldnames
+
+    def test_environment_recorded(self, benchmark_results):
+        results_dir = benchmark_results
+        env_file = results_dir / "environment.txt"
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "hostname:" in content
+        assert "cpu_pinning:" in content
+        assert "seed:" in content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,6 +265,11 @@ docs = [
 ]
 codegen = ["rich", "pydantic>=2.11.9", "jinja2>=3.1.6"]
 benchmark = ["locust>=2.39.1"]
+api-latency-comparison = [
+    {include-group = "benchmark"},
+    "mirakuru>=3.0",
+    "pandas",
+]
 
 [project.urls]
 Homepage = "https://github.com/ogx-ai/ogx"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,17 @@ api-latency-comparison = [
     "mirakuru>=3.0",
     "pandas",
 ]
+benchmark-regression = [
+    {include-group = "api-latency-comparison"},
+    "pymc>=6.0.1",
+    "pytensor>=3.0.4",
+    "nutpie>=0.16.10",
+    "arviz>=1.1.0",
+    "h5py",
+    "h5netcdf",
+    "numpyro",
+    "jax[cpu]",
+]
 
 [project.urls]
 Homepage = "https://github.com/ogx-ai/ogx"

--- a/uv.lock
+++ b/uv.lock
@@ -59,8 +59,8 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -295,6 +295,117 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "arro3-core"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/c8/fc5bacb6fc264dc61e46d4832f690015b7f6c693ff5dea8a1e53b63cb772/arro3_core-0.8.1.tar.gz", hash = "sha256:1df54a8e2c14a877f291d90de65f00bafe9cc6d5958417ff749f178f059dcd39", size = 93684, upload-time = "2026-06-11T18:01:37.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/75/29517738623cccba1d60d0aa65b896bdd046ab4a82c5cd5a9fca115f6d7a/arro3_core-0.8.1-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:64d3ea60da4279e9c6a9b2e60abf7f4fefb6643544ecb2dfde899f72f1f91bad", size = 3085640, upload-time = "2026-06-11T17:59:46.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b5/bff1842ed8dbb2134b004f78c52d977b52a6df1d9389b1284aad02bf4d93/arro3_core-0.8.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:463db0b7f698abc19f4274d6df697560bc9c19463cfdbd01094bb0fa6ddd1206", size = 2800705, upload-time = "2026-06-11T17:59:48.242Z" },
+    { url = "https://files.pythonhosted.org/packages/32/20/ef60404d5008f84bca50510f65d7acfe26812e61638ee19a416bf3f11530/arro3_core-0.8.1-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:881afcb9c83334ac26498b429265223c676e028cd5d88fb0c909578f8e0330de", size = 3272103, upload-time = "2026-06-11T17:59:49.641Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8e/6687efc8e0414cfde6281b1f4ea3b5b44aeb318584e39113d645d1f913a2/arro3_core-0.8.1-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d1dc03e1e5965528bfc7e26a6ee857e3b6fc5f201ff530a03dc731b9f3fb14fd", size = 3405750, upload-time = "2026-06-11T17:59:51.037Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/38/2567f26cd041387a2c1f381f1757b5246184de22dd8bd9dbbcb91a1b3586/arro3_core-0.8.1-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:410cdca92392be39a5580059ebf9a6f89a0410af6dc10a8baa76e9d511fa6624", size = 3467290, upload-time = "2026-06-11T17:59:52.672Z" },
+    { url = "https://files.pythonhosted.org/packages/85/38/2c5af3a3e8c806188f1b3a651cbaa6c22d1f094c41e82900d40219c2b337/arro3_core-0.8.1-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f4082c6bbff7f164619d99dffcbc2313ed69024653a9e58d9f94cc65d9226f6c", size = 3195582, upload-time = "2026-06-11T17:59:54.536Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/8d/d7d8686901a273743c53aae98f898f00caaedea807e28854200f2a7365e4/arro3_core-0.8.1-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:40da2ee0701f217cd482e61228023ee9d8993984daccaf6ded089035b5fdc132", size = 2950909, upload-time = "2026-06-11T17:59:56.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/f44198a859b13f519b331906d08079c7c281f8267d718082a3ca858c93ee/arro3_core-0.8.1-cp311-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d79b12a83403b1a100731587d33f09a818a4ff93472f84fcdf3a38d3934dfc5e", size = 3403497, upload-time = "2026-06-11T17:59:57.651Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6d/431d2ef9942a30599db4a86cf13b7f1de92d340717438074a25659d382f4/arro3_core-0.8.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ff2da3c888ec504291deafd6965f2364f14f1fb63977f202f2f7680f10909f6", size = 3130901, upload-time = "2026-06-11T17:59:59.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/458e8596c675fb88075137ab21d4c4a2f9e585101a97d77e910839862168/arro3_core-0.8.1-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0bbcfb60ddf9b571387b4c0aaf78171d2ee7e0d335c08514bc247685f01bc086", size = 3550071, upload-time = "2026-06-11T18:00:00.808Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cd/8fa1f4a49e707ea364022620ca5033ba69b6396215e0bae1fb9fa9efcfe0/arro3_core-0.8.1-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:44f6256cae47d369fe9076e9fa61f5c2899447b76ca5bda641668ad07cf26bf6", size = 3508957, upload-time = "2026-06-11T18:00:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/02/0126ff3b2ff48187315a9782280c0f6412c066559e22bf206ceec2791299/arro3_core-0.8.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b2517ea3fb7cb15a41e2d0e3496d91afe4703eca86a88072f917bef044c2b8ee", size = 3408923, upload-time = "2026-06-11T18:00:03.97Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fd/a19cb50480a769b1cc3f347efa1a808e13b853bb3b1d94b289677115fe92/arro3_core-0.8.1-cp311-abi3-win_amd64.whl", hash = "sha256:6a96df94a4538ab9acf01873eecf35161ad0c54ab79134247e69a42cd66515dc", size = 3368045, upload-time = "2026-06-11T18:00:05.578Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/86/1ac6eed229482b1ef6ac6f3211c6760012aaaa026b0a385a18e42ec0ff74/arro3_core-0.8.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:71165a75a7d22c16226085ed2255afe84741369cd35eb01cc153c4687e85b49f", size = 1724964, upload-time = "2026-06-11T18:00:07.653Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/32/c2e4a65b3b4f7e00552d280e9c2eaaca59c19466b0f95e4e08d6a020ab2d/arro3_core-0.8.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dc81e079d182dfc2ba6bace815608dbab0158809b9268c4eb59816685f7871fb", size = 3071070, upload-time = "2026-06-11T18:00:09.12Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/32/56016de27757bcc0d66999ae2fec624eaa27bd097ee69ac7a5a0d52d407b/arro3_core-0.8.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7695e9fca1e2c0064571bea65d9b7909a957ed9be4c81718d19356e578818649", size = 2794497, upload-time = "2026-06-11T18:00:10.872Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6e/a7aac0e87d6d63672d4ebb7e8466b276fde2a6413579008fadd1e8e919c5/arro3_core-0.8.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad0f507dfafb1e8a8c15e8a902bccdd9a9c2cf2102fc39ad35c22e23ca76a65e", size = 3272090, upload-time = "2026-06-11T18:00:12.561Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fd/8b96e57eea8ebf5fa4e2556b06c84a29ea25ded924f56d300807ff377a94/arro3_core-0.8.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fc91a59cb27c7660134b9ed0c067d53c0f5bb1722f16f2cf7d4c446ce1086c4", size = 3399753, upload-time = "2026-06-11T18:00:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8b/76f1385ecd0448fcc60902a4474f3f00bd2197fe6d7fa4434bb6a0b3dee9/arro3_core-0.8.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71bc86880256cca5f22802ca444a92b3e9edbb5c9e5b74df1cbfcfe2ca788097", size = 3468912, upload-time = "2026-06-11T18:00:15.502Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/15/e1c3aefee23d926be9f75f125d6d94f189f28826aa01713498f1de60b080/arro3_core-0.8.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94528515f59146b5b4421e468bc269f682754ff082434cccf0ecbfb0d74d0b38", size = 3193338, upload-time = "2026-06-11T18:00:17.064Z" },
+    { url = "https://files.pythonhosted.org/packages/de/3d/bfa3963bd09941f69d810a387bbea61deb8a091101c1765216266ec61394/arro3_core-0.8.1-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:e348fa5349e6655df4b1ea281ab71e0794c749ba842da54248eb942201f93fb8", size = 2950166, upload-time = "2026-06-11T18:00:18.607Z" },
+    { url = "https://files.pythonhosted.org/packages/21/07/67bdc66582294d5914b8f7462907b1e44377ccb77a0f7e7b7760c9f81fd1/arro3_core-0.8.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d97170d56690655699977f4535120f170c5047813341c2b0264abc3af00625dc", size = 3401097, upload-time = "2026-06-11T18:00:20.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a3/ab0d46e8fe2337f0ce1789949c5078e63d532fd628af4f254702e1359989/arro3_core-0.8.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6f71fdd46e1a86bc1db0733361130e51447d2d3c7d5fca13937381e2ba085dca", size = 3128454, upload-time = "2026-06-11T18:00:21.598Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/6e/e90cea2555aaa429c16173cbc121b41fb6a656e70ae9f21edbe3f9e73eb0/arro3_core-0.8.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:3e2c2e4c6b36a0f493f07222eadf7c628155f4a306c650a14c4d6d343870043c", size = 3550294, upload-time = "2026-06-11T18:00:24.344Z" },
+    { url = "https://files.pythonhosted.org/packages/15/38/f3db72e411fbaea83844d19b1965abbdf3dd387083f99a715d3b3752b461/arro3_core-0.8.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90d31db38bc7cbbe6061d23ae11b3e830b55ce60ba6f0550c70915bab4cafe41", size = 3507806, upload-time = "2026-06-11T18:00:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/47/73/5d011dad78ac58aaa61e9cc65d349b879afec6781c5aa78f80c839fe359f/arro3_core-0.8.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9d28d87625d6c743fee1d2e20252531db6cff6c5218b89055a9f7492af99c14c", size = 3408910, upload-time = "2026-06-11T18:00:27.843Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/43/be86ea01c2d53d32376602cb2efa9a9b7a25d98e14ad4b5bf0d7da8b0564/arro3_core-0.8.1-cp313-cp313t-win_amd64.whl", hash = "sha256:b394218ad71ce266088e0e65bfad0542556adf0eb93197b66afaa2009358662f", size = 3356174, upload-time = "2026-06-11T18:00:29.395Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0f/2f7b5b458fd38ecf9277fd59919e4c90047795d1abdfd47f0081c48c28fa/arro3_core-0.8.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:a7c227982c0fd762271d550a6242e54ff7d2aa7aff73c918e127042cf9601ec0", size = 1710676, upload-time = "2026-06-11T18:00:30.947Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/b64c9325173b7d87030955007af55348b866a1c02545382261d8966d8bb1/arro3_core-0.8.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5861781e6363db0707e1a4ba5166025a1113d921ccff870a0a097f27ab2dece1", size = 3072327, upload-time = "2026-06-11T18:00:32.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/bf/2c58a549b2409439fcac4ce2abe31ef060d05114a1e5412ce3088e2a2cde/arro3_core-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8c1d9ff8b2848bf48bbcad962271b2adeda922457cf23591464c12af9b0ddbf6", size = 2794872, upload-time = "2026-06-11T18:00:33.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/21/dee8d1c9309820783fe30ad29149508638743cdc61d2851f0132b370ac49/arro3_core-0.8.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:246057dc9d283a283cb05b228f710e1ada3b4a8c483e519b0ec8b0d8499204db", size = 3272432, upload-time = "2026-06-11T18:00:35.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b2/dbc6a3d5ece2cb11c3041821c8322df500b8c8030534d9f791b66b29c090/arro3_core-0.8.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5d55178ad56c637f278286370532e58256eff48f71d3c36a4e5f8652eb7300b3", size = 3400822, upload-time = "2026-06-11T18:00:37.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/0ca0e96eebc7f96af4ad8b78c545a9477e8db271aa090043bb8f797e7f58/arro3_core-0.8.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7a917195d7553a188bbb9fa815d430ff70ee53357fcc6fdb395d0e4436a66243", size = 3469220, upload-time = "2026-06-11T18:00:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/70/3e9c63e9e4499d373304ceb1315afc8dd326395dd0692ccdebcfec703dab/arro3_core-0.8.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2435dc4057d604650a34d195e6977ef40b26af0b9dea8f1b842a924a270de2fc", size = 3193813, upload-time = "2026-06-11T18:00:41.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a8/48842a836d7fc2bdac16ecaf4e60c9fd98f46d1e9c80f45b85b071ccaffb/arro3_core-0.8.1-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:c8b90ad6fbdd3507c20bdbc2b23c88929a3f7c49a8a43697f316e084b5664289", size = 2950818, upload-time = "2026-06-11T18:00:42.987Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/46/635ca59c20b972f0575b9fd1b7debebd94bcba1d6fd68271bfff65d3ae91/arro3_core-0.8.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8918dd0fcf5c3650332678ddbfb7c13ce1f0534f9669ab6839c38069885318cf", size = 3401202, upload-time = "2026-06-11T18:00:44.654Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/03/020d032cf4937cca0652f434613d327f8f11e10b4a3fbd4ccf48846c3158/arro3_core-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cc8c7c9b81cad2b4eaaeb29da25854bddb5bb373a278f1f1046b277fa7f2ee6", size = 3129352, upload-time = "2026-06-11T18:00:46.322Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/55/ce1c840af64e8c5d4f8b684a4c00c5f6d260659c3d2f732c6074eb5597fe/arro3_core-0.8.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:2aa0bda5251e93c67318aa8315e563b02fe39d5577b72654c335d69fce802d03", size = 3550475, upload-time = "2026-06-11T18:00:48.021Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/fa8f1a53cf10fe33029619d14f06525e08ea35c1bcdce42157b230098e1b/arro3_core-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:cd462e7ef7735c341c27f754756b244d90a9485818c5ea090fa46009bd8ae252", size = 3507877, upload-time = "2026-06-11T18:00:49.798Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e5/bf8349b2e5613e6c0caf2f4f0758d61dc273649c2bdcfc96978ab9bc1686/arro3_core-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:480c33d62d66adf92fd731e77728f81b7bd3fcde4e2eb313f5616b5097b1875f", size = 3409360, upload-time = "2026-06-11T18:00:51.393Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0d/e13efbbc448bc817f8343bf12606d22f83011682c821ccd32dda304816be/arro3_core-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:51bea8dc0bc0230b6af8d1b258cf2a7e4f69770ed99062592ce1b43b17732727", size = 3355557, upload-time = "2026-06-11T18:00:52.922Z" },
+]
+
+[[package]]
+name = "arviz"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arviz-base" },
+    { name = "arviz-plots" },
+    { name = "arviz-stats", extra = ["xarray"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/da/1a15d73964342f63a4459a4b42838ad793c12421e27339b621f5227bcf97/arviz-1.2.0.tar.gz", hash = "sha256:ce9d8233691e37dc4b57b670ac1da3cca0f9312280fb0d77e7cd743772d2895c", size = 8665, upload-time = "2026-06-12T17:41:14.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/37/e66d037fd935f40606fc5dc1c610d78653037dd62d656a25cead401d81dc/arviz-1.2.0-py3-none-any.whl", hash = "sha256:3b2b313b4b57ebb2e028c5237e4eacbd4f56084d0162128f8f1f42266c7cf515", size = 9153, upload-time = "2026-06-12T17:41:13.149Z" },
+]
+
+[[package]]
+name = "arviz-base"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lazy-loader" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/d7/4db6e89b0cc5a26ce0e84accd5dd6ff43572eb32e9b46c577bd5d219ed6a/arviz_base-1.2.0.tar.gz", hash = "sha256:be06f9c15c53a951a971bef697e6b0a68497aae4d1670be065dd8f0482e9efca", size = 1410416, upload-time = "2026-06-12T15:54:46.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d7/82e5f456d50b6accf06d137594282bf6984526fa1b329a061f7b91b123aa/arviz_base-1.2.0-py3-none-any.whl", hash = "sha256:a3f7023b665823068ff4b973bb6205eacc65f3c0a446cc099d7e5326b50f1ffc", size = 1427453, upload-time = "2026-06-12T15:54:44.805Z" },
+]
+
+[[package]]
+name = "arviz-plots"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arviz-base" },
+    { name = "arviz-stats", extra = ["xarray"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/d4/738cd3abcc27d681e9876a897d7bab4aa1ad0321257e1a65d2cdc52849bd/arviz_plots-1.2.0.tar.gz", hash = "sha256:e1f462aa0ac02fb957aabcae2cfcbee9bc089a029c94dab83fa2ed02d02098f3", size = 158834, upload-time = "2026-06-12T17:12:10.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/06/85b6f3d07c8b0bd232c05c236188575074fcb9006174e5a5ca5b6dd12a9f/arviz_plots-1.2.0-py3-none-any.whl", hash = "sha256:2e16ed95ce6d6fbb171d60f7300f50c520ebeeb132be7539591a018076f66f16", size = 243949, upload-time = "2026-06-12T17:12:08.906Z" },
+]
+
+[[package]]
+name = "arviz-stats"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/97/fd555a4b16ac349f297c786dab1a3270b3540677b0222a84e517441eb338/arviz_stats-1.2.0.tar.gz", hash = "sha256:fc49e6e75f4fce953987a9bf17dc39950e1f12e7cd73f865257e5d1b6a5ee114", size = 157554, upload-time = "2026-06-12T16:20:11.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/8f/73f43d90534d49a4af4c8e35d5b60e2838435b0318f44262dc6fe2dd39d8/arviz_stats-1.2.0-py3-none-any.whl", hash = "sha256:f9084addeb1abdbab6e9816f0a063118bc4ff7c48ce9141a4dad20b0e41410ae", size = 183844, upload-time = "2026-06-12T16:20:10.191Z" },
+]
+
+[package.optional-dependencies]
+xarray = [
+    { name = "arviz-base" },
+    { name = "xarray" },
+    { name = "xarray-einstats" },
 ]
 
 [[package]]
@@ -785,11 +896,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.4"
+version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
 ]
 
 [[package]]
@@ -1060,6 +1171,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "cobble"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1105,6 +1225,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/0b/30328302903c55218ffc5199646d0e9d28348ff26c02ba77b2ffc58d294a/configargparse-1.7.5.tar.gz", hash = "sha256:e3f9a7bb6be34d66b2e3c4a2f58e3045f8dfae47b0dc039f87bcfaa0f193fb0f", size = 53548, upload-time = "2026-03-11T02:19:38.144Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl", hash = "sha256:1e63fdffedf94da9cd435fc13a1cd24777e76879dd2343912c1f871d4ac8c592", size = 27692, upload-time = "2026-03-11T02:19:36.442Z" },
+]
+
+[[package]]
+name = "cons"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "logical-unification" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/20/0eca1dcdbac64a570e60df66119847f94cdd513178d9c222c15101ca1022/cons-0.4.7.tar.gz", hash = "sha256:0a96cd2abd6a9f494816c1272cf5583a960041750c2d7a48eeeccd47ce369dfd", size = 8690, upload-time = "2025-07-11T18:01:31.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/9f/bffa3362895e5437d9d12e3bbd242f86d91af1d7cd26f6e14ebb6376581b/cons-0.4.7-py3-none-any.whl", hash = "sha256:e38ee12cf703559ea744c94f725bee0e2329f32daf0249b49db1b0437cc6cb94", size = 8603, upload-time = "2025-07-11T18:01:28.706Z" },
 ]
 
 [[package]]
@@ -1548,6 +1680,18 @@ wheels = [
 ]
 
 [[package]]
+name = "donfig"
+version = "0.8.1.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1611,6 +1755,19 @@ wheels = [
 ]
 
 [[package]]
+name = "etuples"
+version = "0.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cons" },
+    { name = "multipledispatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/c0/ba049efa7d216221713cffc303641bd73bbb309ff0e4e2a623f32af2a4ea/etuples-0.3.10.tar.gz", hash = "sha256:26fde81d7e822837146231bfce4d6ba67eab5d7ed55bc58ba7437c2568051167", size = 21493, upload-time = "2025-07-14T18:49:35.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/19/bf11636df040a9f9c3fd6959aedea5b5cfddd751272732278fb04ee0a78c/etuples-0.3.10-py3-none-any.whl", hash = "sha256:4408c7940ef06af52dbbea0954a8a1817ed5750ce905ff48091ac3cd3aeb720b", size = 12201, upload-time = "2025-07-14T18:49:34.557Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1625,8 +1782,8 @@ version = "0.4.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/08/b3334d7b543ac10dcb129cef4f84723ab696725512f18d69ab3a784b0bf5/fairscale-0.4.13.tar.gz", hash = "sha256:1b797825c427f5dba92253fd0d8daa574e8bd651a2423497775fab1b30cfb768", size = 266261, upload-time = "2022-12-11T18:09:16.892Z" }
 
@@ -2058,6 +2215,29 @@ requests = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
 name = "google-genai"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2198,6 +2378,62 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "h5netcdf"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/03/92d6cc02c0055158167255980461155d6e17f1c4143c03f8bcc18d3e3f3a/h5netcdf-1.8.1.tar.gz", hash = "sha256:9b396a4cc346050fc1a4df8523bc1853681ec3544e0449027ae397cb953c7a16", size = 78679, upload-time = "2026-01-23T07:35:31.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/8b/88f16936a8e8070a83d36239555227ecd91728f9ef222c5382cda07e0fd6/h5netcdf-1.8.1-py3-none-any.whl", hash = "sha256:a76ed7cfc9b8a8908ea7057c4e57e27307acff1049b7f5ed52db6c2247636879", size = 62915, upload-time = "2026-01-23T07:35:30.195Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/7fcd9b4c9eed82e91fb15568992561019ae7a829d1f696b2c844355d95dd/h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65", size = 3678608, upload-time = "2026-03-06T13:48:35.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b7/9366ed44ced9b7ef357ab48c94205280276db9d7f064aa3012a97227e966/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210", size = 3054773, upload-time = "2026-03-06T13:48:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/4964bc0e91e86340c2bbda83420225b2f770dcf1eb8a39464871ad769436/h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965", size = 5198886, upload-time = "2026-03-06T13:48:38.879Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/d905e7f53e661ce2c24686c38048d8e2b750ffc4350009d41c4e6c6c9826/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd", size = 5404883, upload-time = "2026-03-06T13:48:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f2/58f34cb74af46d39f4cd18ea20909a8514960c5a3e5b92fd06a28161e0a8/h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c", size = 5192039, upload-time = "2026-03-06T13:48:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ca/934a39c24ce2e2db017268c08da0537c20fa0be7e1549be3e977313fc8f5/h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc", size = 5421526, upload-time = "2026-03-06T13:48:44.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/615a450205e1b56d16c6783f5ccd116cde05550faad70ae077c955654a75/h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab", size = 3183263, upload-time = "2026-03-06T13:48:47.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/a6faef5ed632cae0c65ac6b214a6614a0b510c3183532c521bdb0055e117/h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63", size = 2663450, upload-time = "2026-03-06T13:48:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/0c8bb8aedb62c772cf7c1d427c7d1951477e8c2835f872bc0a13d1f85f86/h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491", size = 3760693, upload-time = "2026-03-06T13:48:50.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/fcc5977d32d6387c5c9a694afee716a5e20658ac08b3ff24fdec79fb05f2/h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618", size = 3181305, upload-time = "2026-03-06T13:48:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/af87f64b9f986889884243643621ebbd4ac72472ba8ec8cec891ac8e2ca1/h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242", size = 5074061, upload-time = "2026-03-06T13:48:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d0/146f5eaff3dc246a9c7f6e5e4f42bd45cc613bce16693bcd4d1f7c958bf5/h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16", size = 5279216, upload-time = "2026-03-06T13:48:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/12a13424f1e604fc7df9497b73c0356fb78c2fb206abd7465ce47226e8fd/h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7", size = 5070068, upload-time = "2026-03-06T13:48:59.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
 ]
 
 [[package]]
@@ -2532,6 +2768,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jax"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaxlib" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/73/eb91d98fcadfa2cbcfdd4e417ab116e47eb20882acc5ee678e47c35d6b57/jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639", size = 2775110, upload-time = "2026-06-17T23:44:57.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/82/5ab5211079a151b6f661529369c0c8e98ec64cabf5c0cf22a0a05af124d8/jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6", size = 3219515, upload-time = "2026-06-17T23:42:41.259Z" },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/93/ee9cc8743191544f65d26ab7eeb82d65968fe60905662d1a5554d056654b/jaxlib-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47bb7c011515ea862be7e8313f40f9c56cbec09dc98a0fcb5016785fcd454c01", size = 61434612, upload-time = "2026-06-17T23:43:57.808Z" },
+    { url = "https://files.pythonhosted.org/packages/11/06/8cc36021bf74d617c312eeed94c280282bb1bcbb32b63f2a42b10ae41575/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:53b72977ae582c03a9e8e1cdee1efbf8ebc1418270965b0e69eade57acf40331", size = 81085366, upload-time = "2026-06-17T23:44:01.067Z" },
+    { url = "https://files.pythonhosted.org/packages/48/17/38b718af2353dba7753300871e83fbb64a88a772e12727ae27373ab675ce/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe88ec443714c4379968b6c109f9fa617c7ad19b802828e4d7bf861cd66da4b7", size = 85467828, upload-time = "2026-06-17T23:44:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c2/d41d13826ebdfe62e56cd87ba70fab3bb9fcbea4a6c9086739a91667e5bf/jaxlib-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:4b08f5fbc596b83f76308181863996f93d901d1f09cfd4e130a65c1998e1b371", size = 65900139, upload-time = "2026-06-17T23:44:07.476Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/68/eaa4cebe253359196a8e80a33b242959e27d8d2a6ae3d09339f21da2acb8/jaxlib-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4df530afa354a22dc1747a5d560640450cbb895d49889338a3f58c76a4c76c8e", size = 61434805, upload-time = "2026-06-17T23:44:10.511Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/4b884ea5962b6beb3c0f93742db54246bbf8b3274e48b0aca47908e454be/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:45b28b0238697ab74bbcf20411aafb6db42acc31836cc2fd711e5cf056bf9556", size = 81084260, upload-time = "2026-06-17T23:44:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/4ee28c65861605945223145fbcd3c9362ec2255ddf7d917574e205548c82/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9e4818b4a8756fd3918766ca2aa5342125809f4f08a6fe46026d4386e7c23644", size = 85467706, upload-time = "2026-06-17T23:44:17.471Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/9918b0f77a25a1299818c0610305ca2bea38ed90584f4489b60357e2dd39/jaxlib-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:c75d6f1df1c9cff08e110b4a21c79560fdc502f4288972d6b117d25dafd44352", size = 65897894, upload-time = "2026-06-17T23:44:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/70df11da52a8b1a826184cccc05a3fec8aed76058a980021873fba3069cb/jaxlib-0.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4c202d8ff7c1f3b5049dbd8f1e30e52759cd4e0a5835f0b3c7ae076a05818e28", size = 61564746, upload-time = "2026-06-17T23:44:24.421Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/184a648ea5db6c8b1a08fc5784c157b4c557255e009fb56091393df3c6de/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:b7b029bb95d981566750475b9719a9d6b66ed5dd2748851667899b6cfe075299", size = 81204888, upload-time = "2026-06-17T23:44:27.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/539596a55265711d74147913278bcdc38412980be7d74d9c9d860297c486/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8b126097d609b0c6e6786e89f6dd6978adc02ebd5f63a1c61293fbac7821305", size = 85583810, upload-time = "2026-06-17T23:44:30.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/27471ec9f1d04674f6e62de809412371e097aed3eca7d9483e677c54c214/jaxlib-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:72eba28b12fee02616fa42aa4b881b4ab62d7757c7843c462401d3fb34a27be4", size = 61446097, upload-time = "2026-06-17T23:44:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c8/941a7f7f37510f51290a5bd1a413aeef977fb8ba8adc0cfe8391233a764c/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:f18f56fee90699cfba9b6627045a7a299702cb0e2af82ce180d9a6a7c8048093", size = 81096546, upload-time = "2026-06-17T23:44:37.486Z" },
+    { url = "https://files.pythonhosted.org/packages/69/77/ac054882c220872512df28d16aeb648fe0e651efbb5be4fd7c4817fd88b0/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:ca34f363197fb0ac4082582ca755007910369e33f8a8ba3d35ed94b71070107d", size = 85472993, upload-time = "2026-06-17T23:44:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7d/c592d1fa69c210be0d2743fffc598dfc2f54efa9671c5f6f5d1e151c6f4a/jaxlib-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:99818b0a18adc0b899abf4873795e8d65169441d87ab2e5cbb228e73d0f25808", size = 68376553, upload-time = "2026-06-17T23:44:44.968Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9b/91b00ec74985d29708b50420b4103c1f651c8f1c253d4fcb49d1bbb532cd/jaxlib-0.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc62997fce8831819551a2a5469a818169b09582b5b648c102d11ac7205bb812", size = 61564620, upload-time = "2026-06-17T23:44:48.217Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c7/49d2b19c3b3105c30e1d3af2062e82e1977fb239d3dc3cbb583ef676dda7/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:a24d6e3cba263978293eae8b41330d5ccf24d6cdd1a6bcd4e82aff34e767620d", size = 81206365, upload-time = "2026-06-17T23:44:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/99/006cedf443f4a01f2088651facce79b2105bfb4905bfe9162eb0920a6dfb/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:5a2ac7aed7c4e661f67600bbcdec9e589151c1efec91f4cdb8d484af1a45c895", size = 85584458, upload-time = "2026-06-17T23:44:55.377Z" },
 ]
 
 [[package]]
@@ -3037,6 +3319,18 @@ wheels = [
 ]
 
 [[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
 name = "lazy-object-proxy"
 version = "1.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3135,6 +3429,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/c6/246100fa3967074d9725b3716913bd495823547bde5047050d4c3462f994/linkify-1.4.tar.gz", hash = "sha256:9ba276ba179525f7262820d90f009604e51cd4f1466c1112b882ef7eda243d5e", size = 1749, upload-time = "2009-11-12T21:42:00.934Z" }
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
 name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3173,6 +3491,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/03/0fb9e22848c8bda302fd0adb1a8e31e46df1f44abc89ca134cff053c3128/locust-2.44.0.tar.gz", hash = "sha256:338a9fd5389b30df96439baba8299193b5efc1f129763cd9bc6108354fb52547", size = 1436312, upload-time = "2026-05-11T20:42:10.277Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/15/e14290a81e92f84c4d8fad0bfcfcf0c2cbbf0b27bf67d7ec593e101dcb90/locust-2.44.0-py3-none-any.whl", hash = "sha256:5dd69aae3dfca8e25c2565e5c4491b21984b41877406b8172ea96cfa9d76c0e5", size = 1457147, upload-time = "2026-05-11T20:42:07.684Z" },
+]
+
+[[package]]
+name = "logical-unification"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "multipledispatch" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5d/37673e494a4eed550785ad1268df0202e69aa081bcbf7c0aafd0a853b0fc/logical_unification-0.4.7.tar.gz", hash = "sha256:3d73b263a870827b3f52d89c94f3336afd7fcaecf1e0c67fa18e73025399775c", size = 13513, upload-time = "2025-10-20T21:42:24.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d0/337b3c49cbe742ab5c118d14730fbc7b14b57d1a130d4f39efaa9ec04226/logical_unification-0.4.7-py3-none-any.whl", hash = "sha256:077f49e32693bc66a418f08c1de540f55b5a20f237ffb80ea85d99bfc6139c3b", size = 13469, upload-time = "2025-10-20T21:42:24.024Z" },
 ]
 
 [[package]]
@@ -3535,6 +3866,23 @@ wheels = [
 ]
 
 [[package]]
+name = "minikanren"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cons" },
+    { name = "etuples" },
+    { name = "logical-unification" },
+    { name = "multipledispatch" },
+    { name = "toolz" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3d/bbab3c19771efbfafc52de98db8ad7cf3c2c444bbbd7241c2b06e9f305bc/minikanren-1.0.5.tar.gz", hash = "sha256:c030e3e9a3fa5f372f84b66966776a8dc63b16b98768b78be0401982b892e00d", size = 21699, upload-time = "2025-06-24T21:38:51.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/02/5e9ae831946db26f172e03e896fe83b07c5ca643df2b32c1b81557f0e77f/minikanren-1.0.5-py3-none-any.whl", hash = "sha256:22c24f4fdf009a56e30655787af45c90f0704bcc24e8d3e651378675b4bccb21", size = 24072, upload-time = "2025-06-24T21:38:50.113Z" },
+]
+
+[[package]]
 name = "mirakuru"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3553,6 +3901,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]
@@ -3857,6 +4241,15 @@ wheels = [
 ]
 
 [[package]]
+name = "multipledispatch"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/a62c3b824c7dec33c4a1578bcc842e6c30300051033a4e5975ed86cc2536/multipledispatch-1.0.0.tar.gz", hash = "sha256:5c839915465c68206c3e9c473357908216c28383b425361e5d144594bf85a7e0", size = 12385, upload-time = "2023-06-27T16:45:11.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl", hash = "sha256:0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4", size = 12818, upload-time = "2023-06-27T16:45:09.418Z" },
+]
+
+[[package]]
 name = "multiprocess"
 version = "0.70.19"
 source = { registry = "https://pypi.org/simple" }
@@ -4035,6 +4428,61 @@ wheels = [
 ]
 
 [[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
+]
+
+[[package]]
+name = "numcodecs"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/cc/55420f3641a67f78392dc0bc5d02cb9eb0a9dcebf2848d1ac77253ca61fa/numcodecs-0.16.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:24e675dc8d1550cd976a99479b87d872cb142632c75cc402fea04c08c4898523", size = 1656287, upload-time = "2025-11-21T02:49:25.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94ddfa4341d1a3ab99989d13b01b5134abb687d3dab2ead54b450aefe4ad5bd6", size = 1148899, upload-time = "2025-11-21T02:49:26.87Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1e/98aaddf272552d9fef1f0296a9939d1487914a239e98678f6b20f8b0a5c8/numcodecs-0.16.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b554ab9ecf69de7ca2b6b5e8bc696bd9747559cb4dd5127bd08d7a28bec59c3a", size = 8534814, upload-time = "2025-11-21T02:49:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6", size = 9173471, upload-time = "2025-11-21T02:49:30.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/20/2fdec87fc7f8cec950d2b0bea603c12dc9f05b4966dc5924ba5a36a61bf6/numcodecs-0.16.5-cp312-cp312-win_amd64.whl", hash = "sha256:845a9857886ffe4a3172ba1c537ae5bcc01e65068c31cf1fce1a844bd1da050f", size = 801412, upload-time = "2025-11-21T02:49:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/38/38/071ced5a5fd1c85ba0e14ba721b66b053823e5176298c2f707e50bed11d9/numcodecs-0.16.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25be3a516ab677dad890760d357cfe081a371d9c0a2e9a204562318ac5969de3", size = 1654359, upload-time = "2025-11-21T02:49:33.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/5f84ba7525577c1b9909fc2d06ef11314825fc4ad4378f61d0e4c9883b4a/numcodecs-0.16.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0107e839ef75b854e969cb577e140b1aadb9847893937636582d23a2a4c6ce50", size = 1144237, upload-time = "2025-11-21T02:49:35.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/00/787ea5f237b8ea7bc67140c99155f9c00b5baf11c49afc5f3bfefa298f95/numcodecs-0.16.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:015a7c859ecc2a06e2a548f64008c0ec3aaecabc26456c2c62f4278d8fc20597", size = 8483064, upload-time = "2025-11-21T02:49:36.454Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e6/d359fdd37498e74d26a167f7a51e54542e642ea47181eb4e643a69a066c3/numcodecs-0.16.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84230b4b9dad2392f2a84242bd6e3e659ac137b5a1ce3571d6965fca673e0903", size = 9126063, upload-time = "2025-11-21T02:49:38.018Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/6663cc0382ddbb866136c255c837bcb96cc7ce5e83562efec55e1b995941/numcodecs-0.16.5-cp313-cp313-win_amd64.whl", hash = "sha256:5088145502ad1ebf677ec47d00eb6f0fd600658217db3e0c070c321c85d6cf3d", size = 799275, upload-time = "2025-11-21T02:49:39.558Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/38e7ca8184c958b51f45d56a4aeceb1134ecde2d8bd157efadc98502cc42/numcodecs-0.16.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b05647b8b769e6bc8016e9fd4843c823ce5c9f2337c089fb5c9c4da05e5275de", size = 1654721, upload-time = "2025-11-21T02:49:40.602Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3832bd1b5af8bb3e413076b7d93318c8e7d7b68935006b9fa36ca057d1725a8f", size = 1146887, upload-time = "2025-11-21T02:49:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/15/e2e1151b5a8b14a15dfd4bb4abccce7fff7580f39bc34092780088835f3a/numcodecs-0.16.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f7b7d24f103187f53135bed28bb9f0ed6b2e14c604664726487bb6d7c882e1", size = 8476987, upload-time = "2025-11-21T02:49:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/16a57fc4d9fb0ba06c600408bd6634f2f1753c54a7a351c99c5e09b51ee2/numcodecs-0.16.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aec9736d81b70f337d89c4070ee3ffeff113f386fd789492fa152d26a15043e4", size = 9102377, upload-time = "2025-11-21T02:49:45.508Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a5/a0425af36c20d55a3ea884db4b4efca25a43bea9214ba69ca7932dd997b4/numcodecs-0.16.5-cp314-cp314-win_amd64.whl", hash = "sha256:b16a14303800e9fb88abc39463ab4706c037647ac17e49e297faa5f7d7dbbf1d", size = 819022, upload-time = "2025-11-21T02:49:47.39Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4096,12 +4544,98 @@ wheels = [
 ]
 
 [[package]]
+name = "numpyro"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "multipledispatch" },
+    { name = "numpy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/39/46fc1a9ad37f40ad4ce64491da5d1e131ded2d6ab652eb6acb1561fc4151/numpyro-0.21.0.tar.gz", hash = "sha256:fc4a90a024a08840868d46b5f9bdc416dfa3ab76c61691036b44ac2b8a77ac77", size = 433670, upload-time = "2026-05-02T18:10:09.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/03/f338093d5384e4f97cfdc8cd6f015ef8b4694dedb6f7a42ff4f7c7ff20aa/numpyro-0.21.0-py3-none-any.whl", hash = "sha256:f89eb82303610d12edae057fb2180bab079434961357df9483d44ab04568543c", size = 394841, upload-time = "2026-05-02T18:10:07.083Z" },
+]
+
+[[package]]
+name = "nutpie"
+version = "0.16.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arro3-core" },
+    { name = "arviz" },
+    { name = "obstore" },
+    { name = "pandas" },
+    { name = "platformdirs" },
+    { name = "pyarrow" },
+    { name = "xarray" },
+    { name = "zarr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/11/f53d7618c4e3c54a9d5c410ac42711499f5a2554c28a4b9f03c4d0439d5e/nutpie-0.16.11.tar.gz", hash = "sha256:e00bf6c004a345ca95d50a57aa794b1b6a2c39270987da131011e7f672589487", size = 721831, upload-time = "2026-06-30T14:29:49.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/28/f112ef823626cab9cf2359852dd52da47951b6102468a3f799c2f29809a1/nutpie-0.16.11-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4c888815e35936a510570dc31bca00ad716aec035b8d5975b00fd056c2cb431b", size = 9792945, upload-time = "2026-06-30T14:29:42.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/9d/b6843a1b5c98b52024e671b0e11eb2e8583de016c5973f15eb5bff87a242/nutpie-0.16.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33fca4a297b06881945c75bab0e6466d5b428d4fd7955c6f90c62f39fa277952", size = 9066723, upload-time = "2026-06-30T14:29:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/74/13203b2f76a95a5da04f194fa397b47501682b953582dcaac8539cd3a381/nutpie-0.16.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fac130a35a9c044d1ec8dce909b7ffbecd17d0bc3498250be658abad12f0cdc9", size = 8518235, upload-time = "2026-06-30T14:29:19.786Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/8e/0796cf8c12799a1ea074171dbd97e875cc8a75af20b7600dc8744a54ea47/nutpie-0.16.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c383b2638368b20ce85319458ff914dab0bc5e87588ffec68879719e3c7dcf", size = 9198731, upload-time = "2026-06-30T14:29:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/25/b27fe3521b50254cb4841ad19508501388a963cc4bd3446e0e84f51fc9d4/nutpie-0.16.11-cp312-cp312-win_amd64.whl", hash = "sha256:5d6d501066e111ca021a55de03ac080122794b95750e32a62ef9fb3fae77bea0", size = 9716865, upload-time = "2026-06-30T14:29:51.407Z" },
+    { url = "https://files.pythonhosted.org/packages/00/04/5d6ae4432507c5e214028ff86983dd894985fcc002d208b0cb5c91b14f52/nutpie-0.16.11-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:946e8fa1e0c35dd5d90ac6a018639f7f0b9750918a103bf04c4922b39f6ad463", size = 9796609, upload-time = "2026-06-30T14:29:44.89Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b9/efc6c43aca0fad920e6ea60f1b8c9bb6c47f4adcc5e5438a7d6c0c406cbe/nutpie-0.16.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d8586bb001198b2944547ebcf7b60869af41629476478d3d015dc6ff05afcd20", size = 9072919, upload-time = "2026-06-30T14:29:37.638Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/78/5ae182d5e9bdbb0a83d55bf4c4c0241bf1b1d76cd8f454d64cb2f93edadf/nutpie-0.16.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0534b9ca2f840d1f5448d1abb7b00d109195e54e3c1b66fd48b204d741e6a3e5", size = 8522366, upload-time = "2026-06-30T14:29:22.334Z" },
+    { url = "https://files.pythonhosted.org/packages/12/0b/f772965ad238214ade1d7b0dcf017dd1320a3db007ac2d4f2a0933a14016/nutpie-0.16.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf006a9f1372dd21147c0ca511702658ac094155b52223ac00ce1f17a800d5d8", size = 9201373, upload-time = "2026-06-30T14:29:30.05Z" },
+    { url = "https://files.pythonhosted.org/packages/70/42/a27209862624bcd96bbcf06ab2b09f7eedd9190a8094737ae5ec2d8cdc37/nutpie-0.16.11-cp313-cp313-win_amd64.whl", hash = "sha256:3c93116eae6a19d8436408a6b6745fd10c778707552bf3be4c3db4118f308c63", size = 9721668, upload-time = "2026-06-30T14:29:53.959Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/18/513b1f2bec678bf739447a155414760e374dc772e65510b057768de3c809/nutpie-0.16.11-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d080abe9510591a4d52cc8095544d6bbc3ec6a54de76ed1771c212c7e6f1acfe", size = 9793255, upload-time = "2026-06-30T14:29:47.472Z" },
+    { url = "https://files.pythonhosted.org/packages/16/16/9ed76db7fd208c74dd9613ac2c0c9b062d409ae5176122cb904ace61abe2/nutpie-0.16.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:740c7b73591583f0383cd1cca63d36abd1d14a3ad2adb3afed07496b09cc4b54", size = 9070376, upload-time = "2026-06-30T14:29:39.939Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0c/9f44539e11074cd2a366191fbf5b3c18764c122ac85d19b54e622b6bd4ae/nutpie-0.16.11-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:714759c5a6f2bd33e19c96412cedc4c29afe333c1023b8ccb0c7ba07ccbdd1a0", size = 8520110, upload-time = "2026-06-30T14:29:24.871Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/de/90fcb6511f06980c639e5c4ce905c4abb079ce3118758e4b0ce1aff910a4/nutpie-0.16.11-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abf6a66c895ccaf884d33aec4093df8af1947c3ca01105bcdf4aaffaa0e89972", size = 9198390, upload-time = "2026-06-30T14:29:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/79/58/97c6c2976bb7a483cb8314ddbfbe298fd1957a5d128e70c71ba8e9f34c78/nutpie-0.16.11-cp314-cp314-win_amd64.whl", hash = "sha256:f6b7e49894882fb0d5949be3fdb14c4ec990c9f62ecbf3310060ee53ae8f3530", size = 9717171, upload-time = "2026-06-30T14:29:56.573Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "obstore"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/2f/f83afaab7945509d72245b2b00af0b4834ce78fdd2d9ae9f0ad1a3036a91/obstore-0.11.0.tar.gz", hash = "sha256:a2f55163bcd348b4a60d12e6893eac50eddc742bad8032a1705d49140b992204", size = 130565, upload-time = "2026-06-25T18:29:49.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b2/00c213e7e5ca8065f97e37e55294adab836e3f6a88b23e4029069aaecf95/obstore-0.11.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:42f36546c7ac44dbab1173d2330a8a1b1a3f0e37950e553b8c904e3dd0744b25", size = 5491935, upload-time = "2026-06-25T18:28:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/6a6b9a5e15a8a37c24d14317a87648097c4888593b588510c03c030d2e90/obstore-0.11.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:687bb9d3962d568b7c439c5d0c6fea19b2749862a8e5c8eebd0c058c4eccde9e", size = 4672619, upload-time = "2026-06-25T18:28:33.852Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f9/6745ce8c4f7bfac19dc14a4438b48a2e93a689b92b0cecfc695e41a4e8b1/obstore-0.11.0-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:010b51578c7514a41719d795cdb7a1e6529be509dac3772e477187a59422bb97", size = 5072806, upload-time = "2026-06-25T18:28:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/991d3b3cdd851c0225e55f3dc45b47fd9e249827d188995011469f805132/obstore-0.11.0-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfaa8129a3f5d8518a3a75184d4b02348db0f6263177cd1f0951f6568243cc9e", size = 5303777, upload-time = "2026-06-25T18:28:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e9/90e56015a45b5e56a84fc3188c4e5fb088b288d41992c73a629e10df6760/obstore-0.11.0-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c790a5cb9ff2970d1f464a6a708d734dce9939e9f668cb6708c5dba5d61589b2", size = 5493871, upload-time = "2026-06-25T18:28:39.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/02/f1744091d59ce71c5523174eb860fbb298275c901e89b9ea6fbf3e654a33/obstore-0.11.0-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:827113e12fe8088e0281a9d57b90b2b8dbc8a6ffe3b15dadb9baa5feb3d266c1", size = 5361913, upload-time = "2026-06-25T18:28:42.089Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/59/3f47822683ee2b6db8685faa25829946d6343a561251ec2704548455d946/obstore-0.11.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2ff6d3ed553298828fb760b4aef6347fbcc7b5c5e3ce3f8381ce805c370021a", size = 5638724, upload-time = "2026-06-25T18:28:43.897Z" },
+    { url = "https://files.pythonhosted.org/packages/23/50/1df335fdf9b527b3933f1e94ab6fc720ad314260fab8591cb0b6668ff192/obstore-0.11.0-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:39d04b324fcf984e7050734ebda77b81764025b0c011750201a0d8954087f7aa", size = 5413508, upload-time = "2026-06-25T18:28:45.624Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/a259aba149b841ca7c91fea177df9972a60a636b54077beed1a35b254994/obstore-0.11.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:37c0d15d775b1370ef5204ee3919a5ddf7e2592d11815213105f8db031f2ab8d", size = 5619995, upload-time = "2026-06-25T18:28:47.599Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b4/ec25fdb4d6b060bc6eea647fc0e88f75fcc20fe8d16d67fb0dbe999d323b/obstore-0.11.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7f468caf9b6e0f12ff151e5fe618de5fc9192befa9bd02734b06de4efd2e49f6", size = 5299512, upload-time = "2026-06-25T18:28:49.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e5/29be060d06ec13e2af3d1b6cfb77b7c37f8be6c56b77295c945fefad73e4/obstore-0.11.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:42d8e8fad85be8ee488c1a9a9b7c6a42128abb84e67175da40d3d1165c1846df", size = 5427026, upload-time = "2026-06-25T18:28:51.317Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/577a965f440e9ea64243518663f9d16be7df8eafc7123818e8e841fa21ce/obstore-0.11.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9c8fd2a544e2e0b926669c47fcfb8d2314e234abc240ea165dae04ee42e1d7ac", size = 5869187, upload-time = "2026-06-25T18:28:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/18/8fdbaee22bfd5b9c44e1fdff8ca0508e2fe60c42bf9fc85f0c9c27b4ecf2/obstore-0.11.0-cp311-abi3-win_amd64.whl", hash = "sha256:6fb3d4678c0f4242d3109362e9b1df5d7b27765f43d5aacb2e81af53a75cb9ef", size = 5329384, upload-time = "2026-06-25T18:28:55.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/8b/7555e48ec768728fcfc71a051c6b28d6ddaf1bececf492ce5ef995aab5f0/obstore-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f3132393eff9f3f2b543ecbb3bcc12319a7c433fef06493b4350d6854d505a14", size = 5515763, upload-time = "2026-06-25T18:28:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8f/94d83f3336421cbb5e436ab0ae5695eae72f7c82990d6b1ac090712c8052/obstore-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a3a8da19b47af4c14ecc694209b3c18ac6d89f96be5656ee3a19b77947c14155", size = 4649491, upload-time = "2026-06-25T18:28:59.386Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/86/11f4e1f51a8c6cf21a5915c018d2357201ad3c5799d418f0c6529fafaab2/obstore-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e91298b9b6c3a0408c28eece62bca6c5b6cda2f6350351d84e07b4dc8fb2631f", size = 5060659, upload-time = "2026-06-25T18:29:01.139Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e7/fd3036b0923d10e878e2073020f1ef692a618ed1cc3980d3e4a468c93713/obstore-0.11.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3422c532486671dfb5e3e739bf15ec9ca2a8da544a3c23b74ae3857dcab1c6a8", size = 5277058, upload-time = "2026-06-25T18:29:02.96Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a7/b016c3ac6857ac856326dc0a292e3871b8500d03f25f3b90e168b05de357/obstore-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de027ce46cf0592c2b41654e2c27dbc52a4a726f6fbc511380acc0da3a9f658", size = 5475852, upload-time = "2026-06-25T18:29:05.032Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9e/644ffe8db7757de7f71f94a036ab24222bccb4de290d3ca69f76547e812d/obstore-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a80a95548678210bc336b866e37139c293565c3b163eb3fef2433d5d6640a33", size = 5363082, upload-time = "2026-06-25T18:29:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0b/26af6b5fa6ba96af84086f44f78b4e5b0af1729c31402d7b28c68989d174/obstore-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acaa261dc15efb95bbeca06f8fe9b47ee23d7302a6aa1fa3a9654baab8b23d7c", size = 5629116, upload-time = "2026-06-25T18:29:08.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ce/f30d502991c6719b2fbd7b8385ef3e39da07bfca099108bcc5eeed8b9c20/obstore-0.11.0-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:a3300cabbc3129670987b3723629c791d83c117ef1b6a0c670c2043648e000a1", size = 5404534, upload-time = "2026-06-25T18:29:11.294Z" },
+    { url = "https://files.pythonhosted.org/packages/52/20/d5bf5f816e868717ba647ed9a2109e800deb402d0265d410456b3fcb4376/obstore-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f4e6a9480843645cd4ee122c41d5c5a46a56f1e9cdda85638826f2e0e439fe5c", size = 5613159, upload-time = "2026-06-25T18:29:13.414Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b4/6d4c1c211e3b06cc8554189e0d4406e8fa1f98ed55f9213b8e398a11599f/obstore-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:9fb2b1814c4314b8903f4e2ebbe8c3365fea6543669615ee9a0288b0d3a2edeb", size = 5286279, upload-time = "2026-06-25T18:29:15.424Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5e/d7b5589424a56171b16ab94cf92eb493490c300aaa044913bbdd94cace68/obstore-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63fb9b072815eafe4705f617f567d896b1c858adcb390795fa1e269367791031", size = 5401780, upload-time = "2026-06-25T18:29:17.514Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/18/841baea8936e51a18b0e5d4c51f09c0a7798cb73b027e9794be2362a0f0b/obstore-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:086fafba314ff98cfab1c4bf7814699e862513e8889720cf6f7462296cb32787", size = 5853618, upload-time = "2026-06-25T18:29:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/d6127f5422b78e0222b0a9eadcfd7a5aa8d873a9498da7d4a77d4ac8ce2e/obstore-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:676d1154f6f08721110f9b7d14ee3a3c0293abaf9da135bb90f54e276dca1cac", size = 5314113, upload-time = "2026-06-25T18:29:21.209Z" },
 ]
 
 [[package]]
@@ -4184,8 +4718,8 @@ starter = [
     { name = "sqlite-vec" },
     { name = "together" },
     { name = "tokenizers" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "tree-sitter" },
     { name = "unstructured-client" },
@@ -4200,6 +4734,19 @@ api-latency-comparison = [
 ]
 benchmark = [
     { name = "locust" },
+]
+benchmark-regression = [
+    { name = "arviz" },
+    { name = "h5netcdf" },
+    { name = "h5py" },
+    { name = "jax" },
+    { name = "locust" },
+    { name = "mirakuru" },
+    { name = "numpyro" },
+    { name = "nutpie" },
+    { name = "pandas" },
+    { name = "pymc" },
+    { name = "pytensor" },
 ]
 codegen = [
     { name = "jinja2" },
@@ -4243,8 +4790,9 @@ dev = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "sqlite-vec" },
     { name = "together" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "unstructured-client" },
 ]
 docs = [
     { name = "linkify" },
@@ -4287,10 +4835,10 @@ test = [
     { name = "qdrant-client" },
     { name = "requests" },
     { name = "sqlalchemy", extra = ["asyncio"] },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "transformers" },
     { name = "weaviate-client" },
 ]
@@ -4332,8 +4880,8 @@ type-checking = [
     { name = "streamlit-option-menu" },
     { name = "together" },
     { name = "torchtune" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "trl" },
     { name = "types-jsonschema" },
     { name = "types-psutil" },
@@ -4450,6 +4998,19 @@ api-latency-comparison = [
     { name = "pandas" },
 ]
 benchmark = [{ name = "locust", specifier = ">=2.39.1" }]
+benchmark-regression = [
+    { name = "arviz", specifier = ">=1.1.0" },
+    { name = "h5netcdf" },
+    { name = "h5py" },
+    { name = "jax", extras = ["cpu"] },
+    { name = "locust", specifier = ">=2.39.1" },
+    { name = "mirakuru", specifier = ">=3.0" },
+    { name = "numpyro" },
+    { name = "nutpie", specifier = ">=0.16.10" },
+    { name = "pandas" },
+    { name = "pymc", specifier = ">=6.0.1" },
+    { name = "pytensor", specifier = ">=3.0.4" },
+]
 codegen = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pydantic", specifier = ">=2.11.9" },
@@ -4880,16 +5441,16 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.63b1"
+version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/2a/dfeddff262b12eff0c72f4ad9e258aab8889f48c4dc1417a0377a13bc427/opentelemetry_exporter_prometheus-0.63b1.tar.gz", hash = "sha256:31902e22c89431058a95b6dcdb644f9309f226aa4872cc755f0a780d2895e97f", size = 15234, upload-time = "2026-05-21T16:32:57.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/b3/f778f705289ea5f1c54589ae4494d318c9cede052f18ca33979fda0ef016/opentelemetry_exporter_prometheus-0.64b0.tar.gz", hash = "sha256:96fec79be9527cb9dc994d7e663051df35161eb936fe2d41954725e4595abbc1", size = 16405, upload-time = "2026-06-24T15:20:02.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/ec/d7c7435e9000fb69837cf7753b7cbbbdeb5d0585203daf1b6ebf8fa93e02/opentelemetry_exporter_prometheus-0.63b1-py3-none-any.whl", hash = "sha256:0efd00aa6b1939345ddcc6de141b83ebffa2b4401a37a68f880e54217602701d", size = 12466, upload-time = "2026-05-21T16:32:36.622Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/dd/d95db7ac5bec037b3dcc8ea6fe64cd5dc4bc87017d2e06e7410318e85dc0/opentelemetry_exporter_prometheus-0.64b0-py3-none-any.whl", hash = "sha256:9979a15f8d007d442bc7a6e16f4cbde5e8e0c5e99689887ceb5f33da251f0655", size = 13031, upload-time = "2026-06-24T15:19:44.159Z" },
 ]
 
 [[package]]
@@ -4944,6 +5505,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
 ]
 
 [[package]]
@@ -5186,8 +5756,8 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -5997,6 +6567,27 @@ crypto = [
 ]
 
 [[package]]
+name = "pymc"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arviz" },
+    { name = "cachetools" },
+    { name = "cloudpickle" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pytensor" },
+    { name = "rich" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/ee/0340f92961de7e2f7a4a877d8715e43ec58061650bd613b64073a085624d/pymc-6.0.1.tar.gz", hash = "sha256:faa38320a2e034fb153cd0ba2f08e204f14ab68938131bfefa94a2fa8b9f99e2", size = 531456, upload-time = "2026-05-20T21:15:11.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/38/e86045374f31679798e0a09ab5cc9cbb22d2b18f8af6e249cb39a6a64110/pymc-6.0.1-py3-none-any.whl", hash = "sha256:b58bfa2b7abeed5a15281fd937c03affce57377c88efdcbb71a988f31301d22f", size = 584172, upload-time = "2026-05-20T21:15:09.815Z" },
+]
+
+[[package]]
 name = "pymilvus"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6142,6 +6733,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytensor"
+version = "3.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cons" },
+    { name = "etuples" },
+    { name = "filelock" },
+    { name = "logical-unification" },
+    { name = "minikanren" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/c7/ce061b8006c9518005488f9c25966f9bbea6068ceac0f669abc0e4f8f0a4/pytensor-3.0.7.tar.gz", hash = "sha256:858df82fa44e5401c9e913e5acaa5e0044f1515db0290755a139e58e28f22b9e", size = 4952896, upload-time = "2026-06-15T14:42:38.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/20/8c57d5cc7e3e2ec3d8f4e8c33fe587a07d18754d57a02f75822ca5703bbd/pytensor-3.0.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2606cb54fa3442325f99f3515c84f83b342fed0da2152e91ad20fa9bafbe7206", size = 1829975, upload-time = "2026-06-15T14:42:18.867Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/3b7e5171b4662b86475579b130d36129cd709ce42c729ded08b7148b6f94/pytensor-3.0.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:929355f229c9f32696f1071a7c0acafcab0b3cccab45748e5f44519ae30a0310", size = 2329535, upload-time = "2026-06-15T14:42:20.312Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b4/cfcba12527766fa9cc0c4b71f6c64adef48675c8f3a0e40f284bc36ad6e0/pytensor-3.0.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2732fba00d60e85252e496a7ed11ddcf29153694c95cd65cb8236415c8c6e1d5", size = 2326283, upload-time = "2026-06-15T14:42:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/de/42/5c4a5a11e8173f447f53ac7a29a2c0c64ffda0d67ff952204f4e19fe147c/pytensor-3.0.7-cp312-cp312-win_amd64.whl", hash = "sha256:ae0ddade397dcb67212e5be42e9fb9aca1097da6f8faa26e9fb27e4f7442e868", size = 1821816, upload-time = "2026-06-15T14:42:23.239Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f6/20267b1da97ed3faf9d98002794aae142fedef6a332ae7cf0af73a3bc560/pytensor-3.0.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:919ff0130194fcba6c8a2d5f6f733b2cb10e0bc153661b26fcef8123fa6d6410", size = 1829204, upload-time = "2026-06-15T14:42:24.946Z" },
+    { url = "https://files.pythonhosted.org/packages/55/93/fdc33a1cc0936b2f7e75176cf684f8a10a69854e33cc12b6f96f78a18188/pytensor-3.0.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d68d0f294f1d172b979947ea9dc6471baeb6922c971658560de3e1eebe487ef", size = 2327498, upload-time = "2026-06-15T14:42:26.397Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0c/29e81fa57e81aac69d3a32744480e266707ef33eedb6fd6cddfd05bb28cd/pytensor-3.0.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1c8da496748f622e287926eb9107cf4deedc9b79a63cb1ae7f2d366f4992a3e1", size = 2325478, upload-time = "2026-06-15T14:42:27.912Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ae/7add143f07bbe6cba74d28081fcb95aa7d93f75ab8406b37628eb221a86a/pytensor-3.0.7-cp313-cp313-win_amd64.whl", hash = "sha256:8c2d3a4584e25123dbc6e0959bf3be18a23810b5ae3bdfbc8f2f77f91bd4dd16", size = 1821677, upload-time = "2026-06-15T14:42:29.315Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b0/3b2da9a17db7d38c7f9b527c76db0143005db40e40084bd3249f623c21a2/pytensor-3.0.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9b48dda3a9213fefb8a59da9967a306235a39235addd78c2e5a68130b48442a3", size = 1830394, upload-time = "2026-06-15T14:42:30.794Z" },
+    { url = "https://files.pythonhosted.org/packages/60/40/64ca972f98d7b81501573882514fa46694a3009131b49a481197ca12fe30/pytensor-3.0.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89b9cb307fffc31e9cbf2be840884441d29a40bffbeae73ffc2c8752c64ce06b", size = 2320332, upload-time = "2026-06-15T14:42:32.159Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/88e2165ac883a7f1cf6f97e5a0405768de01b5d61fd140c13626f7727f50/pytensor-3.0.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5fa4eaa333e8b8feeffd47670ebff9a6639f05ef1c285b7481f6700aff933f1b", size = 2319452, upload-time = "2026-06-15T14:42:33.807Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/db/3ae89bed19cf752f037bf017f2dce0e178c77b5b49dfec83a1d06ec70bfe/pytensor-3.0.7-cp314-cp314-win_amd64.whl", hash = "sha256:5bfbcc361e32776c019f07b7e38722b3a5a360622dada4b3567c22d78adcec13", size = 1824061, upload-time = "2026-06-15T14:42:35.877Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b6/2dc0d309fe9c309d4edfd5ee2a5456b2216077e9fd548a7d66acfed6de00/pytensor-3.0.7-py2.py3-none-any.whl", hash = "sha256:1f34367fcbf260c64f3756fce6531cba990b3794b5e5b8b8a7543e6cb43008f3", size = 1530061, upload-time = "2026-06-15T14:42:37.215Z" },
 ]
 
 [[package]]
@@ -6978,8 +7601,8 @@ dependencies = [
     { name = "numpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "typing-extensions" },
@@ -7781,23 +8404,31 @@ wheels = [
 ]
 
 [[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.12.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "networkx", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "sympy", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", upload-time = "2026-05-12T16:20:12Z" },
@@ -7818,6 +8449,7 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
@@ -7826,13 +8458,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "networkx", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "sympy", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:b9d0e8eed0af9321ffb12b75f4aca371b071254f12cf75875d5a8e7cc8f52b51", upload-time = "2026-05-12T23:16:33Z" },
@@ -7865,8 +8497,8 @@ version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
     { name = "urllib3" },
 ]
 wheels = [
@@ -7902,15 +8534,14 @@ name = "torchvision"
 version = "0.27.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "pillow", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", upload-time = "2026-05-12T16:20:37Z" },
@@ -7931,6 +8562,7 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
@@ -7939,9 +8571,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "pillow", marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' or sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1b06f42d48b62098114923d8a3fe9fa864182715db06584a515155db0aa8eb30", upload-time = "2026-05-12T16:20:36Z" },
@@ -8643,6 +9275,34 @@ wheels = [
 ]
 
 [[package]]
+name = "xarray"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
+]
+
+[[package]]
+name = "xarray-einstats"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/9b/305ee6a2dac75fc9c28105db061408df6ecbf0f7a1de37636e8e4ea47ca7/xarray_einstats-0.10.0.tar.gz", hash = "sha256:d432a363fc8f09baad164f9826dc711551c684b9abd8098c1b961d18663a627d", size = 33449, upload-time = "2026-02-19T18:13:55.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/d4/225027a913621a879b429a043674aa35220e6ce67785acad4f7bd0c4ff33/xarray_einstats-0.10.0-py3-none-any.whl", hash = "sha256:fa3169b46cee29092db820d8bbc203148bada4fc970ee75e62cbf3dd7c5a8945", size = 39099, upload-time = "2026-02-19T18:13:53.174Z" },
+]
+
+[[package]]
 name = "xlrd"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -8897,6 +9557,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/32/f60d87a99c05a53604c58f20f670c7ea6262b55e0bbeb836ffe4550b248b/youtube_transcript_api-1.0.3.tar.gz", hash = "sha256:902baf90e7840a42e1e148335e09fe5575dbff64c81414957aea7038e8a4db46", size = 2153252, upload-time = "2025-03-25T18:14:21.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/44/40c03bb0f8bddfb9d2beff2ed31641f52d96c287ba881d20e0c074784ac2/youtube_transcript_api-1.0.3-py3-none-any.whl", hash = "sha256:d1874e57de65cf14c9d7d09b2b37c814d6287fa0e770d4922c4cd32a5b3f6c47", size = 2169911, upload-time = "2025-03-25T18:14:19.416Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "donfig" },
+    { name = "google-crc32c" },
+    { name = "numcodecs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -785,11 +785,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.1"
+version = "7.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
@@ -3535,6 +3535,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mirakuru"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psutil", marker = "sys_platform != 'cygwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/23/db9034ba28c7d89a540ffb8ca789f70dc12079108ece1cd1762295d5c807/mirakuru-3.0.2.tar.gz", hash = "sha256:21192186a8680ea7567ca68170261df3785768b12962dd19fe8cccab15ad3441", size = 29338, upload-time = "2026-02-11T19:41:15.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/5f/a3f1a7f1f6e55de9285b03ae7e0d3c2a15e044b6e3f9b53bef5609ca05f2/mirakuru-3.0.2-py3-none-any.whl", hash = "sha256:10e5dac4a8f26872c63e9cdfdc01b775aaa2beb3ced98abc497279d2dc525b8f", size = 27583, upload-time = "2026-02-11T19:41:13.578Z" },
+]
+
+[[package]]
 name = "mistune"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4181,6 +4193,11 @@ starter = [
 ]
 
 [package.dev-dependencies]
+api-latency-comparison = [
+    { name = "locust" },
+    { name = "mirakuru" },
+    { name = "pandas" },
+]
 benchmark = [
     { name = "locust" },
 ]
@@ -4427,6 +4444,11 @@ requires-dist = [
 provides-extras = ["client", "openclient", "starter"]
 
 [package.metadata.requires-dev]
+api-latency-comparison = [
+    { name = "locust", specifier = ">=2.39.1" },
+    { name = "mirakuru", specifier = ">=3.0" },
+    { name = "pandas" },
+]
 benchmark = [{ name = "locust", specifier = ">=2.39.1" }]
 codegen = [
     { name = "jinja2", specifier = ">=3.1.6" },


### PR DESCRIPTION
> **Depends on #6088** — review that first. Retarget to main after #6088 merges.

# What does this PR do?

Adds Bayesian model fitting, diagnostics, and a CI workflow on top of the experiment pipeline from #6088. Estimates changes in API response latency (mean, p50, p95, p99) with uncertainty intervals. The false positive detection runs a negative control (same code as comparison, run independently) to verify the experiment isn't producing spurious differences.


- `analysis/fit_resp_latency_model.py` — Wald (Inverse Gaussian) model with HSGP (Hilbert Space Gaussian Process) temporal adjustment, fitted via nutpie
- `analysis/diagnostics.py` — analysis quality assessment: estimation reliability, model assumptions, data fit
- `analysis/decisions.py` — quantile decisions and false positive detection
- `analysis/wald_numba.py` — numba dispatch shim so nutpie can compile the Wald distribution
- `analysis/smoke_test.py` — smoke test for the analysis dependencies (nutpie, NetCDF, LOO)
- `analysis/MODEL.md` — model specification
- `.github/workflows/response-latency-regression-benchmark.yml` — daily CI comparing latest release vs main

## Test Plan

```bash
uv sync --group benchmark-regression
uv run python -m pytest benchmarking/api_latency_comparison/experiment/test_benchmark.py -v -s
```

`test_benchmark.py` runs the full pipeline (experiment + model fitting) and verifies analysis artifacts: `decisions.csv`, `fp-results.json`, and `idata.nc`.