### PR TITLE
fix: honor file_search ranking_options.weights

### DIFF
--- a/src/ogx/providers/remote/vector_io/milvus/milvus.py
+++ b/src/ogx/providers/remote/vector_io/milvus/milvus.py
@@ -318,7 +318,8 @@ class MilvusIndex(EmbeddingIndex):
         reranker_params: dict[str, Any] | None = None,
         filters: Filter | None = None,
     ) -> QueryChunksResponse:
-        if self.use_native_hybrid:
+        weighted_rrf = reranker_type != RERANKER_TYPE_WEIGHTED and bool((reranker_params or {}).get("weights"))
+        if self.use_native_hybrid and not weighted_rrf:
             return await self._query_hybrid_native(
                 embedding, query_string, k, score_threshold, reranker_type, reranker_params, filters
             )
@@ -354,7 +355,14 @@ class MilvusIndex(EmbeddingIndex):
 
         if reranker_type == RERANKER_TYPE_WEIGHTED:
             alpha = (reranker_params or {}).get("alpha", 0.5)
-            rerank = WeightedRanker(alpha, 1 - alpha)
+            weights = (reranker_params or {}).get("weights")
+            if isinstance(weights, dict):
+                vector_weight = float(weights.get("vector", 0.0))
+                keyword_weight = float(weights.get("keyword", 0.0))
+            else:
+                vector_weight = alpha
+                keyword_weight = 1 - alpha
+            rerank = WeightedRanker(vector_weight, keyword_weight)
         else:
             impact_factor = (reranker_params or {}).get("impact_factor", 60.0)
             rerank = RRFRanker(impact_factor)

--- a/src/ogx/providers/utils/vector_io/vector_utils.py
+++ b/src/ogx/providers/utils/vector_io/vector_utils.py
@@ -175,15 +175,11 @@ class WeightedInMemoryAggregator:
                 keyword_weight = float(weights.get("keyword", 0.0))
                 vector_ranks = {
                     doc_id: i + 1
-                    for i, (doc_id, _) in enumerate(
-                        sorted(vector_scores.items(), key=lambda x: x[1], reverse=True)
-                    )
+                    for i, (doc_id, _) in enumerate(sorted(vector_scores.items(), key=lambda x: x[1], reverse=True))
                 }
                 keyword_ranks = {
                     doc_id: i + 1
-                    for i, (doc_id, _) in enumerate(
-                        sorted(keyword_scores.items(), key=lambda x: x[1], reverse=True)
-                    )
+                    for i, (doc_id, _) in enumerate(sorted(keyword_scores.items(), key=lambda x: x[1], reverse=True))
                 }
                 all_ids = set(vector_scores.keys()) | set(keyword_scores.keys())
                 return {

--- a/src/ogx/providers/utils/vector_io/vector_utils.py
+++ b/src/ogx/providers/utils/vector_io/vector_utils.py
@@ -135,7 +135,7 @@ class WeightedInMemoryAggregator:
         vector_scores: dict[str, float],
         keyword_scores: dict[str, float],
         reranker_type: str = "rrf",
-        reranker_params: dict[str, float] | None = None,
+        reranker_params: dict[str, Any] | None = None,
     ) -> dict[str, float]:
         """
         Combine vector and keyword search results using specified reranking strategy.
@@ -152,12 +152,45 @@ class WeightedInMemoryAggregator:
         if reranker_params is None:
             reranker_params = {}
 
+        weights = reranker_params.get("weights")
         if reranker_type == "weighted":
             alpha = reranker_params.get("alpha", 0.5)
+            if isinstance(weights, dict):
+                vector_weight = float(weights.get("vector", 0.0))
+                keyword_weight = float(weights.get("keyword", 0.0))
+                all_ids = set(vector_scores.keys()) | set(keyword_scores.keys())
+                normalized_vector_scores = WeightedInMemoryAggregator._normalize_scores(vector_scores)
+                normalized_keyword_scores = WeightedInMemoryAggregator._normalize_scores(keyword_scores)
+                return {
+                    doc_id: (keyword_weight * normalized_keyword_scores.get(doc_id, 0.0))
+                    + (vector_weight * normalized_vector_scores.get(doc_id, 0.0))
+                    for doc_id in all_ids
+                }
             return WeightedInMemoryAggregator.weighted_rerank(vector_scores, keyword_scores, alpha)
         else:
             # Default to RRF for None, RRF, or any unknown types
             impact_factor = reranker_params.get("impact_factor", 60.0)
+            if isinstance(weights, dict):
+                vector_weight = float(weights.get("vector", 0.0))
+                keyword_weight = float(weights.get("keyword", 0.0))
+                vector_ranks = {
+                    doc_id: i + 1
+                    for i, (doc_id, _) in enumerate(
+                        sorted(vector_scores.items(), key=lambda x: x[1], reverse=True)
+                    )
+                }
+                keyword_ranks = {
+                    doc_id: i + 1
+                    for i, (doc_id, _) in enumerate(
+                        sorted(keyword_scores.items(), key=lambda x: x[1], reverse=True)
+                    )
+                }
+                all_ids = set(vector_scores.keys()) | set(keyword_scores.keys())
+                return {
+                    doc_id: (vector_weight / (impact_factor + vector_ranks.get(doc_id, float("inf"))))
+                    + (keyword_weight / (impact_factor + keyword_ranks.get(doc_id, float("inf"))))
+                    for doc_id in all_ids
+                }
             return WeightedInMemoryAggregator.rrf_rerank(vector_scores, keyword_scores, impact_factor)
 
 

--- a/tests/unit/providers/responses/builtin/test_openai_responses_file_search_ranking_options.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_file_search_ranking_options.py
@@ -1,0 +1,47 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from ogx.core.datatypes import VectorStoresConfig
+from ogx.providers.inline.responses.builtin.responses.tool_executor import ToolExecutor
+from ogx_api.openai_responses import OpenAIResponseInputToolFileSearch
+from ogx_api.vector_io import SearchRankingOptions, VectorStoreSearchResponsePage
+
+
+async def test_file_search_forwards_ranking_options_weights(mock_vector_io_api):
+    """Test that file_search forwards ranking_options.weights to vector store search."""
+    query = "What is machine learning?"
+    vector_store_id = "test_vector_store"
+    ranking_options = SearchRankingOptions(
+        ranker="rrf",
+        weights={"vector": 1.0, "keyword": 0.0},
+    )
+
+    mock_vector_io_api.openai_search_vector_store.return_value = VectorStoreSearchResponsePage(
+        search_query=[query],
+        has_more=False,
+        data=[],
+    )
+    tool_executor = ToolExecutor(
+        tool_groups_api=None,  # type: ignore
+        tool_runtime_api=None,  # type: ignore
+        vector_io_api=mock_vector_io_api,
+        vector_stores_config=VectorStoresConfig(),
+        mcp_session_manager=None,
+    )
+
+    file_search_tool = OpenAIResponseInputToolFileSearch(
+        vector_store_ids=[vector_store_id],
+        ranking_options=ranking_options,
+    )
+    await tool_executor._execute_file_search_via_vector_store(
+        query=query,
+        response_file_search_tool=file_search_tool,
+    )
+
+    call_kwargs = mock_vector_io_api.openai_search_vector_store.call_args
+    request = call_kwargs.kwargs["request"]
+    assert request.ranking_options == ranking_options
+    assert request.ranking_options.weights == {"vector": 1.0, "keyword": 0.0}

--- a/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
@@ -32,6 +32,7 @@ from ogx_api.openai_responses import (
 )
 from ogx_api.tools import ListToolDefsResponse, ToolDef, ToolInvocationResult
 from ogx_api.vector_io import (
+    SearchRankingOptions,
     VectorStoreContent,
     VectorStoreSearchResponse,
     VectorStoreSearchResponsePage,
@@ -470,6 +471,43 @@ async def test_file_search_uses_default_search_mode_from_config(mock_vector_io_a
     call_kwargs = mock_vector_io_api.openai_search_vector_store.call_args
     request = call_kwargs.kwargs["request"]
     assert request.search_mode == "vector", f"Expected search_mode='vector', got '{request.search_mode}'"
+
+
+async def test_file_search_forwards_ranking_options_weights(mock_vector_io_api):
+    """Test that file_search forwards ranking_options.weights to vector store search."""
+    query = "What is machine learning?"
+    vector_store_id = "test_vector_store"
+    ranking_options = SearchRankingOptions(
+        ranker="rrf",
+        weights={"vector": 1.0, "keyword": 0.0},
+    )
+
+    mock_vector_io_api.openai_search_vector_store.return_value = VectorStoreSearchResponsePage(
+        search_query=[query],
+        has_more=False,
+        data=[],
+    )
+    tool_executor = ToolExecutor(
+        tool_groups_api=None,  # type: ignore
+        tool_runtime_api=None,  # type: ignore
+        vector_io_api=mock_vector_io_api,
+        vector_stores_config=VectorStoresConfig(),
+        mcp_session_manager=None,
+    )
+
+    file_search_tool = OpenAIResponseInputToolFileSearch(
+        vector_store_ids=[vector_store_id],
+        ranking_options=ranking_options,
+    )
+    await tool_executor._execute_file_search_via_vector_store(
+        query=query,
+        response_file_search_tool=file_search_tool,
+    )
+
+    call_kwargs = mock_vector_io_api.openai_search_vector_store.call_args
+    request = call_kwargs.kwargs["request"]
+    assert request.ranking_options == ranking_options
+    assert request.ranking_options.weights == {"vector": 1.0, "keyword": 0.0}
 
 
 async def test_file_search_results_include_chunk_metadata_attributes(mock_vector_io_api):

--- a/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
@@ -32,7 +32,6 @@ from ogx_api.openai_responses import (
 )
 from ogx_api.tools import ListToolDefsResponse, ToolDef, ToolInvocationResult
 from ogx_api.vector_io import (
-    SearchRankingOptions,
     VectorStoreContent,
     VectorStoreSearchResponse,
     VectorStoreSearchResponsePage,
@@ -471,43 +470,6 @@ async def test_file_search_uses_default_search_mode_from_config(mock_vector_io_a
     call_kwargs = mock_vector_io_api.openai_search_vector_store.call_args
     request = call_kwargs.kwargs["request"]
     assert request.search_mode == "vector", f"Expected search_mode='vector', got '{request.search_mode}'"
-
-
-async def test_file_search_forwards_ranking_options_weights(mock_vector_io_api):
-    """Test that file_search forwards ranking_options.weights to vector store search."""
-    query = "What is machine learning?"
-    vector_store_id = "test_vector_store"
-    ranking_options = SearchRankingOptions(
-        ranker="rrf",
-        weights={"vector": 1.0, "keyword": 0.0},
-    )
-
-    mock_vector_io_api.openai_search_vector_store.return_value = VectorStoreSearchResponsePage(
-        search_query=[query],
-        has_more=False,
-        data=[],
-    )
-    tool_executor = ToolExecutor(
-        tool_groups_api=None,  # type: ignore
-        tool_runtime_api=None,  # type: ignore
-        vector_io_api=mock_vector_io_api,
-        vector_stores_config=VectorStoresConfig(),
-        mcp_session_manager=None,
-    )
-
-    file_search_tool = OpenAIResponseInputToolFileSearch(
-        vector_store_ids=[vector_store_id],
-        ranking_options=ranking_options,
-    )
-    await tool_executor._execute_file_search_via_vector_store(
-        query=query,
-        response_file_search_tool=file_search_tool,
-    )
-
-    call_kwargs = mock_vector_io_api.openai_search_vector_store.call_args
-    request = call_kwargs.kwargs["request"]
-    assert request.ranking_options == ranking_options
-    assert request.ranking_options.weights == {"vector": 1.0, "keyword": 0.0}
 
 
 async def test_file_search_results_include_chunk_metadata_attributes(mock_vector_io_api):

--- a/tests/unit/providers/test_milvus_weights.py
+++ b/tests/unit/providers/test_milvus_weights.py
@@ -1,0 +1,110 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+if "pymilvus" not in sys.modules:
+    pymilvus = ModuleType("pymilvus")
+    pymilvus.AnnSearchRequest = object
+    pymilvus.DataType = SimpleNamespace(
+        VARCHAR="VARCHAR",
+        FLOAT_VECTOR="FLOAT_VECTOR",
+        JSON="JSON",
+        SPARSE_FLOAT_VECTOR="SPARSE_FLOAT_VECTOR",
+    )
+    pymilvus.Function = object
+    pymilvus.FunctionType = SimpleNamespace(BM25="BM25")
+    pymilvus.MilvusClient = object
+    pymilvus.RRFRanker = object
+    pymilvus.WeightedRanker = object
+    sys.modules["pymilvus"] = pymilvus
+
+from ogx.providers.remote.vector_io.milvus import milvus as milvus_module
+from ogx.providers.remote.vector_io.milvus.milvus import MilvusIndex
+
+
+class _FakeEmbedding:
+    def tolist(self) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.hybrid_search_kwargs: dict[str, Any] | None = None
+
+    def hybrid_search(self, **kwargs: Any) -> list[list[Any]]:
+        self.hybrid_search_kwargs = kwargs
+        return [[]]
+
+
+class _FakeAnnSearchRequest:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+async def test_milvus_native_weighted_hybrid_uses_ranking_option_weights(monkeypatch):
+    ranker_weights: list[tuple[float, float]] = []
+
+    class _FakeWeightedRanker:
+        def __init__(self, vector_weight: float, keyword_weight: float) -> None:
+            ranker_weights.append((vector_weight, keyword_weight))
+
+    monkeypatch.setattr(milvus_module, "AnnSearchRequest", _FakeAnnSearchRequest)
+    monkeypatch.setattr(milvus_module, "WeightedRanker", _FakeWeightedRanker)
+
+    client = _FakeClient()
+    index = MilvusIndex(
+        client=client,  # type: ignore[arg-type]
+        vector_store=SimpleNamespace(identifier="test-store", embedding_dimension=3),  # type: ignore[arg-type]
+        use_native_hybrid=True,
+    )
+
+    await index._query_hybrid_native(
+        embedding=_FakeEmbedding(),  # type: ignore[arg-type]
+        query_string="test query",
+        k=5,
+        score_threshold=0.0,
+        reranker_type="weighted",
+        reranker_params={"alpha": 0.5, "weights": {"vector": 0.2, "keyword": 0.8}},
+    )
+
+    assert ranker_weights == [(0.2, 0.8)]
+    assert client.hybrid_search_kwargs is not None
+    assert isinstance(client.hybrid_search_kwargs["ranker"], _FakeWeightedRanker)
+
+
+async def test_milvus_native_rrf_with_weights_uses_in_memory_hybrid(monkeypatch):
+    index = MilvusIndex(
+        client=_FakeClient(),  # type: ignore[arg-type]
+        vector_store=SimpleNamespace(identifier="test-store", embedding_dimension=3),  # type: ignore[arg-type]
+        use_native_hybrid=True,
+    )
+    calls: list[str] = []
+
+    async def fake_native(*args: Any, **kwargs: Any) -> str:
+        calls.append("native")
+        return "native"
+
+    async def fake_in_memory(*args: Any, **kwargs: Any) -> str:
+        calls.append("in_memory")
+        return "in_memory"
+
+    monkeypatch.setattr(index, "_query_hybrid_native", fake_native)
+    monkeypatch.setattr(index, "_query_hybrid_in_memory", fake_in_memory)
+
+    result = await index.query_hybrid(
+        embedding=_FakeEmbedding(),  # type: ignore[arg-type]
+        query_string="test query",
+        k=5,
+        score_threshold=0.0,
+        reranker_type="rrf",
+        reranker_params={"weights": {"vector": 1.0, "keyword": 0.0}},
+    )
+
+    assert result == "in_memory"
+    assert calls == ["in_memory"]

--- a/tests/unit/providers/utils/memory/test_reranking.py
+++ b/tests/unit/providers/utils/memory/test_reranking.py
@@ -5,8 +5,11 @@
 # the root directory of this source tree.
 
 
+from ogx.core.datatypes import VectorStoresConfig
+from ogx.providers.utils.memory.openai_vector_store_mixin import OpenAIVectorStoreMixin
 from ogx.providers.utils.memory.vector_store import RERANKER_TYPE_RRF, RERANKER_TYPE_WEIGHTED
 from ogx.providers.utils.vector_io.vector_utils import WeightedInMemoryAggregator
+from ogx_api.vector_io import SearchRankingOptions
 
 
 class TestNormalizeScores:
@@ -207,6 +210,50 @@ class TestCombineSearchResults:
         assert len(combined) == 3
         assert all(0 <= score <= 1 for score in combined.values())
 
+    def test_combine_search_results_weighted_uses_weights(self):
+        """Test explicit vector/keyword weights override weighted alpha."""
+        vector_scores = {"vector-doc": 1.0, "keyword-doc": 0.0}
+        keyword_scores = {"vector-doc": 0.0, "keyword-doc": 1.0}
+
+        vector_only = WeightedInMemoryAggregator.combine_search_results(
+            vector_scores,
+            keyword_scores,
+            reranker_type=RERANKER_TYPE_WEIGHTED,
+            reranker_params={"alpha": 0.5, "weights": {"vector": 1.0, "keyword": 0.0}},
+        )
+        keyword_only = WeightedInMemoryAggregator.combine_search_results(
+            vector_scores,
+            keyword_scores,
+            reranker_type=RERANKER_TYPE_WEIGHTED,
+            reranker_params={"alpha": 0.5, "weights": {"vector": 0.0, "keyword": 1.0}},
+        )
+
+        assert vector_only["vector-doc"] > vector_only["keyword-doc"]
+        assert keyword_only["keyword-doc"] > keyword_only["vector-doc"]
+        assert vector_only != keyword_only
+
+    def test_combine_search_results_rrf_uses_weights(self):
+        """Test explicit vector/keyword weights affect RRF scoring."""
+        vector_scores = {"vector-doc": 1.0, "keyword-doc": 0.0}
+        keyword_scores = {"vector-doc": 0.0, "keyword-doc": 1.0}
+
+        vector_only = WeightedInMemoryAggregator.combine_search_results(
+            vector_scores,
+            keyword_scores,
+            reranker_type=RERANKER_TYPE_RRF,
+            reranker_params={"impact_factor": 60.0, "weights": {"vector": 1.0, "keyword": 0.0}},
+        )
+        keyword_only = WeightedInMemoryAggregator.combine_search_results(
+            vector_scores,
+            keyword_scores,
+            reranker_type=RERANKER_TYPE_RRF,
+            reranker_params={"impact_factor": 60.0, "weights": {"vector": 0.0, "keyword": 1.0}},
+        )
+
+        assert vector_only["vector-doc"] > vector_only["keyword-doc"]
+        assert keyword_only["keyword-doc"] > keyword_only["vector-doc"]
+        assert vector_only != keyword_only
+
     def test_combine_search_results_unknown_type(self):
         """Test combining with unknown reranker type defaults to RRF."""
         vector_scores = {"doc1": 0.9}
@@ -246,3 +293,18 @@ class TestCombineSearchResults:
         # Test with both empty
         combined = WeightedInMemoryAggregator.combine_search_results({}, {})
         assert len(combined) == 0
+
+
+class TestBuildRerankerParams:
+    def test_build_reranker_params_preserves_weights(self):
+        """Test vector store request ranking options preserve weights for reranker inputs."""
+        weights = {"vector": 0.2, "keyword": 0.8}
+
+        params = OpenAIVectorStoreMixin._build_reranker_params(
+            object(),
+            SearchRankingOptions(ranker="rrf", weights=weights),
+            VectorStoresConfig(),
+        )
+
+        assert params["reranker_type"] == RERANKER_TYPE_RRF
+        assert params["reranker_params"]["weights"] == weights


### PR DESCRIPTION
## What does this PR do?

Closes #6189.

This PR makes `tools[].ranking_options.weights` take effect for Responses API `file_search` hybrid reranking.

`ranking_options.weights` was already preserved through the Responses file_search request path, but the downstream reranking consumers ignored the explicit vector/keyword weights.

This change:
- applies explicit vector/keyword weights in in-memory weighted and RRF reranking
- passes explicit weights into Milvus native weighted hybrid search
- routes Milvus native RRF-with-weights through the in-memory hybrid path because Milvus `RRFRanker` does not support explicit weights
- adds regression tests for Responses propagation, reranker behavior, along with Milvus handling

## Test Plan

Relevant unit tests:

`uv run pytest tests/unit/providers/utils/memory/test_reranking.py tests/unit/providers/responses/builtin/test_openai_responses_tools.py tests/unit/providers/test_milvus_weights.py -x --tb=short`

Result:

`38 passed`

Lint:

`uv run ruff check src/ogx/providers/utils/vector_io/vector_utils.py src/ogx/providers/remote/vector_io/milvus/milvus.py tests/unit/providers/utils/memory/test_reranking.py tests/unit/providers/responses/builtin/test_openai_responses_tools.py tests/unit/providers/test_milvus_weights.py`

Result:

`All checks passed`