### PR TITLE
fix: temporarily pin nodejs image version to avoid Premature Close errors

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -150,7 +150,9 @@ jobs:
         client: ${{ github.event_name == 'pull_request' && fromJSON('["server"]') || fromJSON('["library", "server"]') }}
         # Use Python 3.13 only on nightly schedule (daily latest client test), otherwise use 3.12
         python-version: ${{ github.event.schedule == '0 0 * * *' && fromJSON('["3.12", "3.13"]') || fromJSON('["3.12"]') }}
-        node-version: [22]
+        # Pinned to 22.22 due to node-fetch v2 "Premature close" regression in 22.23.0
+        # (nodejs/node#63989). Unpin once a patched 22.x ships with nodejs/node#64004.
+        node-version: ['22.22']
         client-version: ${{ (github.event.schedule == '0 0 * * *' || github.event.inputs.test-all-client-versions == 'true' || inputs.test-all-client-versions == true) && fromJSON('["published", "latest"]') || fromJSON('["latest"]') }}
         # Test configurations: Either from matrix_json input or generated from ci_matrix.json
         config: ${{ fromJSON(inputs.matrix_json || needs.generate-matrix.outputs.matrix).include }}

--- a/.github/workflows/release-branch-scheduled-ci.yml
+++ b/.github/workflows/release-branch-scheduled-ci.yml
@@ -99,7 +99,9 @@ jobs:
         branch: ${{ fromJSON(needs.discover-branches.outputs.branches) }}
         client: [library, docker, server]
         python-version: ["3.12"]
-        node-version: [22]
+        # Pinned to 22.22 due to node-fetch v2 "Premature close" regression in 22.23.0
+        # (nodejs/node#63989). Unpin once a patched 22.x ships with nodejs/node#64004.
+        node-version: ['22.22']
         client-version: ["latest"]
     steps:
       - name: Checkout ${{ matrix.branch }}


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Pins Node.js image versions to work around the latent `node-fetch v2` bug that was exposed by a recent CVE patch of the Node.js images.

The other workflows that reference Node.js 22 (`ui-unit-tests`, `docs-build`, `pre-commit`, `openapi-generator-validation`) don't use `node-fetch` for SSE streaming, so they're unaffected and don't need the pin.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes #6197 

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
