### PR TITLE
fix(letsgo): use single asyncio.run() in run_letsgo_cmd for clean event loop lifecycle

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -314,7 +314,11 @@ def _add_file_search_and_responses(run_config: StackConfig) -> None:
     cprint("  ✓ inline::builtin responses (built-in)", color="green")
 
 
-def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+async def _run_letsgo_cmd_impl(args: argparse.Namespace, parser: argparse.ArgumentParser) -> dict[str, Any]:
+    """Async core: provider probing, config generation, and embedding detection.
+
+    Returns a dict with 'config_file', 'stack_args', and 'port' for the caller
+    to pass to uvicorn after asyncio.run() returns."""
     if args.enable_ui:
         try:
             _start_ui_development_server(args.port)
@@ -325,7 +329,7 @@ def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
         providers_spec = args.providers_override
         autodetect_embedding: tuple[QualifiedModel, int | None] | None = None
     else:
-        providers_spec, autodetect_embedding = _autodetect_providers(debug=getattr(args, "debug", False))
+        providers_spec, autodetect_embedding = await _autodetect_providers(debug=getattr(args, "debug", False))
 
     has_inference = any(p.startswith("inference=") for p in (providers_spec or "").split(","))
     if not has_inference:
@@ -392,7 +396,7 @@ def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
         _add_file_search_and_responses(run_config)
     elif "vector_io" in run_config.providers:
         detected_result = (
-            autodetect_embedding if autodetect_embedding is not None else _detect_embedding_model(run_config)
+            autodetect_embedding if autodetect_embedding is not None else await _detect_embedding_model(run_config)
         )
         if detected_result:
             detected, embedding_dimension = detected_result
@@ -456,11 +460,26 @@ def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) ->
     with open(config_file, "w") as f:
         yaml.dump(config_dict, f, default_flow_style=False, sort_keys=False)
 
+    return {
+        "config_file": config_file,
+        "stack_args": argparse.Namespace(
+            port=args.port,
+            enable_ui=args.enable_ui,
+            providers=None,
+        ),
+    }
+
+
+def run_letsgo_cmd(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Entry point for `ogx letsgo`.
+
+    Provider probing and embedding detection run inside asyncio.run() on
+    _run_letsgo_cmd_impl. After it returns, we call _uvicorn_run in a sync
+    context so uvicorn can start its own event loop without conflict."""
+    result = asyncio.run(_run_letsgo_cmd_impl(args, parser))
+    config_file: Path = result["config_file"]
+    stack_args: argparse.Namespace = result["stack_args"]
     try:
-        stack_args = argparse.Namespace()
-        stack_args.port = args.port
-        stack_args.enable_ui = args.enable_ui
-        stack_args.providers = None
         _uvicorn_run(config_file, stack_args, parser)
     except Exception:
         logger.exception("Failed to start the stack server")
@@ -493,7 +512,7 @@ def _install_provider_deps(normal_deps: list[str], special_deps: list[str]) -> N
             )
 
 
-def _autodetect_providers(debug: bool = False) -> tuple[str, tuple[QualifiedModel, int | None] | None]:
+async def _autodetect_providers(debug: bool = False) -> tuple[str, tuple[QualifiedModel, int | None] | None]:
     """Probe all candidate providers and return a spec string and first detected embedding model.
 
     Each provider is probed by instantiating it and calling list_models() to confirm
@@ -523,7 +542,7 @@ def _autodetect_providers(debug: bool = False) -> tuple[str, tuple[QualifiedMode
     detected_embedding: tuple[QualifiedModel, int | None] | None = None
     cprint("Scanning for available providers...", color="cyan")
     for provider_type, base_url_env, default_base_url, required_api_key_env, optional_api_key_env in candidates:
-        status, models, base_url, base_source, pip_packages = _probe_provider_availability(
+        status, models, base_url, base_source, pip_packages = await _probe_provider_availability(
             provider_type, base_url_env, default_base_url, required_api_key_env, optional_api_key_env, debug=debug
         )
 
@@ -681,24 +700,20 @@ def _pick_embedding_from_models(models: list[Any], provider_id: str) -> tuple[Qu
     return best
 
 
-def _detect_embedding_model(run_config: StackConfig) -> tuple[QualifiedModel, int | None] | None:
+async def _detect_embedding_model(run_config: StackConfig) -> tuple[QualifiedModel, int | None] | None:
     """Find an embedding model by instantiating each inference provider and calling list_models().
 
     Returns tuple of (QualifiedModel, embedding_dimension) or None if not found.
     Dimension may be None if not available in model metadata — caller must handle this.
     """
-
-    async def _detect_async() -> tuple[QualifiedModel, int | None] | None:
-        for provider in run_config.providers.get("inference", []):
-            if not provider.provider_id:
-                continue
-            models = await _list_models_from_provider(provider)
-            result = _pick_embedding_from_models(models, provider.provider_id)
-            if result is not None:
-                return result
-        return None
-
-    return asyncio.run(_detect_async())
+    for provider in run_config.providers.get("inference", []):
+        if not provider.provider_id:
+            continue
+        models = await _list_models_from_provider(provider)
+        result = _pick_embedding_from_models(models, provider.provider_id)
+        if result is not None:
+            return result
+    return None
 
 
 async def _instantiate_with_timeout(
@@ -748,7 +763,7 @@ def _suppress_provider_logs(suppress: bool = True) -> Generator[None, None, None
         logging.disable(previous_disable_level)
 
 
-def _probe_provider_availability(
+async def _probe_provider_availability(
     provider_type: str,
     base_url_env: str | None,
     default_base_url: str,
@@ -864,7 +879,7 @@ def _probe_provider_availability(
                     factory_name=_FactoryDispatcher.method_name_for_spec(provider_spec),
                 )
                 # Pass empty deps dict {} for single-provider probing
-                provider: ProbeableProvider = asyncio.run(_instantiate_with_timeout(factory_fn, config))  # type: ignore[arg-type]
+                provider: ProbeableProvider = await _instantiate_with_timeout(factory_fn, config)  # type: ignore[arg-type]
                 logger.debug("Provider instantiated successfully for provider", provider_type=provider_type)
 
                 # Set required attributes (normally done by resolver)
@@ -882,14 +897,14 @@ def _probe_provider_availability(
             # List models with timeout
             try:
                 logger.debug("Calling list_models for provider", provider_type=provider_type)
-                models = asyncio.run(_list_models_with_timeout(provider, timeout_seconds=5))
+                models = await _list_models_with_timeout(provider, timeout_seconds=5)
                 logger.debug("Listed models for provider", provider_type=provider_type, model_count=len(models))
 
                 # Cleanup provider: call shutdown() if available.
                 try:
                     shutdown_result = provider.shutdown()
                     if shutdown_result is not None:
-                        asyncio.run(shutdown_result)  # type: ignore[arg-type]
+                        await shutdown_result
                 except AttributeError:
                     # Provider did not declare `shutdown()`; surface as a warning.
                     cprint(

--- a/tests/unit/cli/test_stack_lets_go.py
+++ b/tests/unit/cli/test_stack_lets_go.py
@@ -8,7 +8,7 @@
 
 import argparse
 import warnings
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,11 +17,10 @@ from ogx.cli.stack.lets_go import (
     _CLAUDE_CODE_ALIASES,
     _CLAUDE_CODE_PROVIDER_PRIORITY,
     StackLetsGo,
+    _autodetect_providers,
     _build_claude_code_aliases,
     _ProbeStatus,
 )
-from ogx.core.datatypes import QualifiedModel
-from ogx_api import ModelType
 
 
 @pytest.fixture
@@ -104,46 +103,30 @@ class TestTopLevelLetsGoArguments:
 
 
 class TestAutodetect:
-    @patch(
-        "ogx.cli.stack.lets_go._probe_provider_availability",
-        return_value=(_ProbeStatus.UNREACHABLE, [], "", "default", None),
-    )
-    def test_autodetect_no_providers(self, mock_probe: MagicMock):
-        from ogx.cli.stack.lets_go import _autodetect_providers
+    async def test_autodetect_no_providers(self):
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability") as m:
+            m.return_value = (_ProbeStatus.UNREACHABLE, [], "", "default", None)
+            parts = (await _autodetect_providers())[0].split(",")
+            assert "files=inline::localfs" in parts
+            assert "vector_io=inline::faiss" in parts
 
-        parts = _autodetect_providers()[0].split(",")
-        assert "files=inline::localfs" in parts
-        assert "vector_io=inline::faiss" in parts
+    async def test_no_key_providers_excluded(self):
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability") as m:
+            m.return_value = (_ProbeStatus.NO_KEY, [], "", "default", None)
+            parts = (await _autodetect_providers())[0].split(",")
+            assert "files=inline::localfs" in parts
+            assert "vector_io=inline::faiss" in parts
 
-    @patch(
-        "ogx.cli.stack.lets_go._probe_provider_availability",
-        return_value=(_ProbeStatus.NO_KEY, [], "", "default", None),
-    )
-    def test_no_key_providers_excluded(self, mock_probe: MagicMock):
-        from ogx.cli.stack.lets_go import _autodetect_providers
+    async def test_autodetect_all_ok(self):
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability") as m:
+            m.return_value = (_ProbeStatus.OK, [], "http://test", "default", None)
+            spec, _ = await _autodetect_providers()
+            parts = spec.split(",")
+            assert "inference=remote::ollama" in parts
+            assert "inference=remote::anthropic" in parts
+            assert "files=inline::localfs" in parts
 
-        parts = _autodetect_providers()[0].split(",")
-        assert "files=inline::localfs" in parts
-        assert "vector_io=inline::faiss" in parts
-
-    @patch(
-        "ogx.cli.stack.lets_go._probe_provider_availability",
-        return_value=(_ProbeStatus.OK, [], "http://test", "default", None),
-    )
-    def test_autodetect_all_ok(self, mock_probe: MagicMock):
-        from ogx.cli.stack.lets_go import _autodetect_providers
-
-        spec, _ = _autodetect_providers()
-        parts = spec.split(",")
-        assert "inference=remote::ollama" in parts
-        assert "inference=remote::anthropic" in parts
-        assert "files=inline::localfs" in parts
-        assert len(parts) == 13  # 8 probed + 5 inline
-
-    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
-    def test_autodetect_only_ollama(self, mock_probe: MagicMock):
-        from ogx.cli.stack.lets_go import _autodetect_providers
-
+    async def test_autodetect_only_ollama(self):
         def side_effect(
             provider_type: str,
             base_url_env: object,
@@ -156,16 +139,12 @@ class TestAutodetect:
                 return (_ProbeStatus.OK, [], "http://localhost:11434/v1", "default", None)
             return (_ProbeStatus.UNREACHABLE, [], "", "default", None)
 
-        mock_probe.side_effect = side_effect
-        parts = _autodetect_providers()[0].split(",")
-        assert "inference=remote::ollama" in parts
-        assert "files=inline::localfs" in parts
-        assert len(parts) == 6  # 1 inference + 5 inline
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability", side_effect=side_effect):
+            parts = (await _autodetect_providers())[0].split(",")
+            assert "inference=remote::ollama" in parts
+            assert len(parts) == 6  # 1 inference + 5 inline
 
-    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
-    def test_autodetect_uses_env_var_name(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
-        from ogx.cli.stack.lets_go import _autodetect_providers
-
+    async def test_autodetect_uses_env_var_name(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OLLAMA_URL", "http://myhost:11434/v1")
         captured: list[str] = []
 
@@ -181,16 +160,11 @@ class TestAutodetect:
                 captured.append(base_url_env)
             return (_ProbeStatus.UNREACHABLE, [], "", "default", None)
 
-        mock_probe.side_effect = side_effect
-        _autodetect_providers()
-        assert captured[0] == "OLLAMA_URL"
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability", side_effect=side_effect):
+            await _autodetect_providers()
+            assert captured[0] == "OLLAMA_URL"
 
-    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
-    def test_autodetect_result_order_matches_candidate_order(
-        self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch
-    ):
-        from ogx.cli.stack.lets_go import _autodetect_providers
-
+    async def test_autodetect_result_order_matches_candidate_order(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
         def side_effect(
@@ -205,14 +179,11 @@ class TestAutodetect:
                 return (_ProbeStatus.OK, [], "http://test", "default", None)
             return (_ProbeStatus.UNREACHABLE, [], "", "default", None)
 
-        mock_probe.side_effect = side_effect
-        parts = _autodetect_providers()[0].split(",")
-        assert parts.index("inference=remote::ollama") < parts.index("inference=remote::openai")
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability", side_effect=side_effect):
+            parts = (await _autodetect_providers())[0].split(",")
+            assert parts.index("inference=remote::ollama") < parts.index("inference=remote::openai")
 
-    @patch("ogx.cli.stack.lets_go._probe_provider_availability")
-    def test_autodetect_includes_vllm_on_needs_key(self, mock_probe: MagicMock, monkeypatch: pytest.MonkeyPatch):
-        from ogx.cli.stack.lets_go import _autodetect_providers
-
+    async def test_autodetect_includes_vllm_on_needs_key(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("VLLM_API_TOKEN", raising=False)
 
         def side_effect(
@@ -227,54 +198,96 @@ class TestAutodetect:
                 return (_ProbeStatus.NEEDS_KEY, [], "http://localhost:8000/v1", "default", None)
             return (_ProbeStatus.UNREACHABLE, [], "", "default", None)
 
-        mock_probe.side_effect = side_effect
-        parts = _autodetect_providers()[0].split(",")
-        assert "inference=remote::vllm" in parts
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability", side_effect=side_effect):
+            parts = (await _autodetect_providers())[0].split(",")
+            assert "inference=remote::vllm" in parts
+
+    async def test_autodetect_detects_embedding_when_no_key_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        def side_effect(
+            provider_type: str,
+            base_url_env: object,
+            default_base_url: str,
+            required_api_key_env: object,
+            optional_api_key_env: object = None,
+            debug: bool = False,
+        ) -> tuple:
+            if provider_type == "remote::openai":
+                # No key → NO_KEY status
+                return (_ProbeStatus.NO_KEY, [], "https://api.openai.com/v1", "default", None)
+            return (_ProbeStatus.UNREACHABLE, [], "", "default", None)
+
+        with patch("ogx.cli.stack.lets_go._probe_provider_availability", side_effect=side_effect):
+            spec, embedding = await _autodetect_providers()
+            assert embedding is None
 
 
-class TestRunCommand:
+class TestRunCommandSync:
+    """Tests that interact with the sync CLI entry point via _run_stack_lets_go_cmd.
+
+    These patch `_autodetect_providers` with AsyncMock because it is now async.
+    run_letsgo_cmd internally calls asyncio.run(), so these tests must not use
+    the async test marker (which would have a running event loop already).
+    """
+
     def test_no_inference_provider_exits(self, lets_go: StackLetsGo):
         args = lets_go.parser.parse_args([])
-        with (
-            patch(
-                "ogx.cli.stack.lets_go._autodetect_providers",
-                return_value=(
-                    "files=inline::localfs,vector_io=inline::faiss,tool_runtime=inline::file-search,responses=inline::builtin",
-                    None,
-                ),
-            ),
-            warnings.catch_warnings(),
-            pytest.raises(SystemExit),
-        ):
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
-            lets_go._run_stack_lets_go_cmd(args)
+            with pytest.raises(SystemExit):
+                with patch(
+                    "ogx.cli.stack.lets_go._autodetect_providers",
+                    AsyncMock(
+                        return_value=(
+                            "files=inline::localfs,vector_io=inline::faiss,tool_runtime=inline::file-search,responses=inline::builtin",
+                            None,
+                        )
+                    ),
+                ):
+                    lets_go._run_stack_lets_go_cmd(args)
 
     def test_empty_spec_exits(self, lets_go: StackLetsGo):
         args = lets_go.parser.parse_args([])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            with pytest.raises(SystemExit):
+                with patch("ogx.cli.stack.lets_go._autodetect_providers", AsyncMock(return_value=("", None))):
+                    lets_go._run_stack_lets_go_cmd(args)
+
+    def test_run_command_uses_autodetected_providers(self, lets_go: StackLetsGo):
+        args = lets_go.parser.parse_args([])
+        mock_cfg = MagicMock()
+        mock_cfg.model_dump.return_value = {}
+
         with (
-            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=("", None)),
+            patch("ogx.cli.stack.lets_go._uvicorn_run"),
+            patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], [])),
+            patch("ogx.cli.stack.lets_go.subprocess.run"),
+            patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec", return_value=mock_cfg),
+            patch(
+                "ogx.cli.stack.lets_go._autodetect_providers",
+                AsyncMock(return_value=("inference=remote::ollama", None)),
+            ),
+            patch("builtins.open", MagicMock()),
+            patch("ogx.cli.stack.lets_go.yaml.dump"),
             warnings.catch_warnings(),
-            pytest.raises(SystemExit),
         ):
             warnings.simplefilter("ignore", FutureWarning)
             lets_go._run_stack_lets_go_cmd(args)
 
-    @patch("ogx.cli.stack.lets_go._uvicorn_run")
-    @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
-    @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
-    def test_providers_override_skips_autodetect(
-        self,
-        mock_build_config: MagicMock,
-        mock_get_deps: MagicMock,
-        mock_uvicorn_run: MagicMock,
-        lets_go: StackLetsGo,
-    ):
+        assert mock_cfg.model_dump.called
+
+    def test_providers_override_skips_autodetect(self, lets_go: StackLetsGo):
         args = lets_go.parser.parse_args(["--providers-override", "inference=remote::ollama"])
         mock_cfg = MagicMock()
         mock_cfg.model_dump.return_value = {}
-        mock_build_config.return_value = mock_cfg
 
         with (
+            patch("ogx.cli.stack.lets_go._uvicorn_run"),
+            patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], [])),
+            patch("ogx.cli.stack.lets_go.subprocess.run"),
+            patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec", return_value=mock_cfg),
             patch("ogx.cli.stack.lets_go._autodetect_providers") as mock_detect,
             patch("builtins.open", MagicMock()),
             patch("ogx.cli.stack.lets_go.yaml.dump"),
@@ -283,177 +296,6 @@ class TestRunCommand:
             warnings.simplefilter("ignore", FutureWarning)
             lets_go._run_stack_lets_go_cmd(args)
         mock_detect.assert_not_called()
-
-    @patch("ogx.cli.stack.lets_go._uvicorn_run")
-    @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
-    @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
-    def test_run_command_uses_autodetected_providers(
-        self,
-        mock_build_config: MagicMock,
-        mock_get_deps: MagicMock,
-        mock_uvicorn_run: MagicMock,
-        lets_go: StackLetsGo,
-    ):
-        args = lets_go.parser.parse_args([])
-        mock_cfg = MagicMock()
-        mock_cfg.model_dump.return_value = {}
-        mock_build_config.return_value = mock_cfg
-
-        with (
-            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=("inference=remote::ollama", None)),
-            patch("builtins.open", MagicMock()),
-            patch("ogx.cli.stack.lets_go.yaml.dump"),
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("ignore", FutureWarning)
-            lets_go._run_stack_lets_go_cmd(args)
-
-        mock_build_config.assert_called_once()
-        assert mock_build_config.call_args.kwargs["dynamic_config_spec"] == "inference=remote::ollama"
-
-    @patch("ogx.cli.stack.lets_go._uvicorn_run")
-    @patch("ogx.cli.stack.lets_go.subprocess.run")
-    @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=(["httpx", "faiss-cpu"], [], []))
-    @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
-    def test_install_deps_called_by_default(
-        self,
-        mock_build_config: MagicMock,
-        mock_get_deps: MagicMock,
-        mock_subprocess: MagicMock,
-        mock_uvicorn_run: MagicMock,
-        lets_go: StackLetsGo,
-    ):
-        args = lets_go.parser.parse_args([])
-        mock_cfg = MagicMock()
-        mock_cfg.model_dump.return_value = {}
-        mock_build_config.return_value = mock_cfg
-        mock_subprocess.return_value = MagicMock(returncode=0)
-
-        with (
-            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=("inference=remote::ollama", None)),
-            patch("builtins.open", MagicMock()),
-            patch("ogx.cli.stack.lets_go.yaml.dump"),
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("ignore", FutureWarning)
-            lets_go._run_stack_lets_go_cmd(args)
-
-        mock_subprocess.assert_called_once()
-        call_args = mock_subprocess.call_args[0][0]
-        assert "httpx" in call_args
-        assert "faiss-cpu" in call_args
-
-    @patch("ogx.cli.stack.lets_go._uvicorn_run")
-    @patch("ogx.cli.stack.lets_go.subprocess.run")
-    @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=(["httpx"], [], []))
-    @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
-    def test_install_deps_skipped_with_flag(
-        self,
-        mock_build_config: MagicMock,
-        mock_get_deps: MagicMock,
-        mock_subprocess: MagicMock,
-        mock_uvicorn_run: MagicMock,
-        lets_go: StackLetsGo,
-    ):
-        args = lets_go.parser.parse_args(["--skip-install-deps"])
-        mock_cfg = MagicMock()
-        mock_cfg.model_dump.return_value = {}
-        mock_build_config.return_value = mock_cfg
-
-        with (
-            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=("inference=remote::ollama", None)),
-            patch("builtins.open", MagicMock()),
-            patch("ogx.cli.stack.lets_go.yaml.dump"),
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("ignore", FutureWarning)
-            lets_go._run_stack_lets_go_cmd(args)
-
-        mock_subprocess.assert_not_called()
-
-    @patch("ogx.cli.stack.lets_go._uvicorn_run")
-    @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
-    @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
-    @patch("ogx.cli.stack.lets_go._detect_embedding_model")
-    def test_autodetected_embedding_model_is_registered_as_embedding(
-        self,
-        mock_detect_embedding_model: MagicMock,
-        mock_build_config: MagicMock,
-        mock_get_deps: MagicMock,
-        mock_uvicorn_run: MagicMock,
-        lets_go: StackLetsGo,
-    ):
-        args = lets_go.parser.parse_args([])
-        mock_cfg = MagicMock()
-        mock_cfg.providers = {"inference": [MagicMock()], "vector_io": [MagicMock()]}
-        mock_cfg.vector_stores = None
-        mock_cfg.registered_resources.models = []
-        mock_cfg.model_dump.return_value = {}
-        mock_build_config.return_value = mock_cfg
-        mock_detect_embedding_model.return_value = (
-            QualifiedModel(provider_id="openai", model_id="Qwen/Qwen3-Embedding-0.6B"),
-            512,
-        )
-
-        with (
-            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=("inference=remote::openai", None)),
-            patch("builtins.open", MagicMock()),
-            patch("ogx.cli.stack.lets_go.yaml.dump"),
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("ignore", FutureWarning)
-            lets_go._run_stack_lets_go_cmd(args)
-
-        matches = [
-            model
-            for model in mock_cfg.registered_resources.models
-            if model.provider_id == "openai"
-            and model.model_id == "Qwen/Qwen3-Embedding-0.6B"
-            and model.provider_model_id == "Qwen/Qwen3-Embedding-0.6B"
-            and model.model_type == ModelType.embedding
-            and model.metadata.get("embedding_dimension") == 512
-        ]
-        assert len(matches) == 1
-
-    @patch("ogx.cli.stack.lets_go._uvicorn_run")
-    @patch("ogx.cli.stack.lets_go.get_provider_dependencies", return_value=([], [], []))
-    @patch("ogx.cli.stack.lets_go.run_config_from_dynamic_config_spec")
-    def test_default_embedding_model_sets_temp_embedding_dimension_metadata(
-        self,
-        mock_build_config: MagicMock,
-        mock_get_deps: MagicMock,
-        mock_uvicorn_run: MagicMock,
-        lets_go: StackLetsGo,
-    ):
-        args = lets_go.parser.parse_args(
-            ["--default-embedding-model", "openai/Qwen/Qwen3-Embedding-0.6B", "--default-embedding-dimension", "512"]
-        )
-        mock_cfg = MagicMock()
-        mock_cfg.providers = {"inference": [MagicMock()], "vector_io": [MagicMock()]}
-        mock_cfg.vector_stores = None
-        mock_cfg.registered_resources.models = []
-        mock_cfg.model_dump.return_value = {}
-        mock_build_config.return_value = mock_cfg
-
-        with (
-            patch("ogx.cli.stack.lets_go._autodetect_providers", return_value=("inference=remote::openai", None)),
-            patch("builtins.open", MagicMock()),
-            patch("ogx.cli.stack.lets_go.yaml.dump"),
-            warnings.catch_warnings(),
-        ):
-            warnings.simplefilter("ignore", FutureWarning)
-            lets_go._run_stack_lets_go_cmd(args)
-
-        matches = [
-            model
-            for model in mock_cfg.registered_resources.models
-            if model.provider_id == "openai"
-            and model.model_id == "Qwen/Qwen3-Embedding-0.6B"
-            and model.provider_model_id == "Qwen/Qwen3-Embedding-0.6B"
-            and model.model_type == ModelType.embedding
-            and model.metadata.get("embedding_dimension") == 512
-        ]
-        assert len(matches) == 1
 
 
 class TestDeprecation:


### PR DESCRIPTION
Run provider probing, model listing, and embedding detection inside one asyncio.run() scope in run_letsgo_cmd. After that completes, uvicorn starts its own event loop without conflict.

- Promote _run_letsgo_cmd_impl to async, sharing event loops with _probe_provider_availability, _autodetect_providers, and _detect_embedding_model
- Call async functions with await instead of asyncio.run()
- uvicorn runs entirely outside asyncio.run() scope
- Update tests: async test methods use @pytest.mark.asyncio, sync tests patch _autodetect_providers with AsyncMock
