### PR TITLE
chore: bump fallback_version to 0.5.4.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "1.1.4.dev0"
+fallback_version = "0.5.4.dev0"
 
 [tool.uv]
 required-version = ">=0.7.0"
@@ -79,7 +79,7 @@ dependencies = [
 
 [project.optional-dependencies]
 client = [
-    "ogx-client>=1.1.3", # Optional for library-only usage
+    "ogx-client>=0.5.3", # Optional for library-only usage
 ]
 openclient = [
     "ogx-open-client>=1.0.2",

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -97,7 +97,7 @@ ogx_api = ["py.typed", "**/*.json", "**/*.yaml"]
 
 [tool.setuptools_scm]
 root = "../.."
-fallback_version = "1.1.4.dev0"
+fallback_version = "0.5.4.dev0"
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -4258,7 +4258,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.9.4" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=1.1.3" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = ">=0.5.3" },
     { name = "ogx-open-client", marker = "extra == 'openclient'", specifier = ">=1.0.2" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },


### PR DESCRIPTION
Automated post-release version bump after v0.5.3.

Updates fallback_version in both pyproject.toml files to 0.5.4.dev0.

This PR was created automatically by the post-release workflow.