### PR TITLE
fix(vector_io): propagate search errors instead of returning empty results

### DIFF
--- a/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
+++ b/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
@@ -133,6 +133,12 @@ class QdrantIndex(EmbeddingIndex):
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
 
+        # Collections are created lazily on first insert, so a search against a
+        # store that has never had chunks added has no collection yet. Treat that
+        # as an empty result rather than letting Qdrant raise a 404.
+        if not await self.client.collection_exists(self.collection_name):
+            return QueryChunksResponse(chunks=[], scores=[])
+
         results = (
             await self.client.query_points(
                 collection_name=self.collection_name,
@@ -183,6 +189,12 @@ class QdrantIndex(EmbeddingIndex):
         # Qdrant provider does not yet support native filtering
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
+
+        # Collections are created lazily on first insert, so a search against a
+        # store that has never had chunks added has no collection yet. Treat that
+        # as an empty result rather than letting Qdrant raise a 404.
+        if not await self.client.collection_exists(self.collection_name):
+            return QueryChunksResponse(chunks=[], scores=[])
 
         try:
             # Use scroll for keyword-only search since query_points requires a query vector
@@ -263,6 +275,12 @@ class QdrantIndex(EmbeddingIndex):
         # Qdrant provider does not yet support native filtering
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
+
+        # Collections are created lazily on first insert, so a search against a
+        # store that has never had chunks added has no collection yet. Treat that
+        # as an empty result rather than letting Qdrant raise a 404.
+        if not await self.client.collection_exists(self.collection_name):
+            return QueryChunksResponse(chunks=[], scores=[])
 
         try:
             query_words = query_string.lower().split()

--- a/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
@@ -1121,14 +1121,8 @@ class OpenAIVectorStoreMixin(ABC):
             )
 
         except Exception as e:
-            # Log the error and return empty results
-            logger.error("Error searching vector store", vector_store_id=vector_store_id, error=str(e))
-            return VectorStoreSearchResponsePage(
-                search_query=request.query if isinstance(request.query, list) else [request.query],
-                data=[],
-                has_more=False,
-                next_page=None,
-            )
+            logger.error("Failed to search vector store", vector_store_id=vector_store_id, error=str(e))
+            raise
 
     def _build_reranker_params(
         self,

--- a/tests/integration/vector_io/test_openai_vector_stores.py
+++ b/tests/integration/vector_io/test_openai_vector_stores.py
@@ -3585,7 +3585,7 @@ def test_openai_vector_store_with_chunks(
     filtered_search = compat_client.vector_stores.search(
         vector_store_id=vector_store.id,
         query="artificial intelligence",
-        filters={"topic": "ai"},
+        filters={"type": "eq", "key": "topic", "value": "ai"},
         max_num_results=5,
     )
 

--- a/tests/unit/providers/vector_io/test_vector_io_stores_config.py
+++ b/tests/unit/providers/vector_io/test_vector_io_stores_config.py
@@ -213,6 +213,32 @@ async def test_search_vector_store_ignores_rewrite_query(vector_io_adapter):
     assert result.search_query == ["test query"]  # Original query preserved
 
 
+async def test_search_vector_store_propagates_backend_errors(vector_io_adapter):
+    """Test that exceptions from the vector store backend propagate to the caller."""
+    vector_store_id = "test_store_error"
+    vector_io_adapter.openai_vector_stores[vector_store_id] = {
+        "id": vector_store_id,
+        "name": "Test Store",
+        "description": "",
+        "vector_store_id": "test_db",
+        "embedding_model": "test/embedding",
+    }
+
+    async def mock_query_chunks(*args, **kwargs):
+        raise KeyError("chunk_content")
+
+    vector_io_adapter.query_chunks = mock_query_chunks
+
+    from ogx_api import OpenAISearchVectorStoreRequest
+
+    request = OpenAISearchVectorStoreRequest(query="test query", max_num_results=5)
+    with pytest.raises(KeyError, match="chunk_content"):
+        await vector_io_adapter.openai_search_vector_store(
+            vector_store_id=vector_store_id,
+            request=request,
+        )
+
+
 async def test_create_gin_index_executes_correct_sql():
     from ogx.providers.remote.vector_io.pgvector.config import PGVectorHNSWVectorIndex
     from ogx.providers.remote.vector_io.pgvector.pgvector import PGVectorIndex


### PR DESCRIPTION
## Summary
- The catch-all `except Exception` in `openai_search_vector_store` was silently swallowing backend errors and returning empty results with HTTP 200
- Clients had no way to distinguish "no matching documents" from "the search failed"
- This masked bugs like the milvus-lite 3.0 `chunk_content` KeyError (#6089), where file_search appeared to work but retrieval silently returned nothing
- Now re-raises the exception so it surfaces as a 500 to the client
- Also fixes `test_openai_vector_store_with_chunks` which was passing `filters={"topic": "ai"}` (the old shorthand format) instead of the typed format `{"type": "eq", "key": "topic", "value": "ai"}` required since #4471. The error was silently swallowed, and the assertion loop over empty results never executed, so the test appeared to pass.

Closes #6092

## Test plan
- Added unit test `test_search_vector_store_propagates_backend_errors` that verifies a `KeyError` from the backend propagates to the caller
- Fixed `test_openai_vector_store_with_chunks` filter format so it actually exercises the filter path
- Reproduced locally with milvus-lite 3.0: before the fix, search returns 200 with empty results; after, returns 500