### PR TITLE
fix(containers): embed distribution configs as OCI labels on published images

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1025,6 +1025,21 @@ jobs:
           echo "::error::${PACKAGE_NAME}==${VERSION} did not appear on test PyPI after 10 minutes"
           exit 1
 
+      - name: Generate config labels
+        id: labels
+        run: |
+          # Embed distribution configs as OCI labels (see scripts/generate-config-labels.sh).
+          # generate-config-labels.sh emits alternating "--label"/"key=value" lines for
+          # docker CLI; build-push-action wants bare "key=value" lines, so drop the flags.
+          LABELS=$(bash scripts/generate-config-labels.sh \
+            "${{ matrix.distro }}" "${{ needs.compute-version.outputs.version }}" \
+            | grep -v '^--label$')
+          {
+            echo "labels<<EOF"
+            echo "$LABELS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -1033,6 +1048,7 @@ jobs:
           platforms: ${{ matrix.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.labels.outputs.labels }}
           build-args: |
             DISTRO_NAME=${{ matrix.distro }}
             INSTALL_MODE=${{ steps.meta.outputs.install_mode }}


### PR DESCRIPTION
## Summary

The OCI config-label embedding added in #5460 only takes effect in two places:

1. `scripts/docker.sh` — local dev builds
2. `.github/workflows/build-distributions.yml` — a verify-only workflow that builds with `--load` and **never pushes**

The container images that are actually published to DockerHub
(`distribution-<distro>:<tag>`) are built by the `publish-docker-images` job in
`.github/workflows/pypi.yml`, which never generated or applied the labels. As a
result, the published/pulled images carry no embedded distribution configs.

This wires label generation into that publish job: it runs the existing
`scripts/generate-config-labels.sh` and passes the result to
`docker/build-push-action` via its `labels:` input.

## Changes

- `.github/workflows/pypi.yml`: add a `Generate config labels` step to the
  `publish-docker-images` job and pass the output to the build/push action.
  The script emits alternating `--label`/`key=value` lines for the docker CLI;
  `build-push-action` wants bare `key=value` lines, so the flag lines are stripped.

## Notes

- Only the distros in that job's matrix (`starter`, `postgres-demo`) are
  published by this workflow, so those are the images that gain labels.
- Already-published images are unaffected; they would need a backfill re-publish
  (via the `docker_only` / `skip_latest` workflow_dispatch inputs, run from the
  matching release ref) to gain labels retroactively.

## Test plan

- `scripts/generate-config-labels.sh starter <version> | grep -v '^--label$'`
  produces clean `key=value` pairs, which is the format `build-push-action`'s
  `labels:` input expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)