### PR TITLE
feat(cli): support OGX_WORKERS env var to override worker count

### DIFF
--- a/src/ogx/cli/stack/run.py
+++ b/src/ogx/cli/stack/run.py
@@ -153,7 +153,8 @@ def _uvicorn_run(config_file: Path | None, args: argparse.Namespace, parser: arg
 
     env_port = os.getenv("OGX_PORT")
     port = args.port or (int(env_port) if env_port else None) or config.server.port
-    workers = config.server.workers
+    env_workers = os.getenv("OGX_WORKERS")
+    workers = (int(env_workers) if env_workers else None) or config.server.workers
 
     host = ""
     if config.server.host:


### PR DESCRIPTION
## Summary
- Add `OGX_WORKERS` environment variable to override the configured worker count, matching the existing `OGX_PORT` pattern.

## Test plan
- Set `OGX_WORKERS=4` and verify uvicorn starts with 4 workers
- Unset `OGX_WORKERS` and verify the config value is used