### PR TITLE
fix(file_processor): add ZIP decompression limits to MarkItDown processor

### DIFF
--- a/src/ogx/providers/inline/file_processor/docling/docling.py
+++ b/src/ogx/providers/inline/file_processor/docling/docling.py
@@ -20,6 +20,7 @@ from docling_core.transforms.chunker.tokenizer.huggingface import HuggingFaceTok
 from fastapi import UploadFile
 
 from ogx.log import get_logger
+from ogx.providers.inline.file_processor.zip_utils import validate_zip_content
 from ogx.providers.utils.files.response import response_body_bytes
 from ogx.providers.utils.vector_io.vector_utils import generate_chunk_id
 from ogx_api.file_processors import ProcessFileRequest, ProcessFileResponse
@@ -95,6 +96,8 @@ class DoclingFileProcessor:
         start_time: float,
     ) -> ProcessFileResponse:
         """Convert and chunk file content. Runs in a thread."""
+        validate_zip_content(content, filename)
+
         # Preserve original file extension so DocumentConverter can detect the format
         suffix = os.path.splitext(filename)[1] or ".bin"
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:

--- a/src/ogx/providers/inline/file_processor/markitdown/markitdown_processor.py
+++ b/src/ogx/providers/inline/file_processor/markitdown/markitdown_processor.py
@@ -16,6 +16,7 @@ from fastapi import HTTPException, UploadFile
 from markitdown import MarkItDown
 
 from ogx.log import get_logger
+from ogx.providers.inline.file_processor.zip_utils import validate_zip_content
 from ogx.providers.utils.files.response import response_body_bytes
 from ogx.providers.utils.memory.vector_store import make_overlapped_chunks
 from ogx_api.file_processors import ProcessFileRequest, ProcessFileResponse
@@ -84,6 +85,8 @@ class MarkItDownFileProcessor:
         start_time: float,
     ) -> ProcessFileResponse:
         """Convert and chunk file content. Runs in a thread."""
+        validate_zip_content(content, filename)
+
         suffix = os.path.splitext(filename)[1] or ".bin"
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
             tmp.write(content)

--- a/src/ogx/providers/inline/file_processor/zip_utils.py
+++ b/src/ogx/providers/inline/file_processor/zip_utils.py
@@ -1,0 +1,42 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import io
+import zipfile
+
+from fastapi import HTTPException
+
+MAX_ZIP_DECOMPRESSED_BYTES = 25 * 1024 * 1024  # 25MiB
+MAX_ZIP_ENTRIES = 1000
+
+
+def validate_zip_content(content: bytes, filename: str) -> None:
+    """Reject ZIP archives that exceed decompression limits.
+
+    Call before processing any file that may be ZIP-based (DOCX, PPTX, XLSX, etc.).
+    """
+    if not zipfile.is_zipfile(io.BytesIO(content)):
+        return
+
+    with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
+        entries = zf.infolist()
+        if len(entries) > MAX_ZIP_ENTRIES:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Failed to process file '{filename}': ZIP contains {len(entries)} entries, "
+                    f"exceeding the limit of {MAX_ZIP_ENTRIES}"
+                ),
+            )
+        total_size = sum(e.file_size for e in entries)
+        if total_size > MAX_ZIP_DECOMPRESSED_BYTES:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Failed to process file '{filename}': ZIP decompressed size "
+                    f"({total_size} bytes) exceeds the limit of {MAX_ZIP_DECOMPRESSED_BYTES} bytes"
+                ),
+            )

--- a/tests/unit/providers/file_processor/test_zip_validation.py
+++ b/tests/unit/providers/file_processor/test_zip_validation.py
@@ -1,0 +1,92 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import io
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from ogx.providers.inline.file_processor.markitdown.config import MarkItDownFileProcessorConfig
+from ogx.providers.inline.file_processor.markitdown.markitdown_processor import MarkItDownFileProcessor
+from ogx.providers.inline.file_processor.zip_utils import (
+    MAX_ZIP_DECOMPRESSED_BYTES,
+    MAX_ZIP_ENTRIES,
+    validate_zip_content,
+)
+
+
+def _make_zip(num_entries: int, per_entry_bytes: int) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for i in range(num_entries):
+            zf.writestr(f"file_{i}.txt", "A" * per_entry_bytes)
+    return buf.getvalue()
+
+
+# --- Unit tests for validate_zip_content ---
+
+
+def test_validate_zip_rejects_too_many_entries():
+    zip_bytes = _make_zip(MAX_ZIP_ENTRIES + 1, 1)
+    with pytest.raises(HTTPException) as exc_info:
+        validate_zip_content(zip_bytes, "bomb.zip")
+    assert exc_info.value.status_code == 422
+    assert "entries" in exc_info.value.detail.lower()
+
+
+def test_validate_zip_rejects_oversized():
+    per_entry = MAX_ZIP_DECOMPRESSED_BYTES // 2 + 1
+    zip_bytes = _make_zip(2, per_entry)
+    with pytest.raises(HTTPException) as exc_info:
+        validate_zip_content(zip_bytes, "bomb.zip")
+    assert exc_info.value.status_code == 422
+    assert "decompressed size" in exc_info.value.detail.lower()
+
+
+def test_validate_zip_accepts_small_zip():
+    zip_bytes = _make_zip(2, 100)
+    validate_zip_content(zip_bytes, "small.zip")
+
+
+def test_validate_zip_ignores_non_zip():
+    validate_zip_content(b"just plain text", "readme.txt")
+
+
+# --- Integration: markitdown processor calls validation ---
+
+
+@pytest.fixture
+def markitdown_processor():
+    config = MarkItDownFileProcessorConfig()
+    files_api = MagicMock()
+    return MarkItDownFileProcessor(config, files_api)
+
+
+async def test_markitdown_rejects_zip_exceeding_entry_limit(markitdown_processor):
+    zip_bytes = _make_zip(MAX_ZIP_ENTRIES + 1, 1)
+    file = UploadFile(filename="bomb.zip", file=io.BytesIO(zip_bytes))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await markitdown_processor.process_file(
+            request=MagicMock(file_id=None, chunking_strategy=None),
+            file=file,
+        )
+    assert exc_info.value.status_code == 422
+
+
+async def test_markitdown_rejects_zip_exceeding_size_limit(markitdown_processor):
+    per_entry = MAX_ZIP_DECOMPRESSED_BYTES // 2 + 1
+    zip_bytes = _make_zip(2, per_entry)
+    file = UploadFile(filename="bomb.zip", file=io.BytesIO(zip_bytes))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await markitdown_processor.process_file(
+            request=MagicMock(file_id=None, chunking_strategy=None),
+            file=file,
+        )
+    assert exc_info.value.status_code == 422


### PR DESCRIPTION
## Summary
- Reject ZIP-based uploads (DOCX, PPTX, XLSX, etc.) that exceed 25 MiB decompressed or 1000 entries
- Prevents resource exhaustion from malicious archives (observed 17GB RAM / 100% CPU with a 1GB decompressed zip)
- Empirical testing: 25 MiB decompressed peaks at ~785 MB server RSS (from 366 MB baseline), safely under 1 GB

Closes #6099
Ref: RHAIENG-5611

## Test plan
- [x] Unit tests for entry limit, size limit, and small zip acceptance
- [x] Manual test with `scripts/repro_zip_bomb.py --entries 1500` (entry limit)
- [x] Manual test with `scripts/repro_zip_bomb.py --size-mb 100` (size limit)
- [x] Memory profiling: 25 MB ZIP stays under 1 GB server RSS, 50 MB ZIP exceeds it