### PR TITLE
feat(skills): inject skill instructions into Responses API system prompt

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -7780,6 +7780,12 @@ components:
           anyOf:
           - type: string
           - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
         max_tool_calls:
           anyOf:
           - type: integer
@@ -8202,6 +8208,12 @@ components:
         instructions:
           anyOf:
           - type: string
+          - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
           - type: 'null'
         max_tool_calls:
           anyOf:
@@ -12017,6 +12029,13 @@ components:
           - type: string
           - type: 'null'
           description: Instructions to guide the model's behavior.
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: List of skill IDs whose SKILL.md instructions are injected into the model's context.
         parallel_tool_calls:
           anyOf:
           - type: boolean

--- a/demo/skills_api_demo.py
+++ b/demo/skills_api_demo.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Skills API Demo — exercises all 11 Skills API endpoints.
+
+Prerequisites:
+    Start an OGX server with skills enabled:
+        uv run ogx letsgo
+
+Usage:
+    uv run python demo/skills_api_demo.py [--base-url http://localhost:8321]
+"""
+
+import argparse
+import io
+import json
+import sys
+import zipfile
+
+import httpx
+
+DEFAULT_BASE_URL = "http://localhost:8321"
+
+
+def make_skill_zip(name: str, description: str, instructions: str, files: dict[str, str] | None = None) -> bytes:
+    """Create a skill zip bundle with a SKILL.md manifest and optional extra files."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        manifest = f"""---
+name: {name}
+description: {description}
+---
+{instructions}"""
+        zf.writestr("SKILL.md", manifest)
+        if files:
+            for path, content in files.items():
+                zf.writestr(path, content)
+    return buf.getvalue()
+
+
+def print_response(label: str, resp: httpx.Response) -> dict | None:
+    print(f"\n{'=' * 60}")
+    print(f"  {label}")
+    print(f"{'=' * 60}")
+    print(f"  Status: {resp.status_code}")
+    if resp.headers.get("content-type", "").startswith("application/json"):
+        data = resp.json()
+        print(f"  Response: {json.dumps(data, indent=2)}")
+        return data
+    elif resp.headers.get("content-type", "").startswith("application/zip"):
+        print(f"  Response: <zip archive, {len(resp.content)} bytes>")
+        return None
+    else:
+        print(f"  Response: {resp.text[:200]}")
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Skills API Demo")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="OGX server URL")
+    args = parser.parse_args()
+
+    base = args.base_url.rstrip("/")
+    client = httpx.Client(base_url=base, timeout=30.0)
+
+    print("\n" + "=" * 60)
+    print("  OGX Skills API Demo")
+    print("=" * 60)
+
+    # ──────────────────────────────────────────────────────────
+    # 1. Create a skill
+    # ──────────────────────────────────────────────────────────
+    zip_content = make_skill_zip(
+        name="data-analyzer",
+        description="Analyzes CSV data and generates summary statistics",
+        instructions="Use this skill to analyze CSV files. Run `python analyze.py <file>` to get statistics.",
+        files={
+            "analyze.py": 'import sys\nprint(f"Analyzing {sys.argv[1]}...")\nprint("Mean: 42.0, Median: 41.5")\n',
+            "requirements.txt": "pandas>=2.0\n",
+        },
+    )
+
+    resp = client.post(
+        "/v1alpha/skills",
+        files={"file": ("data-analyzer.zip", zip_content, "application/zip")},
+    )
+    skill = print_response("1. POST /v1alpha/skills — Create skill", resp)
+    if resp.status_code != 200:
+        print("\n  ERROR: Failed to create skill. Is the server running with skills enabled?")
+        sys.exit(1)
+
+    skill_id = skill["id"]
+
+    # ──────────────────────────────────────────────────────────
+    # 2. List skills
+    # ──────────────────────────────────────────────────────────
+    resp = client.get("/v1alpha/skills")
+    print_response("2. GET /v1alpha/skills — List skills", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 3. Get skill metadata
+    # ──────────────────────────────────────────────────────────
+    resp = client.get(f"/v1alpha/skills/{skill_id}")
+    print_response(f"3. GET /v1alpha/skills/{skill_id} — Get skill", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 4. Download skill content
+    # ──────────────────────────────────────────────────────────
+    resp = client.get(f"/v1alpha/skills/{skill_id}/content")
+    print_response(f"4. GET /v1alpha/skills/{skill_id}/content — Download zip", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 5. Create a new version
+    # ──────────────────────────────────────────────────────────
+    zip_v2 = make_skill_zip(
+        name="data-analyzer",
+        description="Analyzes CSV data with visualization support",
+        instructions="Run `python analyze.py <file>` for stats, or `python plot.py <file>` for charts.",
+        files={
+            "analyze.py": 'import sys\nprint(f"Analyzing {sys.argv[1]}...")\nprint("Mean: 42.0, Std: 5.2")\n',
+            "plot.py": 'import sys\nprint(f"Plotting {sys.argv[1]}...")\n',
+            "requirements.txt": "pandas>=2.0\nmatplotlib>=3.8\n",
+        },
+    )
+
+    resp = client.post(
+        f"/v1alpha/skills/{skill_id}/versions",
+        files={"file": ("data-analyzer-v2.zip", zip_v2, "application/zip")},
+        data={"default": "true"},
+    )
+    print_response(f"5. POST /v1alpha/skills/{skill_id}/versions — Create version 2", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 6. List versions
+    # ──────────────────────────────────────────────────────────
+    resp = client.get(f"/v1alpha/skills/{skill_id}/versions")
+    print_response(f"6. GET /v1alpha/skills/{skill_id}/versions — List versions", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 7. Get version metadata
+    # ──────────────────────────────────────────────────────────
+    resp = client.get(f"/v1alpha/skills/{skill_id}/versions/2")
+    print_response(f"7. GET /v1alpha/skills/{skill_id}/versions/2 — Get version 2", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 8. Download version content
+    # ──────────────────────────────────────────────────────────
+    resp = client.get(f"/v1alpha/skills/{skill_id}/versions/1/content")
+    print_response(f"8. GET /v1alpha/skills/{skill_id}/versions/1/content — Download v1 zip", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 9. Update default version
+    # ──────────────────────────────────────────────────────────
+    resp = client.post(
+        f"/v1alpha/skills/{skill_id}",
+        json={"default_version": "1"},
+    )
+    print_response(f"9. POST /v1alpha/skills/{skill_id} — Set default to v1", resp)
+
+    # ──────────────────────────────────────────────────────────
+    # 10. Delete version 1
+    # ──────────────────────────────────────────────────────────
+    resp = client.delete(f"/v1alpha/skills/{skill_id}/versions/1")
+    print_response(f"10. DELETE /v1alpha/skills/{skill_id}/versions/1 — Delete version 1", resp)
+
+    # Verify default_version was updated
+    resp = client.get(f"/v1alpha/skills/{skill_id}")
+    updated = print_response(f"    GET /v1alpha/skills/{skill_id} — Verify default updated", resp)
+    if updated:
+        print(f"\n    default_version is now: {updated['default_version']}")
+
+    # ──────────────────────────────────────────────────────────
+    # 11. Delete skill
+    # ──────────────────────────────────────────────────────────
+    resp = client.delete(f"/v1alpha/skills/{skill_id}")
+    print_response(f"11. DELETE /v1alpha/skills/{skill_id} — Delete skill", resp)
+
+    # Verify deletion
+    resp = client.get(f"/v1alpha/skills/{skill_id}")
+    print_response(f"    GET /v1alpha/skills/{skill_id} — Verify deleted (expect error)", resp)
+
+    print("\n" + "=" * 60)
+    print("  Demo complete — all 11 Skills API endpoints exercised")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/static/deprecated-ogx-spec.yaml
+++ b/docs/static/deprecated-ogx-spec.yaml
@@ -3313,6 +3313,12 @@ components:
           anyOf:
           - type: string
           - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
         max_tool_calls:
           anyOf:
           - type: integer
@@ -3735,6 +3741,12 @@ components:
         instructions:
           anyOf:
           - type: string
+          - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
           - type: 'null'
         max_tool_calls:
           anyOf:

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -4193,6 +4193,12 @@ components:
           anyOf:
           - type: string
           - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
         max_tool_calls:
           anyOf:
           - type: integer
@@ -4615,6 +4621,12 @@ components:
         instructions:
           anyOf:
           - type: string
+          - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
           - type: 'null'
         max_tool_calls:
           anyOf:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -6898,6 +6898,12 @@ components:
           anyOf:
           - type: string
           - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
         max_tool_calls:
           anyOf:
           - type: integer
@@ -7320,6 +7326,12 @@ components:
         instructions:
           anyOf:
           - type: string
+          - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
           - type: 'null'
         max_tool_calls:
           anyOf:
@@ -11086,6 +11098,13 @@ components:
           - type: string
           - type: 'null'
           description: Instructions to guide the model's behavior.
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: List of skill IDs whose SKILL.md instructions are injected into the model's context.
         parallel_tool_calls:
           anyOf:
           - type: boolean

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -7780,6 +7780,12 @@ components:
           anyOf:
           - type: string
           - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
         max_tool_calls:
           anyOf:
           - type: integer
@@ -8202,6 +8208,12 @@ components:
         instructions:
           anyOf:
           - type: string
+          - type: 'null'
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
           - type: 'null'
         max_tool_calls:
           anyOf:
@@ -12017,6 +12029,13 @@ components:
           - type: string
           - type: 'null'
           description: Instructions to guide the model's behavior.
+        skills:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          description: List of skill IDs whose SKILL.md instructions are injected into the model's context.
         parallel_tool_calls:
           anyOf:
           - type: boolean

--- a/src/ogx/providers/inline/responses/builtin/__init__.py
+++ b/src/ogx/providers/inline/responses/builtin/__init__.py
@@ -29,6 +29,7 @@ async def get_provider_impl(
         deps[Api.files],
         deps[Api.connectors],
         policy,
+        skills_api=deps.get(Api.skills),
     )
     await impl.initialize()
     return impl

--- a/src/ogx/providers/inline/responses/builtin/impl.py
+++ b/src/ogx/providers/inline/responses/builtin/impl.py
@@ -5,7 +5,10 @@
 # the root directory of this source tree.
 
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ogx_api.skills import Skills
 
 from opentelemetry import metrics
 
@@ -76,7 +79,7 @@ class BuiltinResponsesImpl(Responses):
         files_api: Files,
         connectors_api: Connectors,
         policy: list[AccessRule],
-        skills_api: Any = None,
+        skills_api: "Skills | None" = None,
     ):
         self.config = config
         self.inference_api = inference_api

--- a/src/ogx/providers/inline/responses/builtin/impl.py
+++ b/src/ogx/providers/inline/responses/builtin/impl.py
@@ -5,6 +5,7 @@
 # the root directory of this source tree.
 
 from collections.abc import AsyncIterator
+from typing import Any
 
 from opentelemetry import metrics
 
@@ -75,6 +76,7 @@ class BuiltinResponsesImpl(Responses):
         files_api: Files,
         connectors_api: Connectors,
         policy: list[AccessRule],
+        skills_api: Any = None,
     ):
         self.config = config
         self.inference_api = inference_api
@@ -87,6 +89,7 @@ class BuiltinResponsesImpl(Responses):
         self.openai_responses_impl: OpenAIResponsesImpl | None = None
         self.policy = policy
         self.connectors_api = connectors_api
+        self.skills_api = skills_api
 
     async def initialize(self) -> None:
         self.responses_store = ResponsesStore(self.config.persistence.responses, self.policy)
@@ -106,6 +109,7 @@ class BuiltinResponsesImpl(Responses):
             files_api=self.files_api,
             vector_stores_config=self.config.vector_stores_config,
             connectors_api=self.connectors_api,
+            skills_api=self.skills_api,
             compaction_config=self.config.compaction_config,
             memory_config=self.config.memory_config,
         )
@@ -139,6 +143,7 @@ class BuiltinResponsesImpl(Responses):
             model=request.model,
             prompt=request.prompt,
             instructions=request.instructions,
+            skills=request.skills,
             previous_response_id=request.previous_response_id,
             prompt_cache_key=request.prompt_cache_key,
             conversation=request.conversation,

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -1193,6 +1193,7 @@ class OpenAIResponsesImpl:
             tools=[],  # Will be populated when processing completes
             tool_choice=tool_choice,
             instructions=instructions,
+            skills=skills,
             max_tool_calls=max_tool_calls,
             reasoning=reasoning,
             metadata=metadata,

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from typing import Any
 
 import tiktoken
 from pydantic import TypeAdapter
@@ -129,6 +130,7 @@ class OpenAIResponsesImpl:
         prompts_api: Prompts,
         files_api: Files,
         connectors_api: Connectors,
+        skills_api: Any = None,
         moderation_headers: dict[str, str] | None = None,
         vector_stores_config: VectorStoresConfig | None = None,
         compaction_config=None,
@@ -142,6 +144,7 @@ class OpenAIResponsesImpl:
         self.moderation_endpoint = moderation_endpoint
         self.moderation_headers = moderation_headers
         self.conversations_api = conversations_api
+        self.skills_api = skills_api
         self.tool_executor = ToolExecutor(
             tool_groups_api=tool_groups_api,
             tool_runtime_api=tool_runtime_api,
@@ -529,6 +532,18 @@ class OpenAIResponsesImpl:
                 response_id=response_id,
                 error=str(exc),
             )
+    async def _resolve_skill_instructions(self, skill_ids: list[str]) -> list[OpenAISystemMessageParam]:
+        """Resolve skill IDs and return system messages with their instructions."""
+        parts: list[str] = []
+        for skill_id in skill_ids:
+            try:
+                skill = await self.skills_api.get_skill(skill_id)
+                parts.append(f"## Skill: {skill.name}\n{skill.description}")
+            except Exception:
+                logger.warning("Failed to resolve skill instructions", skill_id=skill_id)
+        if not parts:
+            return []
+        return [OpenAISystemMessageParam(content="\n\n".join(parts))]
 
     async def _prepend_prompt(
         self,
@@ -870,6 +885,7 @@ class OpenAIResponsesImpl:
         background: bool | None = False,
         prompt: OpenAIResponsePrompt | None = None,
         instructions: str | None = None,
+        skills: list[str] | None = None,
         previous_response_id: str | None = None,
         prompt_cache_key: str | None = None,
         conversation: str | None = None,
@@ -961,6 +977,7 @@ class OpenAIResponsesImpl:
                 model=model,
                 prompt=prompt,
                 instructions=instructions,
+                skills=skills,
                 previous_response_id=previous_response_id,
                 conversation=conversation,
                 store=store,
@@ -992,6 +1009,7 @@ class OpenAIResponsesImpl:
             model=model,
             prompt=prompt,
             instructions=instructions,
+            skills=skills,
             previous_response_id=previous_response_id,
             prompt_cache_key=prompt_cache_key,
             store=store,
@@ -1083,6 +1101,7 @@ class OpenAIResponsesImpl:
         model: str,
         prompt: OpenAIResponsePrompt | None = None,
         instructions: str | None = None,
+        skills: list[str] | None = None,
         previous_response_id: str | None = None,
         conversation: str | None = None,
         store: bool | None = True,
@@ -1203,6 +1222,7 @@ class OpenAIResponsesImpl:
         model: str,
         prompt: OpenAIResponsePrompt | None = None,
         instructions: str | None = None,
+        skills: list[str] | None = None,
         previous_response_id: str | None = None,
         conversation: str | None = None,
         store: bool | None = True,
@@ -1246,6 +1266,7 @@ class OpenAIResponsesImpl:
             model=model,
             prompt=prompt,
             instructions=instructions,
+            skills=skills,
             previous_response_id=previous_response_id,
             store=store,
             temperature=temperature,
@@ -1318,6 +1339,7 @@ class OpenAIResponsesImpl:
         input: str | list[OpenAIResponseInput],
         model: str,
         instructions: str | None = None,
+        skills: list[str] | None = None,
         previous_response_id: str | None = None,
         prompt_cache_key: str | None = None,
         conversation: str | None = None,
@@ -1359,6 +1381,12 @@ class OpenAIResponsesImpl:
             input, tools, previous_response_id, conversation
         )
 
+        # Inherit skills from previous response if not explicitly provided
+        if skills is None and previous_response_id:
+            previous_response = await self.responses_store.get_response_object(previous_response_id)
+            if previous_response.skills:
+                skills = previous_response.skills
+
         # Auto-compact if context_management is configured (runs on resolved history, not just new input)
         compacted_history_applied = False
         if context_management:
@@ -1372,6 +1400,13 @@ class OpenAIResponsesImpl:
 
         if instructions:
             messages.insert(0, OpenAISystemMessageParam(content=instructions))
+
+        # Inject skill instructions after user instructions
+        if skills and self.skills_api:
+            skill_messages = await self._resolve_skill_instructions(skills)
+            insert_idx = 1 if instructions else 0
+            for i, msg in enumerate(skill_messages):
+                messages.insert(insert_idx + i, msg)
 
         # Prepend reusable prompt (if provided)
         await self._prepend_prompt(messages, prompt)
@@ -1428,6 +1463,7 @@ class OpenAIResponsesImpl:
                 prompt=prompt,
                 prompt_cache_key=prompt_cache_key,
                 previous_response_id=previous_response_id,
+                skills=skills,
                 text=text,
                 max_infer_iters=max_infer_iters,
                 parallel_tool_calls=parallel_tool_calls,
@@ -1524,6 +1560,7 @@ class OpenAIResponsesImpl:
         model: str | None,
         input: str | list[OpenAIResponseInput] | None = None,
         instructions: str | None = None,
+        skills: list[str] | None = None,
         previous_response_id: str | None = None,
         prompt_cache_key: str | None = None,
         extra_body: dict | None = None,

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -10,7 +10,10 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ogx_api.skills import Skills
 
 import tiktoken
 from pydantic import TypeAdapter
@@ -130,7 +133,7 @@ class OpenAIResponsesImpl:
         prompts_api: Prompts,
         files_api: Files,
         connectors_api: Connectors,
-        skills_api: Any = None,
+        skills_api: "Skills | None" = None,
         moderation_headers: dict[str, str] | None = None,
         vector_stores_config: VectorStoresConfig | None = None,
         compaction_config=None,
@@ -541,18 +544,39 @@ class OpenAIResponsesImpl:
                 error=str(exc),
             )
     async def _resolve_skill_instructions(self, skill_ids: list[str]) -> list[OpenAISystemMessageParam]:
-        """Resolve skill IDs and return system messages with their instructions.
+        """Resolve skill IDs and return system messages with their SKILL.md instructions.
 
-        Fetches each skill's metadata and builds a system message from
-        the skill name and description (from SKILL.md frontmatter).
+        For each skill, fetches the default version's zip content, parses
+        the SKILL.md manifest, and builds a system message from the skill
+        name, description, and full instructions body.
         """
-        parts: list[str] = []
-        for skill_id in skill_ids:
+        from ogx.providers.inline.skills.builtin.manifest import parse_skill_manifest
+        from ogx.providers.inline.skills.builtin.validation import _SKILL_MD
+
+        async def _resolve_one(skill_id: str) -> str:
+            assert self.skills_api is not None
             skill = await self.skills_api.get_skill(skill_id)
+            resp = await self.skills_api.get_skill_version_content(skill_id, skill.default_version)
+            import zipfile
+            from io import BytesIO
+
+            with zipfile.ZipFile(BytesIO(resp.body)) as zf:
+                if _SKILL_MD in zf.namelist():
+                    manifest = parse_skill_manifest(zf.read(_SKILL_MD).decode("utf-8"))
+                else:
+                    manifest = None
+
             section = f"## Skill: {skill.name}"
             if skill.description:
                 section += f"\n{skill.description}"
-            parts.append(section)
+            if manifest and manifest.instructions:
+                section += f"\n\n### Instructions\n{manifest.instructions}"
+            return section
+
+        import asyncio
+
+        results = await asyncio.gather(*[_resolve_one(sid) for sid in skill_ids])
+        parts = list(results)
         if not parts:
             return []
         return [OpenAISystemMessageParam(content="\n\n".join(parts))]
@@ -1417,7 +1441,9 @@ class OpenAIResponsesImpl:
             messages.insert(0, OpenAISystemMessageParam(content=instructions))
 
         # Inject skill instructions after user instructions
-        if skills and self.skills_api:
+        if skills:
+            if not self.skills_api:
+                raise ServiceNotEnabledError("skills")
             skill_messages = await self._resolve_skill_instructions(skills)
             insert_idx = 1 if instructions else 0
             for i, msg in enumerate(skill_messages):

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -321,14 +321,21 @@ class OpenAIResponsesImpl:
         tools: list[OpenAIResponseInputTool] | None,
         previous_response_id: str | None,
         conversation: str | None,
-    ) -> tuple[str | list[OpenAIResponseInput], list[OpenAIMessageParam], ToolContext, OpenAIResponseUsage | None]:
+    ) -> tuple[
+        str | list[OpenAIResponseInput],
+        list[OpenAIMessageParam],
+        ToolContext,
+        OpenAIResponseUsage | None,
+        list[str] | None,
+    ]:
         """Process input with optional previous response context.
 
         Returns:
-            tuple: (all_input for storage, messages for chat completion, tool context, previous usage)
+            tuple: (all_input, messages, tool context, previous usage, inherited skills)
         """
         tool_context = ToolContext(tools)
         previous_usage: OpenAIResponseUsage | None = None
+        inherited_skills: list[str] | None = None
         if previous_response_id:
             previous_response: _OpenAIResponseObjectWithInputAndMessages = (
                 await self.responses_store.get_response_object(previous_response_id)
@@ -339,6 +346,7 @@ class OpenAIResponsesImpl:
                     "Cannot use an incomplete background response as previous_response_id."
                 )
             previous_usage = previous_response.usage
+            inherited_skills = previous_response.skills
             all_input = await self._prepend_previous_response(input, previous_response)
 
             if previous_response.messages:
@@ -390,7 +398,7 @@ class OpenAIResponsesImpl:
             all_input = input
             messages = await convert_response_input_to_chat_messages(all_input, files_api=self.files_api)
 
-        return all_input, messages, tool_context, previous_usage
+        return all_input, messages, tool_context, previous_usage, inherited_skills
 
     @staticmethod
     def _insert_memory_context(messages: list[OpenAIMessageParam], memory_context: str) -> None:
@@ -533,14 +541,18 @@ class OpenAIResponsesImpl:
                 error=str(exc),
             )
     async def _resolve_skill_instructions(self, skill_ids: list[str]) -> list[OpenAISystemMessageParam]:
-        """Resolve skill IDs and return system messages with their instructions."""
+        """Resolve skill IDs and return system messages with their instructions.
+
+        Fetches each skill's metadata and builds a system message from
+        the skill name and description (from SKILL.md frontmatter).
+        """
         parts: list[str] = []
         for skill_id in skill_ids:
-            try:
-                skill = await self.skills_api.get_skill(skill_id)
-                parts.append(f"## Skill: {skill.name}\n{skill.description}")
-            except Exception:
-                logger.warning("Failed to resolve skill instructions", skill_id=skill_id)
+            skill = await self.skills_api.get_skill(skill_id)
+            section = f"## Skill: {skill.name}"
+            if skill.description:
+                section += f"\n{skill.description}"
+            parts.append(section)
         if not parts:
             return []
         return [OpenAISystemMessageParam(content="\n\n".join(parts))]
@@ -1182,6 +1194,7 @@ class OpenAIResponsesImpl:
                         model=model,
                         prompt=prompt,
                         instructions=instructions,
+                        skills=skills,
                         previous_response_id=previous_response_id,
                         conversation=conversation,
                         store=store,
@@ -1377,15 +1390,17 @@ class OpenAIResponsesImpl:
         assert max_infer_iters is not None, "max_infer_iters must not be None"
 
         # Input preprocessing
-        all_input, messages, tool_context, previous_usage = await self._process_input_with_previous_response(
-            input, tools, previous_response_id, conversation
-        )
+        (
+            all_input,
+            messages,
+            tool_context,
+            previous_usage,
+            inherited_skills,
+        ) = await self._process_input_with_previous_response(input, tools, previous_response_id, conversation)
 
         # Inherit skills from previous response if not explicitly provided
-        if skills is None and previous_response_id:
-            previous_response = await self.responses_store.get_response_object(previous_response_id)
-            if previous_response.skills:
-                skills = previous_response.skills
+        if skills is None and inherited_skills:
+            skills = inherited_skills
 
         # Auto-compact if context_management is configured (runs on resolved history, not just new input)
         compacted_history_applied = False

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -5,9 +5,11 @@
 # the root directory of this source tree.
 
 import asyncio
+import io
 import re
 import time
 import uuid
+import zipfile
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -28,6 +30,8 @@ from ogx.core.task import (
 )
 from ogx.log import get_logger
 from ogx.providers.inline.responses.builtin.config import CompactionConfig, MemoryConfig
+from ogx.providers.inline.skills.builtin.manifest import parse_skill_manifest
+from ogx.providers.inline.skills.builtin.validation import _SKILL_MD
 from ogx.providers.utils.responses.responses_store import (
     ResponsesStore,
     _OpenAIResponseObjectWithInputAndMessages,
@@ -550,17 +554,13 @@ class OpenAIResponsesImpl:
         the SKILL.md manifest, and builds a system message from the skill
         name, description, and full instructions body.
         """
-        from ogx.providers.inline.skills.builtin.manifest import parse_skill_manifest
-        from ogx.providers.inline.skills.builtin.validation import _SKILL_MD
 
         async def _resolve_one(skill_id: str) -> str:
             assert self.skills_api is not None
             skill = await self.skills_api.get_skill(skill_id)
             resp = await self.skills_api.get_skill_version_content(skill_id, skill.default_version)
-            import zipfile
-            from io import BytesIO
 
-            with zipfile.ZipFile(BytesIO(resp.body)) as zf:
+            with zipfile.ZipFile(io.BytesIO(resp.body)) as zf:
                 if _SKILL_MD in zf.namelist():
                     manifest = parse_skill_manifest(zf.read(_SKILL_MD).decode("utf-8"))
                 else:
@@ -572,8 +572,6 @@ class OpenAIResponsesImpl:
             if manifest and manifest.instructions:
                 section += f"\n\n### Instructions\n{manifest.instructions}"
             return section
-
-        import asyncio
 
         results = await asyncio.gather(*[_resolve_one(sid) for sid in skill_ids])
         parts = list(results)

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -547,6 +547,7 @@ class OpenAIResponsesImpl:
                 response_id=response_id,
                 error=str(exc),
             )
+
     async def _resolve_skill_instructions(self, skill_ids: list[str]) -> list[OpenAISystemMessageParam]:
         """Resolve skill IDs and return system messages with their SKILL.md instructions.
 

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -234,7 +234,8 @@ class StreamingResponseOrchestrator:
         max_infer_iters: int,
         tool_executor,  # Will be the tool execution logic from the main class
         instructions: str | None,
-        moderation_endpoint: str | None,
+        skills: list[str] | None = None,
+        moderation_endpoint: str | None = None,
         moderation_headers: dict[str, str] | None = None,
         enable_guardrails: bool = False,
         connectors_api: Connectors | None = None,
@@ -272,6 +273,7 @@ class StreamingResponseOrchestrator:
         self.previous_response_id = previous_response_id
         # System message that is inserted into the model's context
         self.instructions = instructions
+        self.skills = skills
         # Whether to allow more than one function tool call generated per turn.
         self.parallel_tool_calls = parallel_tool_calls
         # Max number of total calls to built-in tools that can be processed in a response
@@ -388,6 +390,7 @@ class StreamingResponseOrchestrator:
             incomplete_details=incomplete_details,
             usage=self.accumulated_usage,
             instructions=self.instructions,
+            skills=self.skills,
             prompt=self.prompt,
             parallel_tool_calls=self.parallel_tool_calls if self.parallel_tool_calls is not None else True,
             max_tool_calls=self.max_tool_calls,

--- a/src/ogx/providers/registry/responses.py
+++ b/src/ogx/providers/registry/responses.py
@@ -44,7 +44,7 @@ def available_providers() -> list[ProviderSpec]:
                 Api.files,
                 Api.connectors,
             ],
-            optional_api_dependencies=[],
+            optional_api_dependencies=[Api.skills],
             description="Meta's reference implementation of an agent system that can use tools, access vector databases, and perform complex reasoning tasks.",
         ),
     ]

--- a/src/ogx_api/openai_responses.py
+++ b/src/ogx_api/openai_responses.py
@@ -880,6 +880,7 @@ class OpenAIResponseObject(BaseModel):
     truncation: ResponseTruncation | None = None
     usage: OpenAIResponseUsage | None = None
     instructions: str | None = None
+    skills: list[str] | None = None
     max_tool_calls: int | None = None
     reasoning: OpenAIResponseReasoning | None = None
     max_output_tokens: int | None = None

--- a/src/ogx_api/responses/models.py
+++ b/src/ogx_api/responses/models.py
@@ -139,6 +139,10 @@ class CreateResponseRequest(BaseModel):
         default=None, description="Prompt object with ID, version, and variables."
     )
     instructions: str | None = Field(default=None, description="Instructions to guide the model's behavior.")
+    skills: list[str] | None = Field(
+        default=None,
+        description="List of skill IDs whose SKILL.md instructions are injected into the model's context.",
+    )
     parallel_tool_calls: bool | None = Field(
         default=True,
         description="Whether to enable parallel tool calls.",

--- a/tests/unit/providers/responses/builtin/test_skills_injection.py
+++ b/tests/unit/providers/responses/builtin/test_skills_injection.py
@@ -1,0 +1,105 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import io
+import zipfile
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ogx.providers.inline.responses.builtin.responses.openai_responses import OpenAIResponsesImpl
+
+
+def _make_skill_zip(name: str, description: str, instructions: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        manifest = f"---\nname: {name}\ndescription: {description}\n---\n{instructions}"
+        zf.writestr("SKILL.md", manifest)
+    return buf.getvalue()
+
+
+def _make_mock_skills_api(skill_name: str, skill_description: str, instructions: str) -> AsyncMock:
+    api = AsyncMock()
+    skill = MagicMock()
+    skill.name = skill_name
+    skill.description = skill_description
+    skill.default_version = "1"
+    api.get_skill = AsyncMock(return_value=skill)
+
+    zip_bytes = _make_skill_zip(skill_name, skill_description, instructions)
+    resp = MagicMock()
+    resp.body = zip_bytes
+    api.get_skill_version_content = AsyncMock(return_value=resp)
+    return api
+
+
+class TestResolveSkillInstructions:
+    async def test_skill_instructions_include_manifest_body(self):
+        skills_api = _make_mock_skills_api(
+            "code-reviewer",
+            "Reviews code for security issues",
+            "Always check for SQL injection, XSS, and auth bypass.",
+        )
+        impl = OpenAIResponsesImpl.__new__(OpenAIResponsesImpl)
+        impl.skills_api = skills_api
+
+        messages = await impl._resolve_skill_instructions(["skill-123"])
+
+        assert len(messages) == 1
+        content = messages[0].content
+        assert "## Skill: code-reviewer" in content
+        assert "Reviews code for security issues" in content
+        assert "### Instructions" in content
+        assert "Always check for SQL injection, XSS, and auth bypass." in content
+
+    async def test_skill_instructions_multiple_skills(self):
+        api1 = _make_mock_skills_api("analyzer", "Analyzes data", "Run analyze.py")
+        api2 = _make_mock_skills_api("reviewer", "Reviews code", "Check for bugs")
+
+        call_count = 0
+
+        async def mock_get_skill(skill_id):
+            nonlocal call_count
+            call_count += 1
+            if "analyzer" in skill_id:
+                return api1.get_skill.return_value
+            return api2.get_skill.return_value
+
+        async def mock_get_content(skill_id, version):
+            if "analyzer" in skill_id:
+                return api1.get_skill_version_content.return_value
+            return api2.get_skill_version_content.return_value
+
+        combined_api = AsyncMock()
+        combined_api.get_skill = mock_get_skill
+        combined_api.get_skill_version_content = mock_get_content
+
+        impl = OpenAIResponsesImpl.__new__(OpenAIResponsesImpl)
+        impl.skills_api = combined_api
+
+        messages = await impl._resolve_skill_instructions(["skill-analyzer", "skill-reviewer"])
+
+        assert len(messages) == 1
+        content = messages[0].content
+        assert "analyzer" in content.lower()
+        assert "reviewer" in content.lower()
+
+    async def test_skill_instructions_empty_list(self):
+        impl = OpenAIResponsesImpl.__new__(OpenAIResponsesImpl)
+        impl.skills_api = AsyncMock()
+
+        messages = await impl._resolve_skill_instructions([])
+        assert messages == []
+
+    async def test_skill_instructions_invalid_id_raises(self):
+        api = AsyncMock()
+        api.get_skill = AsyncMock(side_effect=ValueError("Failed to find skill"))
+
+        impl = OpenAIResponsesImpl.__new__(OpenAIResponsesImpl)
+        impl.skills_api = api
+
+        with pytest.raises(ValueError, match="Failed to find skill"):
+            await impl._resolve_skill_instructions(["nonexistent-skill"])


### PR DESCRIPTION
## Summary

- Add `skills` field (`list[str] | None`) to the Responses API create request and response object
- When skills are specified, resolve each skill ID via the Skills API and inject their descriptions as system messages after user instructions
- Skills persist across multi-turn conversations: when `previous_response_id` is set without explicit skills, inherit from the previous response
- Skills is an optional dependency — servers without skills configured continue to work
- Includes demo script (`demo/skills_api_demo.py`) exercising all 11 Skills API endpoints

Closes https://github.com/ogx-ai/ogx/issues/6134

## Key design decisions

- **Optional dependency**: `Api.skills` added to `optional_api_dependencies` (not required)
- **Carry-forward**: Skills inherited from previous response via the same fetch used for input processing (no double DB round-trip)
- **Error propagation**: Invalid skill IDs raise errors instead of being silently dropped
- **Background mode**: Skills correctly passed through background response kwargs

## Test plan

- [x] `uv run pytest tests/unit/providers/responses/ -x` — 224 existing tests pass
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] Skills API demo verified against live server (all 11 endpoints)
- [ ] End-to-end test: create skill + create response with skills param + verify model output reflects skill instructions

Signed-off-by: Varsha Prasad Narsing <varshaprasad96@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)