### PR TITLE
ci: record the bedrock inference suite in record workflow

### DIFF
--- a/.github/workflows/record-integration-tests.yml
+++ b/.github/workflows/record-integration-tests.yml
@@ -207,6 +207,8 @@ jobs:
           - setup: azure
             suite: responses
           - setup: bedrock
+            suite: bedrock
+          - setup: bedrock
             suite: bedrock-responses
           - setup: watsonx
             suite: responses


### PR DESCRIPTION
## What

Adds a matrix entry to `record-integration-tests.yml` so the **`bedrock`** inference suite gets auto-recorded, alongside the existing `bedrock-responses` entry.

## Why

The replay-mode Integration Tests job `Integration Tests (library, bedrock, ..., bedrock)` was failing on a **missing recording**. The record workflow only had:

```yaml
- setup: bedrock
  suite: bedrock-responses
```

There are two distinct bedrock suites (`tests/integration/suites.py`):
- `bedrock` — inference tests (`test_openai_completion.py`)
- `bedrock-responses` — responses tests

Since the record matrix never covered the `bedrock` suite, its recordings were never generated, so replay CI hit "Recording not found".

## Change

```yaml
- setup: bedrock
  suite: bedrock
- setup: bedrock
  suite: bedrock-responses
```

## Notes

- The artifact name is keyed on `${{ matrix.provider.suite }}`, so the two bedrock entries produce distinct artifacts (`recordings-bedrock-bedrock-…` vs `recordings-bedrock-bedrock-responses-…`) — no collision.
- The companion `commit-recordings.yml` is suite-agnostic (globs any `recordings-*` artifact and copies recording dirs by path), so it picks up the new artifact with no changes.
- Bedrock is API-key gated (`AWS_BEARER_TOKEN_BEDROCK`) and only runs via `workflow_dispatch` with `providers: bedrock`; it never runs on auto `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)