### PR TITLE
refactor(vector-io): Convert Qdrant, Milvus, Elasticsearch to eager collection initialization

### DIFF
--- a/src/ogx/providers/remote/vector_io/elasticsearch/elasticsearch.py
+++ b/src/ogx/providers/remote/vector_io/elasticsearch/elasticsearch.py
@@ -46,9 +46,10 @@ OPENAI_VECTOR_STORES_FILES_CONTENTS_PREFIX = f"openai_vector_stores_files_conten
 class ElasticsearchIndex(EmbeddingIndex):
     """Embedding index backed by an Elasticsearch index."""
 
-    def __init__(self, client: AsyncElasticsearch, collection_name: str):
+    def __init__(self, client: AsyncElasticsearch, vector_store: VectorStore):
         self.client = client
-        self.collection_name = collection_name
+        self.collection_name = vector_store.identifier
+        self.dimension = vector_store.embedding_dimension
 
     # Check if the rerank_params contains the following structure:
     # {
@@ -106,15 +107,6 @@ class ElasticsearchIndex(EmbeddingIndex):
         }
 
     async def initialize(self) -> None:
-        # Elasticsearch collections (indexes) are created on-demand in add_chunks
-        # If the index does not exist, it will be created in add_chunks.
-        pass
-
-    async def add_chunks(self, chunks: list[EmbeddedChunk]):
-        """Adds chunks to the Elasticsearch index."""
-        if not chunks:
-            return
-
         try:
             await self.client.indices.create(
                 index=self.collection_name,
@@ -125,17 +117,25 @@ class ElasticsearchIndex(EmbeddingIndex):
                             "chunk_id": {"type": "keyword"},
                             "metadata": {"type": "object"},
                             "chunk_metadata": {"type": "object"},
-                            "embedding": {"type": "dense_vector", "dims": len(chunks[0].embedding)},
+                            "embedding": {"type": "dense_vector", "dims": self.dimension},
                             "embedding_dimension": {"type": "integer"},
                             "embedding_model": {"type": "keyword"},
                         }
                     }
                 },
             )
+            log.info("Created Elasticsearch index", collection_name=self.collection_name)
         except ApiError as e:
-            if e.status_code != 400 or "resource_already_exists_exception" not in e.message:
+            if e.status_code == 400 and "resource_already_exists_exception" in e.message:
+                log.debug("Elasticsearch index already exists", collection_name=self.collection_name)
+            else:
                 log.error(f"Error creating Elasticsearch index {self.collection_name}: {e}")
                 raise
+
+    async def add_chunks(self, chunks: list[EmbeddedChunk]):
+        """Adds chunks to the Elasticsearch index."""
+        if not chunks:
+            return
 
         actions = []
         for chunk in chunks:
@@ -232,8 +232,7 @@ class ElasticsearchIndex(EmbeddingIndex):
                 query={"knn": {"field": "embedding", "query_vector": embedding.tolist(), "k": k}},
                 min_score=score_threshold,
                 size=k,
-                source={"exclude_vectors": False},  # Retrieve the embedding
-                ignore_unavailable=True,  # In case the index does not exist
+                source={"exclude_vectors": False},
             )
         except Exception as e:
             log.error(f"Error performing vector query on Elasticsearch index {self.collection_name}: {e}")
@@ -359,8 +358,7 @@ class ElasticsearchIndex(EmbeddingIndex):
                 size=k,
                 retriever=retriever,
                 min_score=score_threshold,
-                source={"exclude_vectors": False},  # Retrieve the embedding
-                ignore_unavailable=True,  # In case the index does not exist
+                source={"exclude_vectors": False},
             )
         except Exception as e:
             log.error(f"Error performing hybrid query on Elasticsearch index {self.collection_name}: {e}")
@@ -414,9 +412,9 @@ class ElasticsearchVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStore
 
         for vector_store_data in stored_vector_stores:
             vector_store = VectorStore.model_validate_json(vector_store_data)
-            index = VectorStoreWithIndex(
-                vector_store, ElasticsearchIndex(self.client, vector_store.identifier), self.inference_api
-            )
+            es_index = ElasticsearchIndex(self.client, vector_store)
+            await es_index.initialize()
+            index = VectorStoreWithIndex(vector_store, es_index, self.inference_api)
             self.cache[vector_store.identifier] = index
         await self.initialize_openai_vector_stores()
 
@@ -430,9 +428,11 @@ class ElasticsearchVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStore
         key = f"{VECTOR_DBS_PREFIX}{vector_store.identifier}"
         await self.kvstore.set(key=key, value=vector_store.model_dump_json())
 
+        es_index = ElasticsearchIndex(self.client, vector_store)
+        await es_index.initialize()
         index = VectorStoreWithIndex(
             vector_store=vector_store,
-            index=ElasticsearchIndex(self.client, vector_store.identifier),
+            index=es_index,
             inference_api=self.inference_api,
         )
 
@@ -450,16 +450,20 @@ class ElasticsearchVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStore
         if vector_store_id in self.cache:
             return self.cache[vector_store_id]
 
-        if self.vector_store_table is None:
-            raise ValueError(f"Vector DB not found {vector_store_id}")
+        if self.kvstore is None:
+            raise RuntimeError("KVStore not initialized. Call initialize() before using vector stores.")
 
-        vector_store = await self.vector_store_table.get_vector_store(vector_store_id)
-        if not vector_store:
+        key = f"{VECTOR_DBS_PREFIX}{vector_store_id}"
+        vector_store_data = await self.kvstore.get(key)
+        if not vector_store_data:
             raise VectorStoreNotFoundError(vector_store_id)
 
+        vector_store = VectorStore.model_validate_json(vector_store_data)
+        es_index = ElasticsearchIndex(client=self.client, vector_store=vector_store)
+        await es_index.initialize()
         index = VectorStoreWithIndex(
             vector_store=vector_store,
-            index=ElasticsearchIndex(client=self.client, collection_name=vector_store.identifier),
+            index=es_index,
             inference_api=self.inference_api,
         )
         self.cache[vector_store_id] = index

--- a/src/ogx/providers/remote/vector_io/milvus/milvus.py
+++ b/src/ogx/providers/remote/vector_io/milvus/milvus.py
@@ -76,71 +76,64 @@ class MilvusIndex(EmbeddingIndex):
     def __init__(
         self,
         client: MilvusClient,
-        collection_name: str,
+        vector_store: VectorStore,
         consistency_level: str = "Strong",
         kvstore: KVStore | None = None,
         use_native_hybrid: bool = False,
     ):
         self.client = client
-        self.collection_name = sanitize_collection_name(collection_name)
+        self.collection_name = sanitize_collection_name(vector_store.identifier)
         self.consistency_level = consistency_level
         self.kvstore = kvstore
         self.use_native_hybrid = use_native_hybrid
-
-    async def _collection_exists(self) -> bool:
-        return await asyncio.to_thread(self.client.has_collection, self.collection_name)
+        self.dimension = vector_store.embedding_dimension
 
     async def initialize(self):
-        # MilvusIndex does not require explicit initialization
-        # TODO: could move collection creation into initialization but it is not really necessary
-        pass
+        if await asyncio.to_thread(self.client.has_collection, self.collection_name):
+            return
+
+        # Create schema for vector search
+        schema = self.client.create_schema()
+        schema.add_field(field_name="chunk_id", datatype=DataType.VARCHAR, is_primary=True, max_length=100)
+        schema.add_field(
+            field_name="content",
+            datatype=DataType.VARCHAR,
+            max_length=65535,
+            enable_analyzer=True,
+        )
+        schema.add_field(field_name="vector", datatype=DataType.FLOAT_VECTOR, dim=self.dimension)
+        schema.add_field(field_name="chunk_content", datatype=DataType.JSON)
+        schema.add_field(field_name="sparse", datatype=DataType.SPARSE_FLOAT_VECTOR)
+
+        # Create indexes
+        index_params = self.client.prepare_index_params()
+        index_params.add_index(field_name="vector", index_type="FLAT", metric_type="COSINE")
+        index_params.add_index(field_name="sparse", index_type="SPARSE_INVERTED_INDEX", metric_type="BM25")
+
+        # Add BM25 function for full-text search
+        bm25_function = Function(
+            name="text_bm25_emb",
+            input_field_names=["content"],
+            output_field_names=["sparse"],
+            function_type=FunctionType.BM25,
+        )
+        schema.add_function(bm25_function)
+
+        logger.info("Creating Milvus collection", collection_name=self.collection_name)
+        await asyncio.to_thread(
+            self.client.create_collection,
+            self.collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level=self.consistency_level,
+        )
 
     async def delete(self):
-        if await asyncio.to_thread(self.client.has_collection, self.collection_name):
-            await asyncio.to_thread(self.client.drop_collection, collection_name=self.collection_name)
+        await asyncio.to_thread(self.client.drop_collection, collection_name=self.collection_name)
 
     async def add_chunks(self, chunks: list[EmbeddedChunk]):
         if not chunks:
             return
-
-        if not await asyncio.to_thread(self.client.has_collection, self.collection_name):
-            logger.info("Creating new collection with nullable sparse field", collection_name=self.collection_name)
-            # Create schema for vector search
-            schema = self.client.create_schema()
-            schema.add_field(field_name="chunk_id", datatype=DataType.VARCHAR, is_primary=True, max_length=100)
-            schema.add_field(
-                field_name="content",
-                datatype=DataType.VARCHAR,
-                max_length=65535,
-                enable_analyzer=True,  # Enable text analysis for BM25
-            )
-            schema.add_field(field_name="vector", datatype=DataType.FLOAT_VECTOR, dim=len(chunks[0].embedding))
-            schema.add_field(field_name="chunk_content", datatype=DataType.JSON)
-            # Add sparse vector field for BM25 (required by the function)
-            schema.add_field(field_name="sparse", datatype=DataType.SPARSE_FLOAT_VECTOR)
-
-            # Create indexes
-            index_params = self.client.prepare_index_params()
-            index_params.add_index(field_name="vector", index_type="FLAT", metric_type="COSINE")
-            # Add index for sparse field (required by BM25 function)
-            index_params.add_index(field_name="sparse", index_type="SPARSE_INVERTED_INDEX", metric_type="BM25")
-
-            # Add BM25 function for full-text search
-            bm25_function = Function(
-                name="text_bm25_emb",
-                input_field_names=["content"],
-                output_field_names=["sparse"],
-                function_type=FunctionType.BM25,
-            )
-            schema.add_function(bm25_function)
-
-            await asyncio.to_thread(
-                self.client.create_collection,
-                self.collection_name,
-                schema=schema,
-                index_params=index_params,
-                consistency_level=self.consistency_level,
-            )
 
         data = []
         for chunk in chunks:
@@ -227,9 +220,6 @@ class MilvusIndex(EmbeddingIndex):
     async def query_vector(
         self, embedding: NDArray, k: int, score_threshold: float, filters: Any = None
     ) -> QueryChunksResponse:
-        if not await self._collection_exists():
-            return QueryChunksResponse(chunks=[], scores=[])
-
         # Translate filters to Milvus expression format
         filter_expr = self._translate_filters(filters) if filters else None
 
@@ -260,9 +250,6 @@ class MilvusIndex(EmbeddingIndex):
         """
         Perform BM25-based keyword search using Milvus's built-in full-text search.
         """
-        if not await self._collection_exists():
-            return QueryChunksResponse(chunks=[], scores=[])
-
         try:
             # Translate filters to Milvus expression format
             filter_expr = self._translate_filters(filters) if filters else None
@@ -308,9 +295,6 @@ class MilvusIndex(EmbeddingIndex):
         """
         Fallback to simple text search when BM25 search is not available.
         """
-        if not await self._collection_exists():
-            return QueryChunksResponse(chunks=[], scores=[])
-
         # Simple text search using content field
         search_res = await asyncio.to_thread(
             self.client.query,
@@ -358,9 +342,6 @@ class MilvusIndex(EmbeddingIndex):
         Uses Milvus's hybrid_search method which combines vector search and
         BM25 search server-side with configurable reranking strategies.
         """
-        if not await self._collection_exists():
-            return QueryChunksResponse(chunks=[], scores=[])
-
         search_requests = []
 
         search_requests.append(
@@ -453,9 +434,6 @@ class MilvusIndex(EmbeddingIndex):
 
     async def delete_chunks(self, chunks_for_deletion: list[ChunkForDeletion]) -> None:
         """Remove a chunk from the Milvus collection."""
-        if not await self._collection_exists():
-            return
-
         chunk_ids = [c.chunk_id for c in chunks_for_deletion]
         try:
             # Use IN clause with square brackets and single quotes for VARCHAR field
@@ -499,25 +477,6 @@ class MilvusVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
 
             self.metadata_store = await authorized_sqlstore(self.config.metadata_store, self._policy)
 
-        start_key = VECTOR_DBS_PREFIX
-        end_key = f"{VECTOR_DBS_PREFIX}\xff"
-        stored_vector_stores = await self.kvstore.values_in_range(start_key, end_key)
-
-        use_native_hybrid = isinstance(self.config, RemoteMilvusVectorIOConfig)
-        for vector_store_data in stored_vector_stores:
-            vector_store = VectorStore.model_validate_json(vector_store_data)
-            index = VectorStoreWithIndex(
-                vector_store,
-                index=MilvusIndex(
-                    client=self.client,
-                    collection_name=vector_store.identifier,
-                    consistency_level=self.config.consistency_level,
-                    kvstore=self.kvstore,
-                    use_native_hybrid=use_native_hybrid,
-                ),
-                inference_api=self.inference_api,
-            )
-            self.cache[vector_store.identifier] = index
         if isinstance(self.config, RemoteMilvusVectorIOConfig):
             logger.info("Connecting to Milvus server at", uri=self.config.uri)
             self.client = MilvusClient(
@@ -528,7 +487,27 @@ class MilvusVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
             uri = os.path.expanduser(self.config.db_path)
             self.client = MilvusClient(uri=uri)
 
-        # Load existing OpenAI vector stores into the in-memory cache
+        start_key = VECTOR_DBS_PREFIX
+        end_key = f"{VECTOR_DBS_PREFIX}\xff"
+        stored_vector_stores = await self.kvstore.values_in_range(start_key, end_key)
+
+        use_native_hybrid = isinstance(self.config, RemoteMilvusVectorIOConfig)
+        for vector_store_data in stored_vector_stores:
+            vector_store = VectorStore.model_validate_json(vector_store_data)
+            milvus_index = MilvusIndex(
+                client=self.client,
+                vector_store=vector_store,
+                consistency_level=self.config.consistency_level,
+                kvstore=self.kvstore,
+                use_native_hybrid=use_native_hybrid,
+            )
+            await milvus_index.initialize()
+            index = VectorStoreWithIndex(
+                vector_store,
+                index=milvus_index,
+                inference_api=self.inference_api,
+            )
+            self.cache[vector_store.identifier] = index
         await self.initialize_openai_vector_stores()
 
     async def shutdown(self) -> None:
@@ -542,14 +521,16 @@ class MilvusVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
             consistency_level = self.config.consistency_level
         else:
             consistency_level = "Strong"
+        milvus_index = MilvusIndex(
+            self.client,
+            vector_store,
+            consistency_level=consistency_level,
+            use_native_hybrid=use_native_hybrid,
+        )
+        await milvus_index.initialize()
         index = VectorStoreWithIndex(
             vector_store=vector_store,
-            index=MilvusIndex(
-                self.client,
-                vector_store.identifier,
-                consistency_level=consistency_level,
-                use_native_hybrid=use_native_hybrid,
-            ),
+            index=milvus_index,
             inference_api=self.inference_api,
         )
 
@@ -570,14 +551,16 @@ class MilvusVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
 
         vector_store = VectorStore.model_validate_json(vector_store_data)
         use_native_hybrid = isinstance(self.config, RemoteMilvusVectorIOConfig)
+        milvus_index = MilvusIndex(
+            client=self.client,
+            vector_store=vector_store,
+            kvstore=self.kvstore,
+            use_native_hybrid=use_native_hybrid,
+        )
+        await milvus_index.initialize()
         index = VectorStoreWithIndex(
             vector_store=vector_store,
-            index=MilvusIndex(
-                client=self.client,
-                collection_name=vector_store.identifier,
-                kvstore=self.kvstore,
-                use_native_hybrid=use_native_hybrid,
-            ),
+            index=milvus_index,
             inference_api=self.inference_api,
         )
         self.cache[vector_store_id] = index

--- a/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
+++ b/src/ogx/providers/remote/vector_io/qdrant/qdrant.py
@@ -66,36 +66,34 @@ def convert_id(_id: str) -> str:
 class QdrantIndex(EmbeddingIndex):
     """Embedding index backed by a Qdrant collection."""
 
-    def __init__(self, client: AsyncQdrantClient, collection_name: str):
+    def __init__(self, client: AsyncQdrantClient, vector_store: VectorStore):
         self.client = client
-        self.collection_name = collection_name
+        self.collection_name = vector_store.identifier
+        self.dimension = vector_store.embedding_dimension
 
     async def initialize(self) -> None:
-        # Qdrant collections are created on-demand in add_chunks
-        # If the collection does not exist, it will be created in add_chunks.
-        pass
+        if await self.client.collection_exists(self.collection_name):
+            return
+
+        await self.client.create_collection(
+            self.collection_name,
+            vectors_config=models.VectorParams(size=self.dimension, distance=models.Distance.COSINE),
+        )
+        await self.client.create_payload_index(
+            collection_name=self.collection_name,
+            field_name="chunk_content.content",
+            field_schema=models.TextIndexParams(
+                type="text",
+                tokenizer=models.TokenizerType.WORD,
+                min_token_len=2,
+                max_token_len=20,
+                lowercase=True,
+            ),
+        )
 
     async def add_chunks(self, chunks: list[EmbeddedChunk]):
         if not chunks:
             return
-
-        if not await self.client.collection_exists(self.collection_name):
-            await self.client.create_collection(
-                self.collection_name,
-                vectors_config=models.VectorParams(size=len(chunks[0].embedding), distance=models.Distance.COSINE),
-            )
-            # Create text index for keyword search functionality
-            await self.client.create_payload_index(
-                collection_name=self.collection_name,
-                field_name="chunk_content.content",
-                field_schema=models.TextIndexParams(
-                    type="text",
-                    tokenizer=models.TokenizerType.WORD,
-                    min_token_len=2,
-                    max_token_len=20,
-                    lowercase=True,
-                ),
-            )
 
         points = []
         for chunk in chunks:
@@ -129,15 +127,8 @@ class QdrantIndex(EmbeddingIndex):
     async def query_vector(
         self, embedding: NDArray, k: int, score_threshold: float, filters: Any = None
     ) -> QueryChunksResponse:
-        # Filters are not yet implemented for Qdrant provider
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
-
-        # Collections are created lazily on first insert, so a search against a
-        # store that has never had chunks added has no collection yet. Treat that
-        # as an empty result rather than letting Qdrant raise a 404.
-        if not await self.client.collection_exists(self.collection_name):
-            return QueryChunksResponse(chunks=[], scores=[])
 
         results = (
             await self.client.query_points(
@@ -189,12 +180,6 @@ class QdrantIndex(EmbeddingIndex):
         # Qdrant provider does not yet support native filtering
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
-
-        # Collections are created lazily on first insert, so a search against a
-        # store that has never had chunks added has no collection yet. Treat that
-        # as an empty result rather than letting Qdrant raise a 404.
-        if not await self.client.collection_exists(self.collection_name):
-            return QueryChunksResponse(chunks=[], scores=[])
 
         try:
             # Use scroll for keyword-only search since query_points requires a query vector
@@ -276,12 +261,6 @@ class QdrantIndex(EmbeddingIndex):
         if filters is not None:
             raise NotImplementedError("Qdrant provider does not yet support native filtering")
 
-        # Collections are created lazily on first insert, so a search against a
-        # store that has never had chunks added has no collection yet. Treat that
-        # as an empty result rather than letting Qdrant raise a 404.
-        if not await self.client.collection_exists(self.collection_name):
-            return QueryChunksResponse(chunks=[], scores=[])
-
         try:
             query_words = query_string.lower().split()
             if not query_words:
@@ -340,7 +319,7 @@ class QdrantIndex(EmbeddingIndex):
         return QueryChunksResponse(chunks=chunks, scores=scores)
 
     async def delete(self):
-        await self.client.delete_collection(collection_name=self.collection_name)
+        await self.client.delete_collection(collection_name=self.collection_name, timeout=30)
 
 
 class QdrantVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtocolPrivate):
@@ -380,9 +359,9 @@ class QdrantVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
 
         for vector_store_data in stored_vector_stores:
             vector_store = VectorStore.model_validate_json(vector_store_data)
-            index = VectorStoreWithIndex(
-                vector_store, QdrantIndex(self.client, vector_store.identifier), self.inference_api
-            )
+            qdrant_index = QdrantIndex(self.client, vector_store)
+            await qdrant_index.initialize()
+            index = VectorStoreWithIndex(vector_store, qdrant_index, self.inference_api)
             self.cache[vector_store.identifier] = index
         await self.initialize_openai_vector_stores()
 
@@ -397,9 +376,11 @@ class QdrantVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
         key = f"{VECTOR_DBS_PREFIX}{vector_store.identifier}"
         await self.kvstore.set(key=key, value=vector_store.model_dump_json())
 
+        qdrant_index = QdrantIndex(self.client, vector_store)
+        await qdrant_index.initialize()
         index = VectorStoreWithIndex(
             vector_store=vector_store,
-            index=QdrantIndex(self.client, vector_store.identifier),
+            index=qdrant_index,
             inference_api=self.inference_api,
         )
 
@@ -428,9 +409,11 @@ class QdrantVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProtoc
             raise VectorStoreNotFoundError(vector_store_id)
 
         vector_store = VectorStore.model_validate_json(vector_store_data)
+        qdrant_index = QdrantIndex(client=self.client, vector_store=vector_store)
+        await qdrant_index.initialize()
         index = VectorStoreWithIndex(
             vector_store=vector_store,
-            index=QdrantIndex(client=self.client, collection_name=vector_store.identifier),
+            index=qdrant_index,
             inference_api=self.inference_api,
         )
         self.cache[vector_store_id] = index

--- a/tests/unit/providers/vector_io/conftest.py
+++ b/tests/unit/providers/vector_io/conftest.py
@@ -20,7 +20,8 @@ from ogx.providers.inline.vector_io.sqlite_vec.sqlite_vec import SQLiteVecIndex,
 from ogx.providers.remote.vector_io.pgvector.config import PGVectorHNSWVectorIndex, PGVectorVectorIOConfig
 from ogx.providers.remote.vector_io.pgvector.pgvector import PGVectorIndex, PGVectorVectorIOAdapter
 from ogx.providers.remote.vector_io.qdrant.qdrant import QdrantIndex, QdrantVectorIOAdapter
-from ogx_api import Chunk, ChunkMetadata, QueryChunksResponse, VectorStore, VectorStoreNotFoundError
+from ogx_api import Chunk, ChunkMetadata, QueryChunksResponse, VectorStoreNotFoundError
+from ogx_api.vector_stores import VectorStore
 
 EMBEDDING_DIMENSION = 768
 COLLECTION_PREFIX = "test_collection"
@@ -370,7 +371,13 @@ async def qdrant_vec_index(embedding_dimension):
     mock_client.delete_collection = AsyncMock()
 
     collection_name = f"test-qdrant-collection-{random.randint(1, 1000000)}"
-    index = QdrantIndex(mock_client, collection_name)
+    test_vector_store = VectorStore(
+        identifier=collection_name,
+        provider_id="test_provider",
+        embedding_model="test_model",
+        embedding_dimension=embedding_dimension,
+    )
+    index = QdrantIndex(mock_client, test_vector_store)
     index._test_chunks = []
 
     async def mock_add_chunks(embedded_chunks):


### PR DESCRIPTION
Move backing-store creation from lazy (first add_chunks) to eager (register_vector_store / adapter.initialize) for Qdrant, Milvus, and Elasticsearch vector providers. The embedding dimension is now sourced from VectorStore.embedding_dimension rather than inferred from chunk data.

Key changes:
- QdrantIndex, MilvusIndex, ElasticsearchIndex accept VectorStore instead of collection_name: str; create backing store in initialize()
- Remove lazy existence checks from query and delete paths since collections are guaranteed to exist after initialization
