### PR TITLE
fix(file_processors): allow owner-encrypted PDFs in pypdf processor

### DIFF
--- a/src/ogx/providers/inline/file_processor/pypdf/pypdf.py
+++ b/src/ogx/providers/inline/file_processor/pypdf/pypdf.py
@@ -103,7 +103,10 @@ class PyPDFFileProcessor:
         reader = PdfReader(pdf_bytes)
 
         if reader.is_encrypted:
-            raise HTTPException(status_code=422, detail="Password-protected PDFs are not supported")
+            try:
+                reader.decrypt("")
+            except Exception:
+                raise HTTPException(status_code=422, detail="Password-protected PDFs are not supported") from None
 
         text_content, failed_pages = self._extract_pdf_text(reader)
 

--- a/src/ogx/providers/inline/file_processor/pypdf/pypdf.py
+++ b/src/ogx/providers/inline/file_processor/pypdf/pypdf.py
@@ -104,7 +104,10 @@ class PyPDFFileProcessor:
 
         if reader.is_encrypted:
             try:
-                reader.decrypt("")
+                if not reader.decrypt(""):
+                    raise HTTPException(status_code=422, detail="Password-protected PDFs are not supported")
+            except HTTPException:
+                raise
             except Exception:
                 raise HTTPException(status_code=422, detail="Password-protected PDFs are not supported") from None
 

--- a/tests/unit/providers/file_processor/test_pypdf_validation.py
+++ b/tests/unit/providers/file_processor/test_pypdf_validation.py
@@ -96,7 +96,23 @@ async def test_rejects_password_protected_pdf(pypdf_processor):
 
     mock_reader = MagicMock(spec=PdfReader)
     mock_reader.is_encrypted = True
-    mock_reader.decrypt.side_effect = Exception("password required")
+    mock_reader.decrypt.return_value = 0
+
+    with patch("ogx.providers.inline.file_processor.pypdf.pypdf.PdfReader", return_value=mock_reader):
+        with pytest.raises(HTTPException) as exc_info:
+            await pypdf_processor.process_file(file=file)
+
+    assert exc_info.value.status_code == 422
+    assert "Password-protected" in exc_info.value.detail
+
+
+async def test_rejects_corrupted_encrypted_pdf(pypdf_processor):
+    pdf_bytes = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\nxref\n0 3\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \ntrailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n115\n%%EOF"
+    file = UploadFile(filename="corrupted.pdf", file=io.BytesIO(pdf_bytes))
+
+    mock_reader = MagicMock(spec=PdfReader)
+    mock_reader.is_encrypted = True
+    mock_reader.decrypt.side_effect = Exception("corrupted encryption metadata")
 
     with patch("ogx.providers.inline.file_processor.pypdf.pypdf.PdfReader", return_value=mock_reader):
         with pytest.raises(HTTPException) as exc_info:
@@ -115,7 +131,7 @@ async def test_allows_owner_encrypted_pdf(pypdf_processor):
 
     mock_reader = MagicMock(spec=PdfReader)
     mock_reader.is_encrypted = True
-    mock_reader.decrypt.return_value = 1
+    mock_reader.decrypt.return_value = 2
     mock_reader.pages = [mock_page]
     mock_reader.metadata = None
 

--- a/tests/unit/providers/file_processor/test_pypdf_validation.py
+++ b/tests/unit/providers/file_processor/test_pypdf_validation.py
@@ -5,10 +5,11 @@
 # the root directory of this source tree.
 
 import io
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException, UploadFile
+from pypdf import PdfReader
 
 from ogx.providers.inline.file_processor.pypdf.config import PyPDFFileProcessorConfig
 from ogx.providers.inline.file_processor.pypdf.pypdf import PyPDFFileProcessor
@@ -85,5 +86,41 @@ async def test_allows_markdown_files(pypdf_processor):
     file = UploadFile(filename="README.md", file=io.BytesIO(md_bytes))
 
     result = await pypdf_processor.process_file(file=file)
+    assert result is not None
+    assert len(result.chunks) >= 1
+
+
+async def test_rejects_password_protected_pdf(pypdf_processor):
+    pdf_bytes = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\nxref\n0 3\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \ntrailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n115\n%%EOF"
+    file = UploadFile(filename="secret.pdf", file=io.BytesIO(pdf_bytes))
+
+    mock_reader = MagicMock(spec=PdfReader)
+    mock_reader.is_encrypted = True
+    mock_reader.decrypt.side_effect = Exception("password required")
+
+    with patch("ogx.providers.inline.file_processor.pypdf.pypdf.PdfReader", return_value=mock_reader):
+        with pytest.raises(HTTPException) as exc_info:
+            await pypdf_processor.process_file(file=file)
+
+    assert exc_info.value.status_code == 422
+    assert "Password-protected" in exc_info.value.detail
+
+
+async def test_allows_owner_encrypted_pdf(pypdf_processor):
+    pdf_bytes = b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\nxref\n0 3\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \ntrailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n115\n%%EOF"
+    file = UploadFile(filename="ibm-earnings.pdf", file=io.BytesIO(pdf_bytes))
+
+    mock_page = MagicMock()
+    mock_page.extract_text.return_value = "IBM quarterly earnings results"
+
+    mock_reader = MagicMock(spec=PdfReader)
+    mock_reader.is_encrypted = True
+    mock_reader.decrypt.return_value = 1
+    mock_reader.pages = [mock_page]
+    mock_reader.metadata = None
+
+    with patch("ogx.providers.inline.file_processor.pypdf.pypdf.PdfReader", return_value=mock_reader):
+        result = await pypdf_processor.process_file(file=file)
+
     assert result is not None
     assert len(result.chunks) >= 1


### PR DESCRIPTION
## Summary

The `is_encrypted` check in the pypdf file processor rejects all PDFs with any encryption metadata, including owner-encrypted documents that require no password to read. Many corporate PDFs (SEC filings, earnings press releases) use owner encryption to restrict printing/copying while keeping content freely readable.

This PR attempts `reader.decrypt("")` and checks the return value — this succeeds for owner-encrypted PDFs (`PasswordType.OWNER_PASSWORD = 2`) and returns `PasswordType.NOT_DECRYPTED = 0` for truly password-protected ones.

### Why check the return value (not just catch exceptions)

`pypdf`'s `decrypt()` uses a return-code pattern, not exceptions:

| `decrypt("")` result | `PasswordType` | int | bool | Meaning |
|---|---|---|---|---|
| Owner-encrypted (no user password) | `OWNER_PASSWORD` | `2` | `True` | Readable — allow |
| User password matches `""` | `USER_PASSWORD` | `1` | `True` | Readable — allow |
| Wrong password | `NOT_DECRYPTED` | `0` | `False` | Cannot read — reject 422 |
| Corrupted encryption metadata | raises `Exception` | — | — | Cannot read — reject 422 |

## Test Plan

```bash
uv run pytest tests/unit/providers/file_processor/test_pypdf_validation.py -v
```

### Condition coverage

Three new tests cover every branch of the `if reader.is_encrypted` block:

| Test | `decrypt("")` behavior | Expected | Verified against unfixed code |
|---|---|---|---|
| `test_rejects_password_protected_pdf` | returns `0` (`NOT_DECRYPTED`) | 422 | FAILS without fix (falls through) |
| `test_rejects_corrupted_encrypted_pdf` | raises `Exception` | 422 | passes (caught by `except`) |
| `test_allows_owner_encrypted_pdf` | returns `2` (`OWNER_PASSWORD`) | processes normally | passes (decrypt succeeds) |

```
tests/unit/providers/file_processor/test_pypdf_validation.py::test_rejects_docx_with_422 PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_rejects_pptx_with_422 PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_rejects_xlsx_with_422 PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_allows_pdf PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_allows_text_files PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_allows_csv_files PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_allows_markdown_files PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_rejects_password_protected_pdf PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_rejects_corrupted_encrypted_pdf PASSED
tests/unit/providers/file_processor/test_pypdf_validation.py::test_allows_owner_encrypted_pdf PASSED
10 passed
```

Fixes #6181

Signed-off-by: Artemy Hladenko <ahladenk@redhat.com>