### PR TITLE
chore: update ogx-client to ^1.1.2 in UI lockfile

### DIFF
--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -26,7 +26,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.1.1",
+        "ogx-client": "^1.1.2",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.1.tgz",
-      "integrity": "sha512-ZJSvUBEW4P7PqIyESI700pUO81aLoOSB2jAhsI30JFpOxvC9/ii1EFgn5kJ9XIVJ+gR7UOvkYhxF/tgF3Ky3NQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.2.tgz",
+      "integrity": "sha512-lntdB9vyJQ3CXXc0v2RdkVm4Q7kkC4HVUY2Pv49IDS+YWIJl9xxtMLOZbsitSs/09hBx/cm9pMrNfyJwI92ggA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -50,7 +50,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.1.1",
+    "ogx-client": "^1.1.2",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4256,7 +4256,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.1" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.2" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4324,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = "==1.1.1" },
+    { name = "ogx-client", specifier = "==1.1.2" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4417,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = "==1.1.1" },
+    { name = "ogx-client", specifier = "==1.1.2" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4485,7 +4485,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.1"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4504,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/11070a6b3c0712e5821bd5248a08fcf39c9e4c342fbf3377f0b04f6ad49e/ogx_client-1.1.1.tar.gz", hash = "sha256:6157cb5d4e25cf1555b6ed686994e6e3169b8d75b0d9beb517e7b16953591ed7", size = 440837, upload-time = "2026-06-15T15:17:43.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/15/5f02de6eba355443a5687abfc8474beec4ac0aae3357629dc889547f62cb/ogx_client-1.1.2.tar.gz", hash = "sha256:2bb2e7d9100e6332d45dc003777027f9a2f7e9ec82d77cfa6c08ccb670172657", size = 440847, upload-time = "2026-06-17T14:11:44.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/f0/00386a5490d34996cd11a27f593024de53fef70c58a40384aaaed356406b/ogx_client-1.1.1-py3-none-any.whl", hash = "sha256:1449edb824818b470ec84bf114d66942689d109d2e1fe6bff7ed03b91717f120", size = 314009, upload-time = "2026-06-15T15:17:42.226Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4f/c17e5520c0fc282b4b1654bdd5432c7c5e393ce1c5a5b305b34e5ce3ea14/ogx_client-1.1.2-py3-none-any.whl", hash = "sha256:c8b0a0657231da8151ed7267261d3dd7713482ef7d19d97adc13bb42ca25a5da", size = 314013, upload-time = "2026-06-17T14:11:42.51Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release npm lockfile update after v1.1.2.

Updates ogx-client to ^1.1.2 in the UI package lockfile.

This PR was created automatically by the post-release workflow.