### PR TITLE
fix(tests): add Bedrock replay recordings

### DIFF
--- a/tests/integration/inference/recordings/973b50bdf8aa82c68bc278c010975821949b152138a010b1eeecbadbfda9a99d.json
+++ b/tests/integration/inference/recordings/973b50bdf8aa82c68bc278c010975821949b152138a010b1eeecbadbfda9a99d.json
@@ -1,0 +1,164 @@
+{
+  "test_id": "tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming[client_with_models-txt=bedrock/openai.gpt-oss-20b-1:0-inference:chat_completion:streaming_02]",
+  "request": {
+    "method": "POST",
+    "url": "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "openai.gpt-oss-20b-1:0",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is the name of the US captial?"
+        }
+      ],
+      "stream": true
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "openai.gpt-oss-20b-1:0",
+    "provider_metadata": {
+      "openai_sdk_version": "2.30.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-b82395f96e95",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "UnJBNrOsTvQE1LAyu8uKoEuKTcvCSeYvrdw7y0TyvTNd3HKqRijyUxp4Q2UDpZbJ3JrM2BU7CA2ObSF4VzeRLxx"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-b82395f96e95",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "WDEzhQf9dYdf3vJt6hqtJMWB6cjYXeBuZ35l5o5Izg9B04LkZoiVEsb07fAWTY3WzTZo2Ru0Nmrloego"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-b82395f96e95",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>The user asks: \"What is the name of the US captial?\" likely misspelled \"capital\". The answer: Washington, D.C. Probably mention official name: Washington, D.C. (District of Columbia). The capital is Washington, D.C. Provide answer.</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "Ki8ogkPb9ii1DwonXepWHXHA1vSGgSZc"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-b82395f96e95",
+          "choices": [
+            {
+              "delta": {
+                "content": "The capital of the United States is **Washington, D.C.** (the District of Columbia).",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "0PPizw1bGDYi3WAUHjjTp02DpQ8rsvHzuBWcJyNuWpuUieQQkCP2djJdR5Nzk3Lfm4saxSTS9PqD0e0anADCUTavPYq6CEKWMMWzYcW8Pw9sI3vlSd"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-b82395f96e95",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "vyHqx8ExdlIX7h3A9SXrrD0DHyixblFinsl8bZcb8EMjs8HydST5tpIwq0P65sVfE0YQ1xirO4M2mY09F7FrokADlwWOKmscBGCIFdvvALfbbIbPn"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/inference/recordings/bc54f686d570f9fa623ba04f90c5755949e283f6de46b3bcd00306e7afa0e3bb.json
+++ b/tests/integration/inference/recordings/bc54f686d570f9fa623ba04f90c5755949e283f6de46b3bcd00306e7afa0e3bb.json
@@ -1,0 +1,812 @@
+{
+  "test_id": "tests/integration/inference/test_openai_completion.py::test_openai_chat_completion_streaming[client_with_models-txt=bedrock/openai.gpt-oss-20b-1:0-inference:chat_completion:streaming_01]",
+  "request": {
+    "method": "POST",
+    "url": "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "openai.gpt-oss-20b-1:0",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What's the name of the Sun in latin?"
+        }
+      ],
+      "stream": true
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "openai.gpt-oss-20b-1:0",
+    "provider_metadata": {
+      "openai_sdk_version": "2.30.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "MXCepKv56naD1HLVWPqnP2OKKh0H25hnYTDiot1E4L8yDe8P4T5q5v12w5Uz"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "TT61IGWB4e1OOe5GRAxBrfj0I95c92vDwgzEGprME7cHGeqqrcfSjm2S9SIEbFFaRp"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>User asks: \"What's the name of the Sun in Latin?\" Essentially asking for</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "IXFO3q5iDlChQwQyojnaO2lmslm0h9cPL"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> Latin term for Sun. That would be \"sol</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "T6QXNj8ZNkkNUHBScIsWkS7KjLJv2ropTi3vREDHEI8bSpdstQISKXbwJpoL5wwgeWgXOpNvvAF"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>\" in Latin. The Latin noun for Sun: \"sol\" (n</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "gUTCrghqlvSRD4eNcTrnIEdu5JOT4MfEWOJlj6gysXRHU2fSga4OythnNqT14"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>ominative), with genitive \"solis\". Also \"sol\" is masculine</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "PAgtuIkl5dImjDowOfyJJ3zJT09i60IUKmj00TVd6irJdrRO9cQsBINo0XhL5WAOeHAZD2K4XCb88Ed0cJ"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>, \"solere\" as a noun</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "MlEBokYHcUpRX4HUwYL5bxmTHbyewIBchamB1ZfuL36HZVjTZB06fCZgEPxi1X"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>. Also \"dies\" maybe day</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "5tunLmPLOWQMyhsBUIz0apgixs7cj8LENS8kGh6fnjlAG"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> but no. So answer: \"sol\". Provide version:</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "lA2akSXEzU7c4Y7QmtLMgrAvKbOIBj98jKAhc3HrTnIbTIWNmhVz5Hxl3OPuO70dUnl2rHm"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> \"Sol\" is the Latin name for Sun.\n\nBut</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "EJa9RlGrAMPlihiTGuRVphL9cqCR93tc9rB5yybOSHtsfhpIyCMXoWrKvXJOG4HnFjOyler1NUobg5"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> maybe they ask for \"What's the name of the Sun in Latin?\" They could</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "2wvhyNpSMsJlHlZ5Ku6Zbb9tIOTmF3BQovn73zWA1gPVuX1RyRktVaaJG3rySfdpcqlXIvUY4KFNPB2fSAmj"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> be expecting \"sol\" or \"solis\". Provide name: Sol,</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "aZRbuHK54dSR3bxlShT1SfDCD8dg8AsV8CYGHsHXCRVTmc9y"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> \"solis\".\n\nAlso good to mention in</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "EtkfGX1sai0MRc3T1JhJRbwEtAVoNL0ifmPCi"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> Latin the Sun is \"Sol\" (n</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "vFDZZN5n8RISh4ucqRb2cSFdzUfYxSzIXDnxkxgoa"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>ominative) and genitive \"solis\" (owner</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "wpyvW3zRB0yqM3l7gZAfWTXFKEjHXLlIcCS7wGC03PBG1fR4Y7q5DV9uaGc3hU61sSxd62uPn5cuHyNkam4E4TjedqtFD6wRVa5vlciNRQphe8G"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>). The symbol on astrology. Provide</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "8i7n4FD1Mb3lGzGZ79CtCgi7QwzJkaEa58YdFRGJZ8JrOsmOGYSJNqUmhQ"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> details of Latin usage.\n\nAlso discuss that Latin</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "GciUGa29hnkfxEAbZ6UXfz24rIcLP9nYQ8xt0uH0J7yNd54DbacOSBySmliB9yWGYCFQeh"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> for Sun used as \"Sol\"</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "bfy7OVK3Za4Eg7php2dhiMyxWL8ybTLQgqsvmxZ7P3j3soCILzkqx0As3ARS5GsUODwVFPvBLQuy9"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> in name of solar deity in Roman mythology. So</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "AAIGtusb7gZ7M5GuXUR2g7ATlL7EIqSdFXKKAvPKuVrnEVdfcHACqCpiZ2D0RI7P9f3seGScPe7OkybzIex5I0MuQoPrPwp8qoOVGvo7sIaW"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> answer: \"Sol\".\n\nAlso mention that in common Latin literature: \"sol</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "UJa2hAJJNLCS5CfqRVlovFWh78zV9OC07lAhrokkh9c17Z3zmRwZYZ1YIVse9dBQ"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>\" used as \"sol\" means sun</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "uLj7SzTlVxIkkEvTCVqiXvX0SMuSNC1XwgVBu2xL9hZ"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>.\n\nThus answer: The Latin word for sun is \"</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "0BqOycmFO7l1U3AbrndvZEbByM5keWsLj6r2wA6BVsSqDK0q0JsPYKB3qO0ohzi1TsUiZXQvYKjpLMARtpddSI2rTNdQbsfN5zlN4Ft3nvnG9t3WaqU4"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning>sol\". Provide some usage context.\n\nWill output</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "oREIhNGZat4p6yLRKgIdI2moThWKukZga0jv3867ZBDNapZmEif3yc73Xena9EPElnsPdXpP6UhBVFpj3mwox7Vrr5RdQQtIX"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "<reasoning> as direct answer.\n\nOk.</reasoning>",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "Xp9UFVymQyVjIdNnQxw8T9vM1nfVmNhga6aaiDLjpA62J4fV4Cy3MoHKG"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "In",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "7CS5EEJxq97y94MRJnf1TiG6BoSlqjv6G6WagG5lYQGTEz749WU361MuDVMUBM6vZ4LiqsWfsrbXlrEARyI8"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": " Latin the Sun is called **Sol** (nominative).  \nThe genitive form is **solis",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "fVNwqenIbJQy6m3VP7Qm7YmJPaZM0hOeQfqHPCYYJIivcok5SVKDbuKyXninmhMAkMHypKn"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": "** (e.g., *lux solis* \u2013 \u201clight",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "BhH8xFcJ6ZmRYJqL3hwmpf6VFE6cZakHKMl0gP0nue2fBDvRy7vSCXT14ayO7qcO5s5DsJIEQ6ohPINTR15xNmhnLIriD4auIWWkP3cGr0686I7iM"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": " of the Sun\u201d).  \nSo when you need to",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "ciUlQnZSZDB2pV9arXtfuy4bJC9VuZKcRcc33zdrP2V6b0NeuoiDgACMUrtML2USznsOrftWq0e2Sa4XeCci2SuqpfhdkH"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-624b41ef0112",
+          "choices": [
+            {
+              "delta": {
+                "content": " refer to the Sun in Latin, use **Sol**.",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null,
+              "obfuscation": "rUfOzXHUPo3iVrOKJgjo0AZauDJmbrSFUaCUM31mkKJJZ3w6Z"
+            }
+          ],
+          "created": 0,
+          "model": "openai.gpt-oss-20b-1:0",
+          "object": "chat.completion.chunk",
+          "service_tier": "default",
+          "system_fingerprint": null,
+          "usage": null
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}


### PR DESCRIPTION
## Summary
- add replay recordings for the two Bedrock streaming chat-completion hashes introduced after the ogx_open_client switch
- fixes the missing-recording failures from PR #6016 without changing runtime behavior

## Test Plan
- env AWS_BEDROCK_BEARER_TOKEN=replay-mode-dummy-key AWS_DEFAULT_REGION=us-west-2 uv run --no-sync ./scripts/integration-tests.sh --stack-config ci-tests --setup bedrock --suite bedrock --inference-mode replay
- Result: 6 passed, 6 skipped