### PR TITLE
fix(milvus): use explicit output_fields in query_vector for milvus-lite 3.0 compatibility

### DIFF
--- a/src/ogx/providers/remote/vector_io/milvus/milvus.py
+++ b/src/ogx/providers/remote/vector_io/milvus/milvus.py
@@ -238,7 +238,7 @@ class MilvusIndex(EmbeddingIndex):
             "data": [embedding],
             "anns_field": "vector",
             "limit": k,
-            "output_fields": ["*"],
+            "output_fields": ["chunk_content"],
         }
 
         # Only apply radius threshold if score_threshold is meaningful


### PR DESCRIPTION
## Summary
- `query_vector` used `output_fields=["*"]` in `client.search()`, but milvus-lite 3.0 no longer expands `["*"]` to include JSON fields in search results, causing `KeyError: 'chunk_content'`
- Changed to `output_fields=["chunk_content"]`, consistent with `query_keyword` and `query_hybrid` which already use explicit field names
- The `remote::milvus` provider (connecting to a full Milvus server) was not affected

Closes #6090
RHAIENG-5601

## Test plan
- [x] Reproduced the bug with milvus-lite 3.0 via standalone script
- [x] Reproduced via REST API (`/v1/vector-io/query` returns 500, `/v1/vector_stores/{id}/search` returns empty)
- [x] Verified fix works with milvus-lite 3.0 - both endpoints return correct results
- [x] Fix is backward compatible with milvus-lite 2.x (explicit field names work in both versions)