### PR TITLE
fix: default json_schema strict to false in the anthropic adapter

### DIFF
--- a/src/ogx/providers/remote/inference/anthropic/anthropic.py
+++ b/src/ogx/providers/remote/inference/anthropic/anthropic.py
@@ -15,6 +15,7 @@ from ogx_api.inference.models import (
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAICompletion,
     OpenAICompletionRequestWithExtraBody,
+    OpenAIResponseFormatJSONSchema,
 )
 
 from .config import AnthropicConfig
@@ -56,6 +57,13 @@ class AnthropicInferenceAdapter(OpenAIMixin):
                 p = func.get("parameters")
                 if isinstance(p, dict) and not p:
                     func["parameters"] = {"type": "object"}
+        # Anthropic's OpenAI-compatible endpoint requires
+        # response_format.json_schema.strict to be present, while OpenAI treats
+        # an omitted value as false. Default it here so the field is not dropped
+        # during serialization.
+        if isinstance(params.response_format, OpenAIResponseFormatJSONSchema):
+            if params.response_format.json_schema.get("strict") is None:
+                params.response_format.json_schema["strict"] = False
         return await super().openai_chat_completion(params)
 
     async def openai_completion(

--- a/tests/unit/providers/inference/test_anthropic_adapter.py
+++ b/tests/unit/providers/inference/test_anthropic_adapter.py
@@ -10,7 +10,13 @@ import pytest
 
 from ogx.providers.remote.inference.anthropic.anthropic import AnthropicInferenceAdapter
 from ogx.providers.remote.inference.anthropic.config import AnthropicConfig
-from ogx_api.inference.models import OpenAIChatCompletionRequestWithExtraBody
+from ogx_api.inference.models import (
+    OpenAIChatCompletionRequestWithExtraBody,
+    OpenAIResponseFormatJSONSchema,
+    OpenAIUserMessageParam,
+)
+
+MIXIN_PATH = "ogx.providers.utils.inference.openai_mixin.OpenAIMixin.openai_chat_completion"
 
 
 @pytest.fixture
@@ -40,3 +46,29 @@ async def test_empty_tool_parameters_normalized(adapter, input_params, expected_
         await adapter.openai_chat_completion(params)
 
     assert params.tools[0]["function"]["parameters"] == expected_params
+
+
+def _request(strict=...):
+    json_schema = {"name": "s", "schema": {"type": "object"}}
+    if strict is not ...:
+        json_schema["strict"] = strict
+    return OpenAIChatCompletionRequestWithExtraBody(
+        model="claude-sonnet-4-6",
+        messages=[OpenAIUserMessageParam(role="user", content="hi")],
+        response_format=OpenAIResponseFormatJSONSchema(json_schema=json_schema),
+    )
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [(..., False), (None, False), (True, True), (False, False)],
+)
+async def test_json_schema_strict_defaulted_for_anthropic(given, expected):
+    adapter = AnthropicInferenceAdapter(config=AnthropicConfig(api_key="test"))
+    params = _request(strict=given)
+
+    with patch(MIXIN_PATH, new=AsyncMock(return_value=None)) as mock_super:
+        await adapter.openai_chat_completion(params)
+
+    forwarded = mock_super.call_args.args[0]
+    assert forwarded.response_format.json_schema["strict"] is expected


### PR DESCRIPTION
## What

When `response_format` with `json_schema` is used for structured output, the `strict` field was dropped during serialization when it was `None` (params are serialized with `exclude_none=True`). Anthropic's OpenAI-compatible endpoint requires the field to be present and returns `400 - response_format.json_schema.strict: Field required`.

OpenAI treats an omitted `strict` as `false`, so the Anthropic adapter now defaults `strict` to `false` when it is absent before forwarding the request. Per review feedback, the default lives in the Anthropic adapter's `openai_chat_completion` so other providers are unaffected.

Fixes #6020

## Test plan

Added `tests/unit/providers/inference/test_anthropic_adapter.py`, which asserts the forwarded `strict` value for absent / `None` / `True` / `False` inputs.

```
uv run pytest tests/unit/providers/inference/test_anthropic_adapter.py -v
# 4 passed

uv run pytest tests/unit/providers/inference/ -q
# 465 passed
```

`uv run ruff check` and `uv run ruff format --check` pass on the changed files; `uv run mypy` reports no issues.