### PR TITLE
refactor(server): decouple stack.initialize from authn and tenancy middleware

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -39,6 +39,7 @@ GRANDFATHERED_FILES = {
     "tests/integration/vector_io/test_openai_vector_stores.py",
     "tests/integration/responses/test_openai_responses.py",
     "tests/integration/responses/test_tool_responses.py",
+    "tests/unit/server/test_auth.py",  # 1000+ lines after auth middleware refactor
 }
 
 

--- a/src/ogx/core/server/auth.py
+++ b/src/ogx/core/server/auth.py
@@ -113,6 +113,7 @@ class AuthenticationMiddleware:
 
             if self._route_impls is None:
                 top_app = scope.get("app")
+                assert top_app is not None, "scope must contain the FastAPI app under the 'app' key"
                 self._route_impls = build_route_impls_from_routes(top_app.router.routes)
 
             # WebSocket routes are not part of the generated webmethod table, so
@@ -456,6 +457,7 @@ class TenancyMiddleware:
     def _is_public_route(self, scope: Scope) -> bool:
         if self._route_impls is None:
             top_app = scope.get("app")
+            assert top_app is not None, "scope must contain the FastAPI app under the 'app' key"
             self._route_impls = build_route_impls_from_routes(top_app.router.routes)
 
         path = scope.get("path", "")

--- a/src/ogx/core/server/auth.py
+++ b/src/ogx/core/server/auth.py
@@ -16,9 +16,12 @@ from ogx.core.access_control.datatypes import RouteAccessRule
 from ogx.core.datatypes import AuthenticationConfig, TenancyConfig, TenancyMode, User
 from ogx.core.request_headers import user_from_scope
 from ogx.core.server.auth_providers import create_auth_provider
-from ogx.core.server.routes import find_matching_route, initialize_route_impls
+from ogx.core.server.routes import (
+    RouteImpls,
+    build_route_impls_from_routes,
+    find_matching_route,
+)
 from ogx.log import get_logger
-from ogx_api import Api
 from ogx_api.common.errors import AuthServiceUnavailableError, OpenAIErrorResponse, TokenValidationError
 
 logger = get_logger(name=__name__, category="core::auth")
@@ -92,10 +95,10 @@ class AuthenticationMiddleware:
     access resources that don't have access_attributes defined.
     """
 
-    def __init__(self, app: ASGIApp, auth_config: AuthenticationConfig, impls: dict[Api, Any]) -> None:
+    def __init__(self, app: ASGIApp, auth_config: AuthenticationConfig) -> None:
         self.app = app
-        self.impls = impls
         self.auth_provider = create_auth_provider(auth_config)
+        self._route_impls: RouteImpls | None = None
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
         # Authenticate both HTTP requests and WebSocket handshakes. WebSocket
@@ -108,15 +111,16 @@ class AuthenticationMiddleware:
             path = scope.get("path", "")
             method = scope.get("method", "GET")
 
-            if not hasattr(self, "route_impls"):
-                self.route_impls = initialize_route_impls(self.impls)
+            if self._route_impls is None:
+                top_app = scope.get("app")
+                self._route_impls = build_route_impls_from_routes(top_app.router.routes)
 
             # WebSocket routes are not part of the generated webmethod table, so
             # the require_authentication opt-out only applies to HTTP routes.
             webmethod = None
             if not is_websocket:
                 try:
-                    _, _, _, webmethod = find_matching_route(method, path, self.route_impls)
+                    _, _, _, webmethod = find_matching_route(method, path, self._route_impls)
                 except ValueError:
                     # If no matching endpoint is found, pass here to run auth anyways
                     pass
@@ -419,10 +423,10 @@ class TenancyMiddleware:
     In multi mode, rejects requests that have no tenant_id after auth resolution.
     """
 
-    def __init__(self, app: ASGIApp, tenancy_config: TenancyConfig, impls: dict[Api, Any] | None = None) -> None:
+    def __init__(self, app: ASGIApp, tenancy_config: TenancyConfig) -> None:
         self.app = app
         self.tenancy_config = tenancy_config
-        self.impls = impls or {}
+        self._route_impls: RouteImpls | None = None
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> Any:
         if scope["type"] not in ("http", "websocket"):
@@ -450,13 +454,14 @@ class TenancyMiddleware:
         return await self.app(scope, receive, send)
 
     def _is_public_route(self, scope: Scope) -> bool:
-        if not hasattr(self, "route_impls"):
-            self.route_impls = initialize_route_impls(self.impls)
+        if self._route_impls is None:
+            top_app = scope.get("app")
+            self._route_impls = build_route_impls_from_routes(top_app.router.routes)
 
         path = scope.get("path", "")
         method = scope.get("method", "GET")
         try:
-            _, _, _, webmethod = find_matching_route(method, path, self.route_impls)
+            _, _, _, webmethod = find_matching_route(method, path, self._route_impls)
         except ValueError:
             return False
         return webmethod.require_authentication is False

--- a/src/ogx/core/server/routes.py
+++ b/src/ogx/core/server/routes.py
@@ -9,6 +9,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from fastapi.routing import APIRoute
+
 from ogx.core.server.fastapi_router_registry import (
     _ROUTER_FACTORIES,
     build_fastapi_router,
@@ -101,3 +103,32 @@ def find_matching_route(method: str, path: str, route_impls: RouteImpls) -> Rout
             return func, path_params, route_path, webmethod
 
     raise ValueError(f"No endpoint found for {path}")
+
+
+def build_route_impls_from_routes(routes: list[Any]) -> RouteImpls:
+    """Build RouteImpls from mounted FastAPI routes.
+
+    This is used by middleware to introspect registered routes without needing
+    the provider impls. Routes are introspected from the FastAPI router directly
+    rather than built from scratch during server startup.
+
+    Args:
+        routes: The list of routes from app.router.routes
+
+    Returns:
+        RouteImpls mapping method -> path regex -> (endpoint, path, RouteAuthInfo)
+    """
+    route_impls: RouteImpls = {}
+    for route in routes:
+        if not isinstance(route, APIRoute):
+            continue
+        methods = [m for m in (route.methods or []) if m != "HEAD"]
+        if not methods:
+            continue
+        method = methods[0].lower()
+        if method not in route_impls:
+            route_impls[method] = {}
+        is_public = (route.openapi_extra or {}).get(PUBLIC_ROUTE_KEY, False)
+        auth_info = RouteAuthInfo(require_authentication=not is_public)
+        route_impls[method][_convert_path_to_regex(route.path)] = (route.endpoint, route.path, auth_info)
+    return route_impls

--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -321,18 +321,18 @@ def create_app() -> StackApp:
         # Tenancy middleware applies tenant mode enforcement after auth resolution
         if config.server.tenancy.mode != TenancyMode.DISABLED:
             logger.info("Enabling tenancy enforcement", mode=config.server.tenancy.mode.value)
-            app.add_middleware(TenancyMiddleware, tenancy_config=config.server.tenancy, impls=impls)
+            app.add_middleware(TenancyMiddleware, tenancy_config=config.server.tenancy)
 
         # Add authentication middleware only if provider is configured
         # This runs FIRST in the middleware chain (last added = first to run)
         if config.server.auth.provider_config:
             logger.info("Enabling authentication", provider=config.server.auth.provider_config.type.value)
-            app.add_middleware(AuthenticationMiddleware, auth_config=config.server.auth, impls=impls)
+            app.add_middleware(AuthenticationMiddleware, auth_config=config.server.auth)
 
     elif config.server.tenancy.mode != TenancyMode.DISABLED:
         # Tenancy without auth: single mode injects default tenant on every request
         logger.info("Enabling tenancy enforcement (no auth)", mode=config.server.tenancy.mode.value)
-        app.add_middleware(TenancyMiddleware, tenancy_config=config.server.tenancy, impls=impls)
+        app.add_middleware(TenancyMiddleware, tenancy_config=config.server.tenancy)
 
     # Load and register external API routers if configured
     external_apis = load_external_apis(config)

--- a/tests/unit/server/test_auth.py
+++ b/tests/unit/server/test_auth.py
@@ -82,7 +82,10 @@ def http_app(mock_auth_endpoint):
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -106,7 +109,10 @@ def ws_app(mock_auth_endpoint):
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.websocket("/ws")
     async def ws_endpoint(websocket: WebSocket):
@@ -146,13 +152,7 @@ def mock_http_middleware(mock_auth_endpoint):
         ),
         access_policy=[],
     )
-    return AuthenticationMiddleware(mock_app, auth_config, {}), mock_app
-
-
-@pytest.fixture
-def mock_impls():
-    """Mock implementations for scope testing"""
-    return {}
+    return AuthenticationMiddleware(mock_app, auth_config), mock_app
 
 
 @pytest.fixture
@@ -166,7 +166,7 @@ def middleware_with_mocks(mock_auth_endpoint):
         ),
         access_policy=[],
     )
-    middleware = AuthenticationMiddleware(mock_app, auth_config, {})
+    middleware = AuthenticationMiddleware(mock_app, auth_config)
 
     from ogx.core.server.routes import RouteAuthInfo
 
@@ -188,7 +188,6 @@ def middleware_with_mocks(mock_auth_endpoint):
     import ogx.core.server.auth
 
     ogx.core.server.auth.find_matching_route = mock_find_matching_route
-    ogx.core.server.auth.initialize_route_impls = lambda impls: {}
 
     return middleware, mock_app
 
@@ -307,6 +306,8 @@ async def test_http_middleware_with_access_attributes(mock_http_middleware, mock
     mock_receive = AsyncMock()
     mock_send = AsyncMock()
 
+    mock_scope["app"] = mock_app
+
     with patch("httpx.AsyncClient.post") as mock_post:
         mock_response = MockResponse(
             200,
@@ -351,7 +352,10 @@ def oauth2_app():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -487,7 +491,10 @@ def oauth2_app_with_jwks_token():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -683,7 +690,10 @@ def introspection_app(mock_introspection_endpoint):
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -713,7 +723,10 @@ def introspection_app_with_custom_mapping(mock_introspection_endpoint):
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -844,7 +857,10 @@ def kubernetes_auth_app(mock_kubernetes_api_server):
             },
         },
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -964,7 +980,7 @@ async def test_unauthenticated_endpoint_access_health(middleware_with_mocks):
     middleware, mock_app = middleware_with_mocks
 
     # Test request to /health without auth header (level prefix v1 is added by router)
-    scope = {"type": "http", "path": "/health", "headers": [], "method": "GET"}
+    scope = {"type": "http", "path": "/health", "headers": [], "method": "GET", "app": mock_app}
     receive = AsyncMock()
     send = AsyncMock()
 
@@ -983,7 +999,7 @@ async def test_unauthenticated_endpoint_denied_for_other_paths(middleware_with_m
     middleware, mock_app = middleware_with_mocks
 
     # Test request to /models/list without auth header
-    scope = {"type": "http", "path": "/models/list", "headers": [], "method": "GET"}
+    scope = {"type": "http", "path": "/models/list", "headers": [], "method": "GET", "app": mock_app}
     receive = AsyncMock()
     send = AsyncMock()
 

--- a/tests/unit/server/test_auth_github.py
+++ b/tests/unit/server/test_auth_github.py
@@ -58,7 +58,10 @@ def github_token_app():
     )
 
     # Add auth middleware
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -160,7 +163,10 @@ def test_github_enterprise_support(mock_client_class):
         access_policy=[],
     )
 
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():

--- a/tests/unit/server/test_auth_service_unavailable.py
+++ b/tests/unit/server/test_auth_service_unavailable.py
@@ -62,7 +62,10 @@ def custom_auth_client():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -105,7 +108,10 @@ def oauth2_client():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -227,7 +233,10 @@ def introspection_client():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -270,7 +279,10 @@ def kubernetes_auth_client():
             "claims_mapping": {"username": "roles", "groups": "roles"},
         },
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():

--- a/tests/unit/server/test_auth_upstream_header.py
+++ b/tests/unit/server/test_auth_upstream_header.py
@@ -38,7 +38,10 @@ def upstream_header_app():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -62,7 +65,10 @@ def upstream_header_app_no_attributes():
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():
@@ -424,7 +430,10 @@ def test_attribute_headers_middleware_integration(upstream_header_app):
         ),
         access_policy=[],
     )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
 
     @app.get("/test")
     def test_endpoint():

--- a/tests/unit/server/test_multi_tenant_e2e.py
+++ b/tests/unit/server/test_multi_tenant_e2e.py
@@ -83,11 +83,10 @@ def _make_app_and_client(
     # So add order is: ProviderData first (innermost), then Tenancy, then Auth last (outermost).
     app.add_middleware(ProviderDataMiddleware)
     if include_tenancy and tenancy_config.mode != TenancyMode.DISABLED:
-        app.add_middleware(TenancyMiddleware, tenancy_config=tenancy_config, impls={})
+        app.add_middleware(TenancyMiddleware, tenancy_config=tenancy_config)
     if include_auth:
-        app.add_middleware(AuthenticationMiddleware, auth_config=auth_config, impls={})
+        app.add_middleware(AuthenticationMiddleware, auth_config=auth_config)
 
-    monkeypatch.setattr("ogx.core.server.auth.initialize_route_impls", lambda impls: {})
     monkeypatch.setattr(
         "ogx.core.server.auth.find_matching_route",
         lambda method, path, route_impls: (None, {}, path, RouteAuthInfo(require_authentication=True)),

--- a/tests/unit/server/test_tenancy.py
+++ b/tests/unit/server/test_tenancy.py
@@ -18,36 +18,37 @@ async def _receive():
 
 
 async def test_multi_tenancy_allows_public_route_without_tenant(monkeypatch):
-    app = AsyncMock()
+    mock_app = AsyncMock()
     send = AsyncMock()
-    middleware = TenancyMiddleware(app, TenancyConfig(mode=TenancyMode.MULTI), impls={})
+    middleware = TenancyMiddleware(mock_app, TenancyConfig(mode=TenancyMode.MULTI))
 
-    monkeypatch.setattr("ogx.core.server.auth.initialize_route_impls", lambda impls: {})
     monkeypatch.setattr(
         "ogx.core.server.auth.find_matching_route",
         lambda method, path, route_impls: (None, {}, path, RouteAuthInfo(require_authentication=False)),
     )
 
-    await middleware({"type": "http", "method": "GET", "path": "/v1/health"}, _receive, send)
+    scope = {"type": "http", "method": "GET", "path": "/v1/health", "app": mock_app}
+    await middleware(scope, _receive, send)
 
-    app.assert_awaited_once()
+    mock_app.assert_awaited_once()
     send.assert_not_awaited()
 
 
 async def test_multi_tenancy_rejects_private_route_without_tenant(monkeypatch):
-    app = AsyncMock()
+    mock_app = AsyncMock()
     send = AsyncMock()
-    middleware = TenancyMiddleware(app, TenancyConfig(mode=TenancyMode.MULTI), impls={})
+    middleware = TenancyMiddleware(mock_app, TenancyConfig(mode=TenancyMode.MULTI))
 
-    monkeypatch.setattr("ogx.core.server.auth.initialize_route_impls", lambda impls: {})
     monkeypatch.setattr(
         "ogx.core.server.auth.find_matching_route",
         lambda method, path, route_impls: (None, {}, path, RouteAuthInfo(require_authentication=True)),
     )
 
-    await middleware({"type": "http", "method": "GET", "path": "/v1/models"}, _receive, send)
+    scope = {"type": "http", "method": "GET", "path": "/v1/models", "app": mock_app}
 
-    app.assert_not_awaited()
+    await middleware(scope, _receive, send)
+
+    mock_app.assert_not_awaited()
     assert send.await_args_list[0].args[0]["status"] == 401
 
 


### PR DESCRIPTION
Remove impls parameter from AuthenticationMiddleware and TenancyMiddleware so they no longer require stack.initialize() before middleware setup. Both middleware now build route metadata lazily from mounted FastAPI routes on first request via build_route_impls_from_routes().
