### PR TITLE
fix(deps): bump urllib3 and python-dotenv constraints for multiple CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ constraint-dependencies = [
     "setuptools<81",                   # milvus-lite imports pkg_resources; setuptools 81+ removes it
     "starlette>=1.3.1",                # CVE-2026-48710
     "tornado>=6.5.5",
-    "urllib3>=2.7.0",
+    "urllib3>=2.7.0",                  # CVE-2026-44432: DoS via excessive decompression; CVE-2026-44431: cross-origin redirect header leak
     "transformers>=4.57.2,<5.0.0",     # CVE-2026-1839 fix only in 5.x; ogx doesn't use Trainer; 5.x breaks HybridCache imports
     "werkzeug>=3.1.6",                 # CVE-2025-66221 + 2 more: safe_join() device name bypass
 ]
@@ -56,7 +56,7 @@ dependencies = [
     "jsonschema",
     "ogx-api",                                # API and provider specifications (local dev via tool.uv.sources)
     "openai>=2.41.0",
-    "python-dotenv",
+    "python-dotenv>=1.2.2",                              # CVE-2026-28684: arbitrary file overwrite via symlink following
     "pyjwt[crypto]>=2.13.0",                          # Pull crypto to support RS256 for jwt. Requires 2.12.0+ to fix CVE-2026-32597.
     "pydantic>=2.11.9",
     "rich",

--- a/uv.lock
+++ b/uv.lock
@@ -4275,7 +4275,7 @@ requires-dist = [
     { name = "pymongo", marker = "extra == 'starter'" },
     { name = "pypdf", marker = "extra == 'starter'", specifier = ">=6.13.0" },
     { name = "pythainlp", marker = "extra == 'starter'" },
-    { name = "python-dotenv" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'starter'" },
     { name = "redis", marker = "extra == 'starter'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary

Add CVE reference comments and bump minimum version constraints for urllib3 and python-dotenv:

| Package | Old Constraint | New Constraint | CVE(s) |
|---|---|---|---|
| `urllib3` | `>=2.7.0` (no comment) | `>=2.7.0` (comment added) | CVE-2026-44432: DoS via excessive decompression; CVE-2026-44431: cross-origin redirect header leak |
| `python-dotenv` | (none) | `>=1.2.2` | CVE-2026-28684: arbitrary file overwrite via symlink following |

### Impact analysis

- **urllib3**: Already at the fixed version (`>=2.7.0`). This change only adds CVE reference comments for traceability.
- **python-dotenv**: Only `load_dotenv()` is used in the codebase. Vulnerable functions `set_key()`/`unset_key()` are never called. Bump is defensive.

## Test plan

- [x] `uv run pre-commit run --all-files` — all checks passed
- [x] `uv run pytest tests/unit/ -x --tb=short` — 2576 passed, 0 failed
- [ ] Verify updated package versions resolve in clean install