### PR TITLE
chore: bump fallback_version to 1.1.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "1.1.1.dev0"
+fallback_version = "1.1.2.dev0"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -80,7 +80,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client>=1.1.0", # Optional for library-only usage
+    "ogx-client>=1.1.1", # Optional for library-only usage
 ]
 starter = [
     "aiohttp",
@@ -144,7 +144,7 @@ dev = [
     "pre-commit>=4.4.0",
     "ruamel.yaml",                   # needed for openapi generator
     "openapi-spec-validator>=0.9.0",
-    "ogx-client>=1.1.0",
+    "ogx-client>=1.1.1",
     "boto3>=1.43.18",
     "torch>=2.6.0",
 ]
@@ -183,7 +183,7 @@ type_checking = [
     "langchain-openai>=1.2.2",
     "langchain-core",
     "langgraph",
-    "ogx-client>=1.1.0",
+    "ogx-client>=1.1.1",
 ]
 test-common = [
     "aiohttp",

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -96,7 +96,7 @@ ogx_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "1.1.1.dev0"
+fallback_version = "1.1.2.dev0"
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -4256,7 +4256,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.1.0" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.1.1" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4324,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = ">=1.1.0" },
+    { name = "ogx-client", specifier = ">=1.1.1" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4417,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = ">=1.1.0" },
+    { name = "ogx-client", specifier = ">=1.1.1" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4485,7 +4485,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4504,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/df/34b1895ca3d608434347db103c3711b158feea3db9f091366ac93ee126cf/ogx_client-1.1.0.tar.gz", hash = "sha256:b51d945544a59212e960b692ee2832f7c59c683f997f33d9f7ea55ef63de68e4", size = 440837, upload-time = "2026-06-11T13:10:30.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/11070a6b3c0712e5821bd5248a08fcf39c9e4c342fbf3377f0b04f6ad49e/ogx_client-1.1.1.tar.gz", hash = "sha256:6157cb5d4e25cf1555b6ed686994e6e3169b8d75b0d9beb517e7b16953591ed7", size = 440837, upload-time = "2026-06-15T15:17:43.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/d3/19cd05d73b8c4ac6402fe73d74fdcd30a6072889a4a2a4f476957c333aa9/ogx_client-1.1.0-py3-none-any.whl", hash = "sha256:fd09360e39dd0ff142f7a9cde417318c25e3b68ce44f0e061d1de4fd24e2bce8", size = 314014, upload-time = "2026-06-11T13:10:28.843Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f0/00386a5490d34996cd11a27f593024de53fef70c58a40384aaaed356406b/ogx_client-1.1.1-py3-none-any.whl", hash = "sha256:1449edb824818b470ec84bf114d66942689d109d2e1fe6bff7ed03b91717f120", size = 314009, upload-time = "2026-06-15T15:17:42.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release version bump after v1.1.1.

Updates fallback_version in both pyproject.toml files to 1.1.2.dev0.

This PR was created automatically by the post-release workflow.