### PR TITLE
feat(cli): remember last model used in `ogx connect opencode`

### DIFF
--- a/src/ogx/cli/connect/opencode.py
+++ b/src/ogx/cli/connect/opencode.py
@@ -15,9 +15,12 @@ from openai import APIConnectionError, APIStatusError, OpenAI
 from termcolor import cprint
 
 from ogx.cli.subcommand import Subcommand
+from ogx.core.utils.config_dirs import OGX_CONFIG_DIR
 from ogx.log import get_logger
 
 logger = get_logger(name=__name__, category="cli")
+
+_STATE_FILE = OGX_CONFIG_DIR / "connect" / "opencode.json"
 
 
 class ConnectOpenCode(Subcommand):
@@ -71,6 +74,7 @@ class ConnectOpenCode(Subcommand):
             sys.exit(1)
 
         default_model = self._select_default_model(args.model, models)
+        self._save_last_model(default_model)
 
         config = self._build_opencode_config(base_url, models, default_model)
         config_json = json.dumps(config)
@@ -119,7 +123,30 @@ class ConnectOpenCode(Subcommand):
                 sys.exit(1)
             return requested_model
 
+        last_model = self._load_last_model()
+        if last_model and last_model in available_models:
+            return last_model
+
         return available_models[0]
+
+    @staticmethod
+    def _load_last_model() -> str | None:
+        try:
+            data = json.loads(_STATE_FILE.read_text())
+            model = data.get("last_model")
+            if isinstance(model, str):
+                return model
+            return None
+        except (OSError, json.JSONDecodeError, ValueError):
+            return None
+
+    @staticmethod
+    def _save_last_model(model: str) -> None:
+        try:
+            _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+            _STATE_FILE.write_text(json.dumps({"last_model": model}))
+        except OSError:
+            logger.debug("Failed to save last model selection", model=model)
 
     def _build_opencode_config(self, base_url: str, all_models: list[str], default_model: str) -> dict:
         models_config = {

--- a/tests/unit/cli/test_connect_opencode.py
+++ b/tests/unit/cli/test_connect_opencode.py
@@ -8,6 +8,7 @@
 
 import argparse
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -134,6 +135,40 @@ class TestModelSelection:
         result = connect_opencode._select_default_model(None, ["gpt-4o", "llama-3.1-8b"])
         assert result == "gpt-4o"
 
+    def test_recalls_last_model(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "opencode.json"
+        state_file.write_text(json.dumps({"last_model": "llama-3.1-8b"}))
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            result = connect_opencode._select_default_model(None, ["gpt-4o", "llama-3.1-8b"])
+        assert result == "llama-3.1-8b"
+
+    def test_recall_ignores_unavailable_model(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "opencode.json"
+        state_file.write_text(json.dumps({"last_model": "removed-model"}))
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            result = connect_opencode._select_default_model(None, ["gpt-4o", "llama-3.1-8b"])
+        assert result == "gpt-4o"
+
+    def test_recall_handles_missing_state_file(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "nonexistent" / "opencode.json"
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            result = connect_opencode._select_default_model(None, ["gpt-4o", "llama-3.1-8b"])
+        assert result == "gpt-4o"
+
+    def test_recall_handles_corrupt_state_file(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "opencode.json"
+        state_file.write_text("not json")
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            result = connect_opencode._select_default_model(None, ["gpt-4o", "llama-3.1-8b"])
+        assert result == "gpt-4o"
+
+    def test_explicit_model_overrides_recall(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "opencode.json"
+        state_file.write_text(json.dumps({"last_model": "llama-3.1-8b"}))
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            result = connect_opencode._select_default_model("gpt-4o", ["gpt-4o", "llama-3.1-8b"])
+        assert result == "gpt-4o"
+
     def test_filters_out_embedding_models(self, connect_opencode: ConnectOpenCode) -> None:
         mock_client = _make_mock_client(
             [
@@ -194,6 +229,37 @@ class TestConfigGeneration:
         serialized = json.dumps(config)
         parsed = json.loads(serialized)
         assert parsed == config
+
+
+class TestModelRecallPersistence:
+    def test_saves_selected_model(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "connect" / "opencode.json"
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            connect_opencode._save_last_model("gpt-4o")
+        assert state_file.exists()
+        data = json.loads(state_file.read_text())
+        assert data["last_model"] == "gpt-4o"
+
+    def test_save_creates_parent_dirs(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "nested" / "dir" / "opencode.json"
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            connect_opencode._save_last_model("llama-3.1-8b")
+        assert state_file.exists()
+
+    def test_save_overwrites_previous(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "opencode.json"
+        state_file.write_text(json.dumps({"last_model": "old-model"}))
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            connect_opencode._save_last_model("new-model")
+        data = json.loads(state_file.read_text())
+        assert data["last_model"] == "new-model"
+
+    def test_roundtrip(self, connect_opencode: ConnectOpenCode, tmp_path: Path) -> None:
+        state_file = tmp_path / "opencode.json"
+        with patch("ogx.cli.connect.opencode._STATE_FILE", state_file):
+            connect_opencode._save_last_model("llama-3.1-8b")
+            result = connect_opencode._load_last_model()
+        assert result == "llama-3.1-8b"
 
 
 class TestConnect:


### PR DESCRIPTION
## Summary
- Persists the selected model to `~/.ogx/connect/opencode.json` after each `ogx connect opencode` invocation
- On subsequent runs without `--model`, the last-used model is automatically re-selected (if still available on the server)
- Falls back to the first available model when no state file exists, the file is corrupt, or the saved model is no longer served

Closes #6114

## Test plan
- [x] Unit tests cover recall of last model, fallback when model unavailable, corrupt/missing state file, explicit `--model` override, save/load roundtrip
- [x] All 31 tests pass (`uv run pytest tests/unit/cli/test_connect_opencode.py`)
- [x] Pre-commit checks pass (ruff, mypy, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)