### PR TITLE
chore: update ogx-client to ^1.1.3 in UI lockfile

### DIFF
--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -26,7 +26,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.1.2",
+        "ogx-client": "^1.1.3",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.2.tgz",
-      "integrity": "sha512-lntdB9vyJQ3CXXc0v2RdkVm4Q7kkC4HVUY2Pv49IDS+YWIJl9xxtMLOZbsitSs/09hBx/cm9pMrNfyJwI92ggA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.1.3.tgz",
+      "integrity": "sha512-rUfmtKA5MWNbfoO+oL/rSWl7CNJEo4C5Lm84WX/Gr3JQuC7booG8++5ao6zMoler0rZUYzlT8aSB4U3KFe2m5Q==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -50,7 +50,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.1.2",
+    "ogx-client": "^1.1.3",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4256,7 +4256,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.2" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.1.3" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "opentelemetry-distro", specifier = ">=0.60b1" },
@@ -4324,7 +4324,7 @@ dev = [
     { name = "moto", extras = ["s3"], specifier = ">=5.1.10" },
     { name = "mypy" },
     { name = "nbval" },
-    { name = "ogx-client", specifier = "==1.1.2" },
+    { name = "ogx-client", specifier = "==1.1.3" },
     { name = "ollama" },
     { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
@@ -4417,7 +4417,7 @@ type-checking = [
     { name = "markitdown", extras = ["all"] },
     { name = "mcp", specifier = ">=1.23.0,<2.0" },
     { name = "nest-asyncio" },
-    { name = "ogx-client", specifier = "==1.1.2" },
+    { name = "ogx-client", specifier = "==1.1.3" },
     { name = "ollama" },
     { name = "pandas" },
     { name = "pandas-stubs" },
@@ -4485,7 +4485,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.1.2"
+version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4504,9 +4504,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/15/5f02de6eba355443a5687abfc8474beec4ac0aae3357629dc889547f62cb/ogx_client-1.1.2.tar.gz", hash = "sha256:2bb2e7d9100e6332d45dc003777027f9a2f7e9ec82d77cfa6c08ccb670172657", size = 440847, upload-time = "2026-06-17T14:11:44.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ac/2fd77ab57ef26b8689d29d3f0a2e9020966282797b715ecf537806ca3486/ogx_client-1.1.3.tar.gz", hash = "sha256:d61a6f4cd996a5ce5cd6eb1389215f520cc1ca49d485b454d00faa021d4f4f0a", size = 440850, upload-time = "2026-06-24T15:07:27.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/c17e5520c0fc282b4b1654bdd5432c7c5e393ce1c5a5b305b34e5ce3ea14/ogx_client-1.1.2-py3-none-any.whl", hash = "sha256:c8b0a0657231da8151ed7267261d3dd7713482ef7d19d97adc13bb42ca25a5da", size = 314013, upload-time = "2026-06-17T14:11:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f0/be21078666dc51b30a92dcd83e7711f923230b2cdd4a274994c36059233d/ogx_client-1.1.3-py3-none-any.whl", hash = "sha256:56390f857807f99c1927ab2de46d3427d63970d55533945c92e575fbe51d2252", size = 314011, upload-time = "2026-06-24T15:07:25.85Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release npm lockfile update after v1.1.3.

Updates ogx-client to ^1.1.3 in the UI package lockfile.

This PR was created automatically by the post-release workflow.