### PR TITLE
fix(tests): allow slower Bedrock chat completion recordings

### DIFF
--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -8,6 +8,7 @@
 import time
 
 import pytest
+from openai import OpenAI
 from pydantic import BaseModel
 
 from ..helpers import assert_text_contains
@@ -247,6 +248,7 @@ def test_openai_chat_completion_non_streaming(compat_client, client_with_models,
     question = tc["question"]
     expected = tc["expected"]
 
+    request_options = {"timeout": 120} if isinstance(compat_client, OpenAI) else {}
     response = compat_client.chat.completions.create(
         model=text_model_id,
         messages=[
@@ -256,6 +258,7 @@ def test_openai_chat_completion_non_streaming(compat_client, client_with_models,
             }
         ],
         stream=False,
+        **request_options,
     )
     message_content = response.choices[0].message.content
     assert len(message_content) > 0


### PR DESCRIPTION
## Summary
Bedrock GPT-OSS can take longer than the OpenAI SDK's 30s default on the first live non-streaming chat completion. The OpenAI SDK path now gets the same 120s timeout we already use for the adjacent streaming and reasoning chat-completion tests.

The timeout is only applied when the compat client is the OpenAI SDK client, so the generated ogx_open_client path does not get a new request field or recording hash change.

## Test plan

```bash
uv run pytest tests/integration/inference/test_openai_completion.py --stack-config=server:ci-tests --setup=bedrock --suite=bedrock --inference-mode=replay --collect-only -q
```

Output: 33 tests collected.

```bash
uv run ruff check tests/integration/inference/test_openai_completion.py
```

Output: All checks passed.

```bash
AWS_BEDROCK_BEARER_TOKEN=... AWS_BEARER_TOKEN_BEDROCK=... AWS_DEFAULT_REGION=us-west-2 \
  uv run --no-sync ./scripts/integration-tests.sh \
  --stack-config server:ci-tests \
  --setup bedrock \
  --suite bedrock \
  --inference-mode record-if-missing
```

Output: 12 passed, 7 warnings. This is the local OGX server path that mirrors the Bedrock record workflow's integration-test wrapper.

Also validated the same west-2 token directly against Bedrock's OpenAI-compatible endpoint outside OGX; non-streaming and streaming both succeeded.

## Breaking changes
None.