### PR TITLE
fix: require replay checks in ci status gate

### DIFF
--- a/.github/workflows/ci-status.yml
+++ b/.github/workflows/ci-status.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 180
     permissions:
       checks: read
+      pull-requests: read
     steps:
       - name: Wait for CI checks to complete
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -43,11 +44,39 @@ jobs:
             const excludedApps = new Set(['mergify']);
 
             const terminalStatuses = new Set(['completed']);
-            const successConclusions = new Set(['success', 'skipped', 'neutral', 'cancelled']);
-            const failureConclusions = new Set(['failure', 'timed_out']);
+            const successConclusions = new Set(['success', 'skipped', 'neutral']);
+            const failureConclusions = new Set(['failure', 'timed_out', 'cancelled', 'action_required', 'startup_failure', 'stale']);
+            const replayCheckPrefix = 'Integration Tests (';
+            const recordCheckPrefix = 'record-providers (';
+
+            function pathTriggersReplay(path) {
+              if (path.startsWith('src/ogx_ui/')) return false;
+              return path.startsWith('src/ogx/') ||
+                path.startsWith('tests/') ||
+                path === 'uv.lock' ||
+                path === 'pyproject.toml' ||
+                path === '.github/workflows/integration-tests.yml' ||
+                path === '.github/actions/setup-ollama/action.yml' ||
+                path === '.github/actions/setup-test-environment/action.yml' ||
+                path === '.github/actions/run-and-record-tests/action.yml' ||
+                path === 'scripts/integration-tests.sh' ||
+                path === 'scripts/generate_ci_matrix.py';
+            }
+
+            let replayRequired = context.eventName === 'merge_group';
+            if (context.payload.pull_request) {
+              const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              replayRequired = changedFiles.some(file => pathTriggersReplay(file.filename));
+              core.info(`Replay required: ${replayRequired} (${changedFiles.length} changed file(s) checked)`);
+            }
 
             while (true) {
-              const { data: checkRuns } = await github.rest.checks.listForRef({
+              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
                 owner,
                 repo,
                 ref: sha,
@@ -55,7 +84,7 @@ jobs:
               });
 
               // Filter to only GitHub Actions checks, excluding ourselves and bots
-              const relevant = checkRuns.check_runs.filter(cr => {
+              const relevant = checkRuns.filter(cr => {
                 if (excludedChecks.has(cr.name)) return false;
                 if (cr.app && excludedApps.has(cr.app.slug)) return false;
                 // Only include GitHub Actions checks
@@ -71,8 +100,11 @@ jobs:
 
               const pending = relevant.filter(cr => !terminalStatuses.has(cr.status));
               const completed = relevant.filter(cr => terminalStatuses.has(cr.status));
+              const replayChecks = relevant.filter(cr => cr.name.startsWith(replayCheckPrefix));
+              const recordChecks = relevant.filter(cr => cr.name.startsWith(recordCheckPrefix));
 
               core.info(`Checks: ${completed.length} completed, ${pending.length} pending out of ${relevant.length} total`);
+              core.info(`Replay checks: ${replayChecks.length}; record checks: ${recordChecks.length}`);
 
               for (const cr of completed) {
                 core.info(`  ✓ ${cr.name}: ${cr.conclusion}`);
@@ -83,6 +115,15 @@ jobs:
 
               if (pending.length > 0) {
                 core.info('Waiting 30s for pending checks...');
+                await new Promise(r => setTimeout(r, 30000));
+                continue;
+              }
+
+              if (replayRequired && replayChecks.length === 0) {
+                if (recordChecks.length > 0) {
+                  core.warning('Record checks are present, but no replay matrix checks were found for this SHA.');
+                }
+                core.info('Replay checks are required for this change. Waiting 30s for the replay workflow to appear...');
                 await new Promise(r => setTimeout(r, 30000));
                 continue;
               }


### PR DESCRIPTION
## Summary

Make the required `ci-status` gate wait for the replay integration matrix when a PR touches files that should trigger replay tests. This keeps the aggregate status aligned with the provider replay checks that branch protection depends on.

This also treats cancelled/action-required check runs as blocking and paginates check-run reads so large CI matrices are evaluated completely.

## Breaking changes

None
