### PR TITLE
fix(sqlstore): break ties on the cursor key in cursor pagination

### DIFF
--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -17,8 +17,10 @@ from sqlalchemy import (
     String,
     Table,
     Text,
+    and_,
     event,
     inspect,
+    or_,
     select,
     text,
 )
@@ -321,11 +323,29 @@ class SqlAlchemySqlStoreImpl(SqlStore):
 
                 cursor_value = cursor_row[0]
 
-                # Apply cursor condition based on sort direction
+                # Apply cursor condition based on sort direction. Break ties on the
+                # unique cursor key so rows that share the cursor row's order value
+                # are not skipped across pages.
                 if order_direction == "desc":
-                    query = query.where(table_obj.c[order_column] < cursor_value)
+                    query = query.where(
+                        or_(
+                            table_obj.c[order_column] < cursor_value,
+                            and_(
+                                table_obj.c[order_column] == cursor_value,
+                                table_obj.c[cursor_key_column] > cursor_id,
+                            ),
+                        )
+                    )
                 else:
-                    query = query.where(table_obj.c[order_column] > cursor_value)
+                    query = query.where(
+                        or_(
+                            table_obj.c[order_column] > cursor_value,
+                            and_(
+                                table_obj.c[order_column] == cursor_value,
+                                table_obj.c[cursor_key_column] > cursor_id,
+                            ),
+                        )
+                    )
 
             # Apply ordering
             if order_by:
@@ -347,6 +367,23 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                         query = query.order_by(table_obj.c[name].desc())
                     else:
                         raise ValueError(f"Invalid order '{order_type}' for column '{name}'")
+
+            # Append a unique tiebreaker to the ORDER BY so rows that share the
+            # primary order value have a stable total order across pages. On cursor
+            # pages this is the cursor key; otherwise the table's primary key.
+            tiebreaker_column = None
+            if cursor:
+                tiebreaker_column = cursor[0]
+            else:
+                primary_key_columns = list(table_obj.primary_key.columns)
+                if len(primary_key_columns) == 1:
+                    tiebreaker_column = primary_key_columns[0].name
+            if (
+                tiebreaker_column is not None
+                and order_by
+                and tiebreaker_column not in [column_name for column_name, _ in order_by]
+            ):
+                query = query.order_by(table_obj.c[tiebreaker_column].asc())
 
             # Fetch limit + 1 to determine has_more
             fetch_limit = limit

--- a/tests/unit/utils/sqlstore/test_sqlstore.py
+++ b/tests/unit/utils/sqlstore/test_sqlstore.py
@@ -197,6 +197,37 @@ async def test_sqlstore_pagination_basic():
         assert result3.has_more is False
 
 
+async def test_sqlstore_pagination_same_order_value():
+    """Rows that share the cursor row's order value must not be skipped (keyset tiebreaker)."""
+    with TemporaryDirectory() as tmp_dir:
+        db_path = tmp_dir + "/test.db"
+        store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+        await store.create_table(
+            "test_records",
+            {
+                "id": ColumnType.STRING,
+                "created_at": ColumnType.INTEGER,
+                "name": ColumnType.STRING,
+            },
+        )
+
+        # All rows share the same created_at, so pagination must fall back to the
+        # unique id as a tiebreaker instead of dropping the tied rows.
+        for record_id in ["a", "b", "c", "d", "e"]:
+            await store.insert("test_records", {"id": record_id, "created_at": 1000, "name": record_id})
+
+        # The page after id "b" is every same-second row whose id sorts after "b".
+        result = await store.fetch_all(
+            table="test_records",
+            order_by=[("created_at", "desc")],
+            cursor=("id", "b"),
+            limit=10,
+        )
+
+        assert [row["id"] for row in result.data] == ["c", "d", "e"]
+
+
 async def test_sqlstore_pagination_with_filter():
     """Test pagination with WHERE conditions."""
     with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
# What does this PR do?

`SqlAlchemySqlStoreImpl.fetch_all` implements cursor pagination by resolving the cursor id to the value of its (non-unique) order-by column and filtering with a strict inequality:

```python
if order_direction == "desc":
    query = query.where(table_obj.c[order_column] < cursor_value)
else:
    query = query.where(table_obj.c[order_column] > cursor_value)
```

When several rows share that order value (e.g. `created_at`, stored at one-second granularity), the strict comparison excludes **every** tied row — including rows that sort after the cursor row — so they are silently skipped across pages even though `has_more` was `True` on the previous page. This drops data from every list endpoint that paginates on a non-unique timestamp: `/v1/files`, `/v1/responses`, and `/v1/chat/completions`. (Conversations sidestepped this via the unique `sort_order` column added in #5850, but the `fetch_all` primitive itself was never fixed.)

This applies the standard keyset-pagination fix: a compound cursor condition that breaks ties on the unique cursor key, plus a secondary `ORDER BY` on that key (or the table's primary key on the first page) so pages have a stable total order.

## Test Plan

Added `test_sqlstore_pagination_same_order_value` to `tests/unit/utils/sqlstore/test_sqlstore.py`: it inserts five rows with an identical `created_at` and paginates after `id="b"`.

- **Before** this change the page returns `[]` (all tied rows excluded) — silent data loss.
- **After** this change it returns `["c", "d", "e"]`.

```
$ uv run pytest tests/unit/utils/sqlstore/test_sqlstore.py -q
22 passed in 0.80s
```

`uv run ruff check`, `uv run ruff format --check`, and `uv run mypy src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py` all pass. The existing pagination tests (which use distinct order values) are unaffected.
