### PR TITLE
fix: tolerate current vLLM metrics routing package

### DIFF
--- a/.github/actions/setup-vllm-gpu/action.yml
+++ b/.github/actions/setup-vllm-gpu/action.yml
@@ -127,7 +127,8 @@ runs:
             "                continue"
         )
         if old not in source:
-            raise SystemExit(f"Expected route.path assignment not found in {routing_path}")
+            print(f"Patch not needed: {old!r} not found in {routing_path}")
+            raise SystemExit(0)
         routing_path.write_text(source.replace(old, new, 1))
         print(f"Patched {routing_path}")
         PY


### PR DESCRIPTION
## Summary

Keep the GPU recording setup from failing when the installed prometheus FastAPI instrumentator package no longer has the exact internal line our compatibility patch expects.

The patch still applies when the old implementation is present. If the package has already moved past that shape, the setup action logs that the patch is not needed and continues.

## Test plan

Validation branch run after this fix:

- Launch GPU EC2 Runner run 28380846166 passed for the base suite.
- compute-pr-info, start-gpu-runner, Setup vLLM GPU, record-mode integration tests, artifact upload, cleanup, and summary all passed.
- Commit Recordings run 28381881066 downloaded recordings-vllm-gpu-gpt-oss-base-28380846166-1, loaded PR metadata, and pushed the recordings commit back to the PR branch.

Local commit checks:

```text
pre-commit hooks run during git commit
check yaml: Passed
check for merge conflicts: Passed
check for missing __init__.py files: Passed
Ensure ogx_api does not import ogx: Passed
Enforce AuthorizedSqlStore usage: Passed
```

## Breaking changes

None.