### PR TITLE
chore(refactor, responses): pass `CreateResponseRequest` object directly through the call chain instead of unpacking individual fields

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -41,6 +41,7 @@ GRANDFATHERED_FILES = {
     "tests/integration/responses/test_openai_responses.py",
     "tests/integration/responses/test_tool_responses.py",
     "tests/unit/server/test_auth.py",  # 1000+ lines after auth middleware refactor
+    "tests/unit/providers/responses/builtin/test_openai_responses_tools.py",  # sometimes 1000+ depending on ruff
 }
 
 

--- a/src/ogx/providers/inline/responses/builtin/impl.py
+++ b/src/ogx/providers/inline/responses/builtin/impl.py
@@ -141,42 +141,7 @@ class BuiltinResponsesImpl(Responses):
         """
         _record_parameter_usage(request, operation="create_response")
         assert self.openai_responses_impl is not None, "OpenAI responses not initialized"
-        result = await self.openai_responses_impl.create_openai_response(
-            input=request.input,
-            model=request.model,
-            prompt=request.prompt,
-            instructions=request.instructions,
-            skills=request.skills,
-            previous_response_id=request.previous_response_id,
-            prompt_cache_key=request.prompt_cache_key,
-            conversation=request.conversation,
-            store=request.store,
-            stream=request.stream,
-            temperature=request.temperature,
-            top_p=request.top_p,
-            frequency_penalty=request.frequency_penalty,
-            text=request.text,
-            tool_choice=request.tool_choice,
-            tools=request.tools,
-            include=request.include,
-            max_infer_iters=request.max_infer_iters,
-            guardrails=request.guardrails,
-            parallel_tool_calls=request.parallel_tool_calls,
-            max_tool_calls=request.max_tool_calls,
-            max_output_tokens=request.max_output_tokens,
-            reasoning=request.reasoning,
-            service_tier=request.service_tier,
-            metadata=request.metadata,
-            safety_identifier=request.safety_identifier,
-            background=request.background,
-            truncation=request.truncation,
-            top_logprobs=request.top_logprobs,
-            presence_penalty=request.presence_penalty,
-            extra_body=request.model_extra,
-            stream_options=request.stream_options,
-            context_management=request.context_management,
-            memory=request.memory,
-        )
+        result = await self.openai_responses_impl.create_openai_response(request)
         return result
 
     async def list_openai_responses(

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -1028,7 +1028,7 @@ class OpenAIResponsesImpl:
                 )
                 raise InternalServerError()
             # Preserve the request mode on the terminal response object returned to the caller.
-            final_response.background = request.background
+            final_response.background = bool(request.background)
             return final_response
 
     async def _create_background_response(

--- a/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/openai_responses.py
@@ -43,6 +43,7 @@ from ogx_api import (
     Connectors,
     ConversationItem,
     Conversations,
+    CreateResponseRequest,
     Files,
     GetPromptRequest,
     Inference,
@@ -80,7 +81,6 @@ from ogx_api import (
     Prompts,
     ResponseItemInclude,
     ResponseNotFoundError,
-    ResponseStreamOptions,
     ResponseTruncation,
     ServiceNotEnabledError,
     ToolGroups,
@@ -915,61 +915,24 @@ class OpenAIResponsesImpl:
 
     async def create_openai_response(
         self,
-        input: str | list[OpenAIResponseInput],
-        model: str,
-        background: bool | None = False,
-        prompt: OpenAIResponsePrompt | None = None,
-        instructions: str | None = None,
-        skills: list[str] | None = None,
-        previous_response_id: str | None = None,
-        prompt_cache_key: str | None = None,
-        conversation: str | None = None,
-        store: bool | None = True,
-        stream: bool | None = False,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        frequency_penalty: float | None = None,
-        text: OpenAIResponseText | None = None,
-        tool_choice: OpenAIResponseInputToolChoice | None = None,
-        tools: list[OpenAIResponseInputTool] | None = None,
-        include: list[ResponseItemInclude] | None = None,
-        max_infer_iters: int | None = 10,
-        guardrails: bool | None = None,
-        parallel_tool_calls: bool | None = None,
-        max_tool_calls: int | None = None,
-        reasoning: OpenAIResponseReasoning | None = None,
-        max_output_tokens: int | None = None,
-        service_tier: ServiceTier | None = None,
-        metadata: dict[str, str] | None = None,
-        safety_identifier: str | None = None,
-        truncation: ResponseTruncation | None = None,
-        top_logprobs: int | None = None,
-        presence_penalty: float | None = None,
-        extra_body: dict | None = None,
-        stream_options: ResponseStreamOptions | None = None,
-        context_management: list | None = None,
-        memory: MemoryToolConfig | None = None,
+        request: CreateResponseRequest,
     ) -> OpenAIResponseObject | AsyncIterator[OpenAIResponseObjectStream]:
-        stream = bool(stream)
-        background = bool(background)
-        text = OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")) if text is None else text
-
         # Validate that stream and background are mutually exclusive
-        if stream and background:
+        if request.stream and request.background:
             raise ValueError("OGX does not yet support 'stream' and 'background' together.")
 
-        if background and store is False:
+        if request.background and request.store is False:
             raise ValueError("Cannot use 'background' with 'store=False'. Background responses must be stored.")
 
         # Filter out unsupported include items instead of rejecting the request
-        if include:
-            include = [item for item in include if str(item) != "reasoning.encrypted_content"]
+        if request.include:
+            request.include = [item for item in request.include if str(item) != "reasoning.encrypted_content"]
 
         # Validate MCP tools: ensure Authorization header is not passed via headers dict
-        if tools:
+        if request.tools:
             from ogx_api.openai_responses import OpenAIResponseInputToolMCP
 
-            for tool in tools:
+            for tool in request.tools:
                 if isinstance(tool, OpenAIResponseInputToolMCP) and tool.headers:
                     for key in tool.headers.keys():
                         if key.lower() == "authorization":
@@ -979,101 +942,39 @@ class OpenAIResponsesImpl:
                                 "Authorization credentials must be passed via the 'authorization' parameter, not 'headers'.",
                             )
 
-        enable_guardrails = bool(guardrails)
-
-        if enable_guardrails and not self.moderation_endpoint:
+        if request.guardrails and not self.moderation_endpoint:
             raise ServiceNotEnabledError(
                 "moderation_endpoint",
                 provider_specific_message="Guardrails require a moderation endpoint to be configured on the server. Contact your platform administrator to set 'moderation_endpoint' on the responses provider, or remove the 'guardrails' parameter from your request.",
             )
 
-        if conversation is not None:
-            if previous_response_id is not None:
+        if request.conversation is not None:
+            if request.previous_response_id is not None:
                 raise InvalidParameterError(
                     "previous_response_id, conversation",
                     "previous_response_id and conversation are both provided",
                     "Provide only one of these parameters.",
                 )
 
-            if not CONVERSATION_ID_PATTERN.fullmatch(conversation):
+            if not CONVERSATION_ID_PATTERN.fullmatch(request.conversation):
                 raise InvalidParameterError(
                     "conversation",
-                    conversation,
+                    request.conversation,
                     "Must match format 'conv_' followed by 48 lowercase hex characters.",
                 )
 
+        max_tool_calls = request.max_tool_calls
         if max_tool_calls is not None and max_tool_calls < 1:
             raise ValueError(f"Invalid {max_tool_calls=}; should be >= 1")
 
         # Handle background mode
-        if background:
-            return await self._create_background_response(
-                input=input,
-                model=model,
-                prompt=prompt,
-                instructions=instructions,
-                skills=skills,
-                previous_response_id=previous_response_id,
-                conversation=conversation,
-                store=store,
-                temperature=temperature,
-                frequency_penalty=frequency_penalty,
-                text=text,
-                tool_choice=tool_choice,
-                tools=tools,
-                include=include,
-                max_infer_iters=max_infer_iters,
-                enable_guardrails=enable_guardrails,
-                parallel_tool_calls=parallel_tool_calls,
-                max_tool_calls=max_tool_calls,
-                reasoning=reasoning,
-                max_output_tokens=max_output_tokens,
-                service_tier=service_tier,
-                metadata=metadata,
-                safety_identifier=safety_identifier,
-                truncation=truncation,
-                presence_penalty=presence_penalty,
-                extra_body=extra_body,
-                context_management=context_management,
-                memory=memory,
-            )
+        if request.background:
+            response_id = f"resp_{uuid.uuid4()}"
+            return await self._create_background_response(request, response_id)
 
-        stream_gen = self._create_streaming_response(
-            input=input,
-            conversation=conversation,
-            model=model,
-            prompt=prompt,
-            instructions=instructions,
-            skills=skills,
-            previous_response_id=previous_response_id,
-            prompt_cache_key=prompt_cache_key,
-            store=store,
-            temperature=temperature,
-            top_p=top_p,
-            frequency_penalty=frequency_penalty,
-            text=text,
-            tools=tools,
-            tool_choice=tool_choice,
-            max_infer_iters=max_infer_iters,
-            enable_guardrails=enable_guardrails,
-            parallel_tool_calls=parallel_tool_calls,
-            max_tool_calls=max_tool_calls,
-            reasoning=reasoning,
-            max_output_tokens=max_output_tokens,
-            service_tier=service_tier,
-            metadata=metadata,
-            safety_identifier=safety_identifier,
-            include=include,
-            truncation=truncation,
-            top_logprobs=top_logprobs,
-            presence_penalty=presence_penalty,
-            extra_body=extra_body,
-            stream_options=stream_options,
-            context_management=context_management,
-            memory=memory,
-        )
+        stream_gen = self._create_streaming_response(request)
 
-        if stream:
+        if request.stream:
             return stream_gen
         else:
             final_response = None
@@ -1088,9 +989,9 @@ class OpenAIResponsesImpl:
                                 response_id=stream_chunk.response.id,
                                 first_terminal_event=final_event_type,
                                 second_terminal_event=stream_chunk.type,
-                                model=model,
-                                conversation=conversation,
-                                previous_response_id=previous_response_id,
+                                model=request.model,
+                                conversation=request.conversation,
+                                previous_response_id=request.previous_response_id,
                             )
                             raise InternalServerError()
                         final_response = stream_chunk.response
@@ -1108,12 +1009,12 @@ class OpenAIResponsesImpl:
                             error_message=error_message,
                             error_code=error_code,
                             response_id=failed_response.id,
-                            model=model,
+                            model=request.model,
                         )
                         # Surface the provider message — it may be actionable (e.g. wrong tool-call-parser,
                         # context window exceeded). Use the error code to pick the right HTTP status.
                         if error_code == "invalid_prompt":
-                            raise InvalidParameterError("model", model, error_message)
+                            raise InvalidParameterError("model", request.model, error_message)
                         raise InternalServerError(error_message)
                     case _:
                         pass  # Other event types don't have .response
@@ -1121,45 +1022,19 @@ class OpenAIResponsesImpl:
             if final_response is None:
                 logger.error(
                     "The response stream never reached a terminal state",
-                    model=model,
-                    conversation=conversation,
-                    previous_response_id=previous_response_id,
+                    model=request.model,
+                    conversation=request.conversation,
+                    previous_response_id=request.previous_response_id,
                 )
                 raise InternalServerError()
             # Preserve the request mode on the terminal response object returned to the caller.
-            final_response.background = background
+            final_response.background = request.background
             return final_response
 
     async def _create_background_response(
         self,
-        input: str | list[OpenAIResponseInput],
-        model: str,
-        prompt: OpenAIResponsePrompt | None = None,
-        instructions: str | None = None,
-        skills: list[str] | None = None,
-        previous_response_id: str | None = None,
-        conversation: str | None = None,
-        store: bool | None = True,
-        temperature: float | None = None,
-        frequency_penalty: float | None = None,
-        text: OpenAIResponseText | None = None,
-        tool_choice: OpenAIResponseInputToolChoice | None = None,
-        tools: list[OpenAIResponseInputTool] | None = None,
-        include: list[ResponseItemInclude] | None = None,
-        max_infer_iters: int | None = 10,
-        enable_guardrails: bool = False,
-        parallel_tool_calls: bool | None = None,
-        max_tool_calls: int | None = None,
-        reasoning: OpenAIResponseReasoning | None = None,
-        max_output_tokens: int | None = None,
-        service_tier: ServiceTier | None = None,
-        metadata: dict[str, str] | None = None,
-        safety_identifier: str | None = None,
-        truncation: ResponseTruncation | None = None,
-        presence_penalty: float | None = None,
-        extra_body: dict | None = None,
-        context_management: list | None = None,
-        memory: MemoryToolConfig | None = None,
+        request: CreateResponseRequest,
+        response_id: str,
     ) -> OpenAIResponseObject:
         """Create a response that processes in the background.
 
@@ -1168,36 +1043,40 @@ class OpenAIResponsesImpl:
         # Start workers in the current (request-handling) event loop if not already running.
         await self._ensure_workers_started()
 
-        response_id = f"resp_{uuid.uuid4()}"
+        # Extract extra_body from request's model_extra for queueing
+        extra_body = request.model_extra.get("extra_body") if request.model_extra else None
+
         created_at = int(time.time())
 
         # Normalize input to list format for storage
         input_items: list[OpenAIResponseInput] = (
-            [OpenAIResponseMessage(content=input, role="user")] if isinstance(input, str) else input
+            [OpenAIResponseMessage(content=request.input, role="user")]
+            if isinstance(request.input, str)
+            else request.input
         )
 
         # Create initial queued response
         queued_response = OpenAIResponseObject(
             id=response_id,
             created_at=created_at,
-            model=model,
+            model=request.model,
             status="queued",
             output=[],
             background=True,
-            parallel_tool_calls=parallel_tool_calls if parallel_tool_calls is not None else True,
-            previous_response_id=previous_response_id,
-            prompt=prompt,
-            temperature=temperature,
-            text=text if text else OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
+            parallel_tool_calls=request.parallel_tool_calls if request.parallel_tool_calls is not None else True,
+            previous_response_id=request.previous_response_id,
+            prompt=request.prompt,
+            temperature=request.temperature,
+            text=request.text if request.text else OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
             tools=[],  # Will be populated when processing completes
-            tool_choice=tool_choice,
-            instructions=instructions,
-            skills=skills,
-            max_tool_calls=max_tool_calls,
-            reasoning=reasoning,
-            metadata=metadata,
-            safety_identifier=safety_identifier,
-            store=store if store is not None else True,
+            tool_choice=request.tool_choice,
+            instructions=request.instructions,
+            skills=request.skills,
+            max_tool_calls=request.max_tool_calls,
+            reasoning=request.reasoning,
+            metadata=request.metadata,
+            safety_identifier=request.safety_identifier,
+            store=request.store if request.store is not None else True,
         )
 
         # Store the queued response
@@ -1214,34 +1093,34 @@ class OpenAIResponsesImpl:
                     request_context=capture_request_context(),
                     kwargs=dict(
                         response_id=response_id,
-                        input=input,
-                        model=model,
-                        prompt=prompt,
-                        instructions=instructions,
-                        skills=skills,
-                        previous_response_id=previous_response_id,
-                        conversation=conversation,
-                        store=store,
-                        temperature=temperature,
-                        frequency_penalty=frequency_penalty,
-                        text=text,
-                        tool_choice=tool_choice,
-                        tools=tools,
-                        include=include,
-                        max_infer_iters=max_infer_iters,
-                        enable_guardrails=enable_guardrails,
-                        parallel_tool_calls=parallel_tool_calls,
-                        max_tool_calls=max_tool_calls,
-                        reasoning=reasoning,
-                        max_output_tokens=max_output_tokens,
-                        service_tier=service_tier,
-                        metadata=metadata,
-                        safety_identifier=safety_identifier,
-                        truncation=truncation,
-                        presence_penalty=presence_penalty,
+                        input=request.input,
+                        model=request.model,
+                        prompt=request.prompt,
+                        instructions=request.instructions,
+                        skills=request.skills,
+                        previous_response_id=request.previous_response_id,
+                        conversation=request.conversation,
+                        store=request.store,
+                        temperature=request.temperature,
+                        frequency_penalty=request.frequency_penalty,
+                        text=request.text,
+                        tool_choice=request.tool_choice,
+                        tools=request.tools,
+                        include=request.include,
+                        max_infer_iters=request.max_infer_iters,
+                        guardrails=request.guardrails,
+                        parallel_tool_calls=request.parallel_tool_calls,
+                        max_tool_calls=request.max_tool_calls,
+                        reasoning=request.reasoning,
+                        max_output_tokens=request.max_output_tokens,
+                        service_tier=request.service_tier,
+                        metadata=request.metadata,
+                        safety_identifier=request.safety_identifier,
+                        truncation=request.truncation,
+                        presence_penalty=request.presence_penalty,
+                        context_management=request.context_management,
+                        memory=request.memory,
                         extra_body=extra_body,
-                        context_management=context_management,
-                        memory=memory,
                     ),
                 )
             )
@@ -1270,7 +1149,7 @@ class OpenAIResponsesImpl:
         tools: list[OpenAIResponseInputTool] | None = None,
         include: list[ResponseItemInclude] | None = None,
         max_infer_iters: int | None = 10,
-        enable_guardrails: bool = False,
+        guardrails: bool | None = None,
         parallel_tool_calls: bool | None = None,
         max_tool_calls: int | None = None,
         reasoning: OpenAIResponseReasoning | None = None,
@@ -1297,7 +1176,7 @@ class OpenAIResponsesImpl:
             await self.responses_store.update_response_object(existing)
 
         # Process the response using existing streaming logic
-        stream_gen = self._create_streaming_response(
+        request = CreateResponseRequest(
             input=input,
             conversation=conversation,
             model=model,
@@ -1305,14 +1184,14 @@ class OpenAIResponsesImpl:
             instructions=instructions,
             skills=skills,
             previous_response_id=previous_response_id,
-            store=store,
+            store=store if store is not None else True,
             temperature=temperature,
             frequency_penalty=frequency_penalty,
             text=text,
             tools=tools,
             tool_choice=tool_choice,
             max_infer_iters=max_infer_iters,
-            enable_guardrails=enable_guardrails,
+            guardrails=guardrails,
             parallel_tool_calls=parallel_tool_calls,
             max_tool_calls=max_tool_calls,
             reasoning=reasoning,
@@ -1328,7 +1207,8 @@ class OpenAIResponsesImpl:
             context_management=context_management,
             memory=memory,
             background=True,
-        )
+        )  # type: ignore[call-arg]
+        stream_gen = self._create_streaming_response(request, response_id=response_id)
 
         result_response = None
 
@@ -1373,45 +1253,21 @@ class OpenAIResponsesImpl:
 
     async def _create_streaming_response(
         self,
-        input: str | list[OpenAIResponseInput],
-        model: str,
-        instructions: str | None = None,
-        skills: list[str] | None = None,
-        previous_response_id: str | None = None,
-        prompt_cache_key: str | None = None,
-        conversation: str | None = None,
-        prompt: OpenAIResponsePrompt | None = None,
-        store: bool | None = True,
-        temperature: float | None = None,
-        top_p: float | None = None,
-        frequency_penalty: float | None = None,
-        text: OpenAIResponseText | None = None,
-        tools: list[OpenAIResponseInputTool] | None = None,
-        tool_choice: OpenAIResponseInputToolChoice | None = None,
-        max_infer_iters: int | None = 10,
-        enable_guardrails: bool = False,
-        parallel_tool_calls: bool | None = True,
-        max_tool_calls: int | None = None,
-        reasoning: OpenAIResponseReasoning | None = None,
-        max_output_tokens: int | None = None,
-        service_tier: ServiceTier | None = None,
-        metadata: dict[str, str] | None = None,
-        safety_identifier: str | None = None,
-        include: list[ResponseItemInclude] | None = None,
-        truncation: ResponseTruncation | None = None,
+        request: CreateResponseRequest,
         response_id: str | None = None,
-        top_logprobs: int | None = None,
-        presence_penalty: float | None = None,
-        extra_body: dict | None = None,
-        stream_options: ResponseStreamOptions | None = None,
-        context_management: list | None = None,
-        memory: MemoryToolConfig | None = None,
-        background: bool = False,
     ) -> AsyncIterator[OpenAIResponseObjectStream]:
+        extra_body = request.model_extra.get("extra_body") if request.model_extra else None
+
+        text = (
+            request.text
+            if request.text is not None
+            else OpenAIResponseText(format=OpenAIResponseTextFormat(type="text"))
+        )
+
         # These should never be None when called from create_openai_response (which sets defaults)
         # but we assert here to help mypy understand the types
         assert text is not None, "text must not be None"
-        assert max_infer_iters is not None, "max_infer_iters must not be None"
+        assert request.max_infer_iters is not None, "max_infer_iters must not be None"
 
         # Input preprocessing
         (
@@ -1420,45 +1276,47 @@ class OpenAIResponsesImpl:
             tool_context,
             previous_usage,
             inherited_skills,
-        ) = await self._process_input_with_previous_response(input, tools, previous_response_id, conversation)
+        ) = await self._process_input_with_previous_response(
+            request.input, request.tools, request.previous_response_id, request.conversation
+        )
 
         # Inherit skills from previous response if not explicitly provided
-        if skills is None and inherited_skills:
-            skills = inherited_skills
+        if request.skills is None and inherited_skills:
+            request.skills = inherited_skills
 
         # Auto-compact if context_management is configured (runs on resolved history, not just new input)
         compacted_history_applied = False
-        if context_management:
+        if request.context_management:
             compacted_input = await self._maybe_auto_compact(
-                all_input, model, context_management, previous_usage, extra_body=extra_body
+                all_input, request.model, request.context_management, previous_usage, extra_body=extra_body
             )
             if compacted_input is not all_input:
                 compacted_history_applied = True
                 all_input = compacted_input
                 messages = await convert_response_input_to_chat_messages(all_input, files_api=self.files_api)
 
-        if instructions:
-            messages.insert(0, OpenAISystemMessageParam(content=instructions))
+        if request.instructions:
+            messages.insert(0, OpenAISystemMessageParam(content=request.instructions))
 
         # Inject skill instructions after user instructions
-        if skills:
+        if request.skills:
             if not self.skills_api:
                 raise ServiceNotEnabledError("skills")
-            skill_messages = await self._resolve_skill_instructions(skills)
-            insert_idx = 1 if instructions else 0
+            skill_messages = await self._resolve_skill_instructions(request.skills)
+            insert_idx = 1 if request.instructions else 0
             for i, msg in enumerate(skill_messages):
                 messages.insert(insert_idx + i, msg)
 
         # Prepend reusable prompt (if provided)
-        await self._prepend_prompt(messages, prompt)
+        await self._prepend_prompt(messages, request.prompt)
 
         memory_context = await resolve_memory_context(
             vector_io_api=self.vector_io_api,
             memory_config=self.memory_config,
-            request_memory=memory,
-            input=input,
-            metadata=metadata,
-            safety_identifier=safety_identifier,
+            request_memory=request.memory,
+            input=request.input,
+            metadata=request.metadata,
+            safety_identifier=request.safety_identifier,
         )
         if memory_context:
             self._insert_memory_context(messages, memory_context)
@@ -1467,13 +1325,13 @@ class OpenAIResponsesImpl:
         response_format = await convert_response_text_to_chat_response_format(text)
 
         ctx = ChatCompletionContext(
-            model=model,
+            model=request.model,
             messages=messages,
-            response_tools=tools,
-            tool_choice=tool_choice,
-            temperature=temperature,
-            top_p=top_p,
-            frequency_penalty=frequency_penalty,
+            response_tools=request.tools,
+            tool_choice=request.tool_choice,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            frequency_penalty=request.frequency_penalty,
             response_format=response_format,
             tool_context=tool_context,
             inputs=all_input,
@@ -1501,32 +1359,32 @@ class OpenAIResponsesImpl:
                 ctx=ctx,
                 response_id=response_id,
                 created_at=created_at,
-                prompt=prompt,
-                prompt_cache_key=prompt_cache_key,
-                previous_response_id=previous_response_id,
-                skills=skills,
+                prompt=request.prompt,
+                prompt_cache_key=request.prompt_cache_key,
+                previous_response_id=request.previous_response_id,
+                skills=request.skills,
                 text=text,
-                max_infer_iters=max_infer_iters,
-                parallel_tool_calls=parallel_tool_calls,
+                max_infer_iters=request.max_infer_iters,
+                parallel_tool_calls=request.parallel_tool_calls,
                 tool_executor=request_tool_executor,
                 moderation_endpoint=self.moderation_endpoint,
                 moderation_headers=self.moderation_headers,
                 connectors_api=self.connectors_api,
-                enable_guardrails=enable_guardrails,
-                instructions=instructions,
-                max_tool_calls=max_tool_calls,
-                reasoning=reasoning,
-                max_output_tokens=max_output_tokens,
-                service_tier=service_tier,
-                metadata=metadata,
-                safety_identifier=safety_identifier,
-                include=include,
-                store=store,
-                truncation=truncation,
-                top_logprobs=top_logprobs,
-                presence_penalty=presence_penalty,
+                enable_guardrails=bool(request.guardrails),
+                instructions=request.instructions,
+                max_tool_calls=request.max_tool_calls,
+                reasoning=request.reasoning,
+                max_output_tokens=request.max_output_tokens,
+                service_tier=request.service_tier,
+                metadata=request.metadata,
+                safety_identifier=request.safety_identifier,
+                include=request.include,
+                store=request.store,
+                truncation=request.truncation,
+                top_logprobs=request.top_logprobs,
+                presence_penalty=request.presence_penalty,
+                stream_options=request.stream_options,
                 extra_body=extra_body,
-                stream_options=stream_options,
             )
 
             final_response = None
@@ -1537,9 +1395,9 @@ class OpenAIResponsesImpl:
             # Store only new input when building on a previous response (O(n) vs O(n²) storage).
             # If auto-compaction rewrote the history, store the effective compacted input as a full snapshot
             # so subsequent previous_response_id turns continue from the compacted context.
-            incremental = bool(previous_response_id) and not compacted_history_applied
+            incremental = bool(request.previous_response_id) and not compacted_history_applied
             if incremental:
-                input_items_for_storage = self._prepare_input_items_for_storage(input)
+                input_items_for_storage = self._prepare_input_items_for_storage(request.input)
             else:
                 input_items_for_storage = self._prepare_input_items_for_storage(all_input)
 
@@ -1557,14 +1415,14 @@ class OpenAIResponsesImpl:
 
                 # Incremental persistence: persist on significant state changes
                 # This enables clients to poll GET /v1/responses/{response_id} during streaming
-                if store:
+                if request.store:
                     await self._persist_streaming_state(
                         stream_chunk=stream_chunk,
                         orchestrator=orchestrator,
                         input_items=input_items_for_storage,
                         output_items=output_items,
                         incremental_input=incremental,
-                        is_background_response=background,
+                        is_background_response=bool(request.background),
                     )
 
                 # Store and sync before yielding terminal events
@@ -1573,22 +1431,22 @@ class OpenAIResponsesImpl:
                     stream_chunk.type in {"response.completed", "response.incomplete"}
                     and final_response
                     and failed_response is None
-                    and store
+                    and request.store
                 ):
-                    if conversation:
+                    if request.conversation:
                         messages_to_store = list(
                             filter(lambda x: not isinstance(x, OpenAISystemMessageParam), orchestrator.final_messages)
                         )
-                        await self._sync_response_to_conversation(conversation, input, output_items)
-                        await self.responses_store.store_conversation_messages(conversation, messages_to_store)
+                        await self._sync_response_to_conversation(request.conversation, request.input, output_items)
+                        await self.responses_store.store_conversation_messages(request.conversation, messages_to_store)
                         self._schedule_memory_write(
-                            conversation_id=conversation,
+                            conversation_id=request.conversation,
                             response_id=final_response.id,
                             response_status=final_response.status,
-                            model=model,
-                            memory=memory,
-                            metadata=metadata,
-                            safety_identifier=safety_identifier,
+                            model=request.model,
+                            memory=request.memory,
+                            metadata=request.metadata,
+                            safety_identifier=request.safety_identifier,
                         )
 
                 yield stream_chunk

--- a/tests/unit/providers/inline/messages/test_impl.py
+++ b/tests/unit/providers/inline/messages/test_impl.py
@@ -875,7 +875,7 @@ class TestErrorStreamEvent:
     async def test_error_event_terminates_stream(self, impl):
         async def failing_stream():
             raise RuntimeError("immediate failure")
-            yield  # noqa: unreachable — makes this an async generator
+            yield  # unreachable — makes this an async generator
 
         events = []
         async for event in impl._stream_openai_to_anthropic(failing_stream(), "m"):

--- a/tests/unit/providers/responses/builtin/test_openai_responses_agent.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_agent.py
@@ -25,6 +25,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseObject,
     OpenAIResponseObjectStreamResponseFailed,
 )
+from ogx_api.responses.models import CreateResponseRequest
 from ogx_api.tools import ToolDef, ToolInvocationResult
 
 
@@ -55,11 +56,9 @@ async def test_failed_stream_persists_non_system_messages(openai_responses_impl,
         FakeOrchestrator,
     ):
         stream = await openai_responses_impl.create_openai_response(
-            input=input_text,
-            model=model,
-            instructions="system instructions",
-            stream=True,
-            store=True,
+            CreateResponseRequest(
+                input=input_text, model=model, instructions="system instructions", stream=True, store=True
+            )
         )
         chunks = [chunk async for chunk in stream]
 
@@ -124,10 +123,7 @@ async def test_failed_stream_raises_internal_server_error_in_non_streaming_mode(
     ):
         with pytest.raises(InternalServerError) as exc_info:
             await openai_responses_impl.create_openai_response(
-                input="Hello",
-                model=model,
-                stream=False,
-                store=False,
+                CreateResponseRequest(input="Hello", model=model, stream=False, store=False)
             )
 
     # The provider message is surfaced to the caller: response.failed errors are
@@ -290,11 +286,13 @@ async def test_agent_loop_incomplete_due_to_max_output_tokens(
 
     # Execute with max_output_tokens that will be exceeded after first tool call
     result = await openai_responses_impl.create_openai_response(
-        input="Test input",
-        model=model,
-        max_output_tokens=max_output_tokens,
-        tools=[OpenAIResponseInputToolWebSearch(type="web_search")],
-        stream=True,
+        CreateResponseRequest(
+            input="Test input",
+            model=model,
+            max_output_tokens=max_output_tokens,
+            tools=[OpenAIResponseInputToolWebSearch(type="web_search")],
+            stream=True,
+        )
     )
 
     # Collect all events
@@ -364,10 +362,9 @@ async def test_agent_loop_incomplete_due_to_max_iterations(
 
     # Execute with tool configuration
     result = await openai_responses_impl.create_openai_response(
-        input="Test input",
-        model=model,
-        tools=[OpenAIResponseInputToolWebSearch(type="web_search")],
-        stream=True,
+        CreateResponseRequest(
+            input="Test input", model=model, tools=[OpenAIResponseInputToolWebSearch(type="web_search")], stream=True
+        )
     )
 
     # Collect all events
@@ -423,9 +420,7 @@ async def test_agent_loop_incomplete_due_to_length_finish_reason(openai_response
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input="Test input",
-        model=model,
-        stream=True,
+        CreateResponseRequest(input="Test input", model=model, stream=True)
     )
 
     # Collect all events

--- a/tests/unit/providers/responses/builtin/test_openai_responses_conversations.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_conversations.py
@@ -31,6 +31,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseObjectStreamResponseOutputItemDone,
     OpenAIResponseOutputMessageContentOutputText,
 )
+from ogx_api.responses.models import CreateResponseRequest
 
 
 @pytest.fixture
@@ -74,7 +75,7 @@ class TestConversationValidation:
 
         with pytest.raises(ConversationNotFoundError):
             await responses_impl_with_conversations.create_openai_response(
-                input="Hello", model="test-model", conversation=conv_id, stream=False
+                CreateResponseRequest(input="Hello", model="test-model", conversation=conv_id, stream=False)
             )
 
 
@@ -217,7 +218,7 @@ class TestIntegrationWorkflow:
         conversation_id = "conv_" + "a" * 48
 
         response = await responses_impl_with_conversations.create_openai_response(
-            input=input_text, model="test-model", conversation=conversation_id, stream=False
+            CreateResponseRequest(input=input_text, model="test-model", conversation=conversation_id, stream=False)
         )
 
         assert response is not None
@@ -233,7 +234,7 @@ class TestIntegrationWorkflow:
             InvalidParameterError, match="Must match format 'conv_' followed by 48 lowercase hex characters"
         ):
             await responses_impl_with_conversations.create_openai_response(
-                input="Hello", model="test-model", conversation="invalid_id", stream=False
+                CreateResponseRequest(input="Hello", model="test-model", conversation="invalid_id", stream=False)
             )
 
     async def test_create_response_with_nonexistent_conversation(
@@ -245,7 +246,7 @@ class TestIntegrationWorkflow:
 
         with pytest.raises(ConversationNotFoundError) as exc_info:
             await responses_impl_with_conversations.create_openai_response(
-                input="Hello", model="test-model", conversation=conv_id, stream=False
+                CreateResponseRequest(input="Hello", model="test-model", conversation=conv_id, stream=False)
             )
 
         assert "not found" in str(exc_info.value)
@@ -255,7 +256,9 @@ class TestIntegrationWorkflow:
     ):
         with pytest.raises(InvalidParameterError, match="Provide only one") as exc_info:
             await responses_impl_with_conversations.create_openai_response(
-                input="test", model="test", conversation="conv_123", previous_response_id="resp_123"
+                CreateResponseRequest(
+                    input="test", model="test", conversation="conv_123", previous_response_id="resp_123"
+                )
             )
 
         assert "previous_response_id" in str(exc_info.value)
@@ -301,11 +304,9 @@ class TestStoreFalseConversationLeak:
         mock_inference_api.openai_chat_completion.return_value = self._fake_stream()
 
         result = await responses_impl_with_conversations.create_openai_response(
-            input="What is 2+2?",
-            model="test-model",
-            store=False,
-            conversation=conv_id,
-            stream=False,
+            CreateResponseRequest(
+                input="What is 2+2?", model="test-model", store=False, conversation=conv_id, stream=False
+            )
         )
 
         assert result.status == "completed"
@@ -329,11 +330,9 @@ class TestStoreFalseConversationLeak:
         mock_inference_api.openai_chat_completion.return_value = self._fake_stream()
 
         result = await responses_impl_with_conversations.create_openai_response(
-            input="What is 2+2?",
-            model="test-model",
-            store=True,
-            conversation=conv_id,
-            stream=False,
+            CreateResponseRequest(
+                input="What is 2+2?", model="test-model", store=True, conversation=conv_id, stream=False
+            )
         )
 
         assert result.status == "completed"
@@ -358,11 +357,9 @@ class TestStoreFalseConversationLeak:
 
         chunks = []
         async for chunk in await responses_impl_with_conversations.create_openai_response(
-            input="What is 2+2?",
-            model="test-model",
-            store=False,
-            conversation=conv_id,
-            stream=True,
+            CreateResponseRequest(
+                input="What is 2+2?", model="test-model", store=False, conversation=conv_id, stream=True
+            )
         ):
             chunks.append(chunk)
 

--- a/tests/unit/providers/responses/builtin/test_openai_responses_core.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_core.py
@@ -41,6 +41,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseText,
     OpenAIResponseTextFormat,
 )
+from ogx_api.responses.models import CreateResponseRequest
 from tests.unit.providers.responses.builtin.test_openai_responses_helpers import fake_stream
 
 
@@ -55,10 +56,12 @@ async def test_create_openai_response_with_string_input(openai_responses_impl, m
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        temperature=0.1,
-        stream=True,  # Enable streaming to test content part events
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            temperature=0.1,
+            stream=True,  # Enable streaming to test content part events
+        )
     )
 
     # For streaming response, collect all chunks
@@ -133,9 +136,7 @@ async def test_create_openai_response_with_multiple_messages(openai_responses_im
 
     # Execute
     await openai_responses_impl.create_openai_response(
-        input=input_messages,
-        model=model,
-        temperature=0.1,
+        CreateResponseRequest(input=input_messages, model=model, temperature=0.1)
     )
 
     # Verify the the correct messages were sent to the inference API i.e.
@@ -305,9 +306,7 @@ async def test_create_openai_response_with_instructions(openai_responses_impl, m
 
     # Execute
     await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        instructions=instructions,
+        CreateResponseRequest(input=input_text, model=model, instructions=instructions)
     )
 
     # Verify
@@ -344,9 +343,7 @@ async def test_create_openai_response_with_instructions_and_multiple_messages(
 
     # Execute
     await openai_responses_impl.create_openai_response(
-        input=input_messages,
-        model=model,
-        instructions=instructions,
+        CreateResponseRequest(input=input_messages, model=model, instructions=instructions)
     )
 
     # Verify
@@ -408,7 +405,9 @@ async def test_create_openai_response_with_instructions_and_previous_response(
 
     # Execute
     await openai_responses_impl.create_openai_response(
-        input="Which is the largest?", model=model, instructions=instructions, previous_response_id="123"
+        CreateResponseRequest(
+            input="Which is the largest?", model=model, instructions=instructions, previous_response_id="123"
+        )
     )
 
     # Verify
@@ -471,7 +470,9 @@ async def test_create_openai_response_with_previous_response_instructions(
 
     # Execute
     await openai_responses_impl.create_openai_response(
-        input="Which is the largest?", model=model, instructions=instructions, previous_response_id="123"
+        CreateResponseRequest(
+            input="Which is the largest?", model=model, instructions=instructions, previous_response_id="123"
+        )
     )
 
     # Verify
@@ -680,10 +681,7 @@ async def test_store_response_uses_incremental_input_with_previous_response(
 
     # Execute - Create response with previous_response_id
     result = await openai_responses_impl.create_openai_response(
-        input=current_input,
-        model=model,
-        previous_response_id="resp-previous-123",
-        store=True,
+        CreateResponseRequest(input=current_input, model=model, previous_response_id="resp-previous-123", store=True)
     )
 
     store_call_args = mock_responses_store.upsert_response_object.call_args
@@ -750,11 +748,13 @@ async def test_store_response_disables_incremental_input_when_auto_compaction_ap
     openai_responses_impl._maybe_auto_compact = AsyncMock(return_value=compacted_input)
 
     await openai_responses_impl.create_openai_response(
-        input="Now what is 3+3?",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        previous_response_id="resp-previous-123",
-        context_management=[{"type": "compaction", "compact_threshold": 1}],
-        store=True,
+        CreateResponseRequest(
+            input="Now what is 3+3?",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            previous_response_id="resp-previous-123",
+            context_management=[{"type": "compaction", "compact_threshold": 1}],
+            store=True,
+        )
     )
 
     openai_responses_impl._maybe_auto_compact.assert_awaited_once()
@@ -796,9 +796,7 @@ async def test_create_openai_response_with_text_format(
 
     # Execute
     _result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        text=text_format,
+        CreateResponseRequest(input=input_text, model=model, text=text_format)
     )
 
     # Verify
@@ -817,9 +815,7 @@ async def test_create_openai_response_with_invalid_text_format(openai_responses_
     # Execute
     with pytest.raises(ValueError):
         _result = await openai_responses_impl.create_openai_response(
-            input=input_text,
-            model=model,
-            text=OpenAIResponseText(format={"type": "invalid"}),
+            CreateResponseRequest(input=input_text, model=model, text=OpenAIResponseText(format={"type": "invalid"}))
         )
 
 
@@ -842,11 +838,7 @@ async def test_create_openai_response_with_output_types_as_input(
 
     # Create a response with store=True to trigger the storage path
     result = await openai_responses_impl.create_openai_response(
-        input="What's the weather?",
-        model=model,
-        stream=True,
-        temperature=0.1,
-        store=True,
+        CreateResponseRequest(input="What's the weather?", model=model, stream=True, temperature=0.1, store=True)
     )
 
     # Consume the stream

--- a/tests/unit/providers/responses/builtin/test_openai_responses_memory.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_memory.py
@@ -33,6 +33,7 @@ from ogx_api import (
 )
 from ogx_api.files.models import OpenAIFilePurpose
 from ogx_api.responses.models import MemoryToolConfig
+from ogx_api.responses.models import CreateResponseRequest
 from ogx_api.vector_io.models import VectorStoreContent, VectorStoreSearchResponse, VectorStoreSearchResponsePage
 from tests.unit.providers.responses.builtin.memory_needle_cases import (
     MemoryNeedleCase,
@@ -502,10 +503,12 @@ async def test_memory_context_is_injected_without_file_search_output(
     openai_responses_impl.memory_config.enabled = True
 
     result = await openai_responses_impl.create_openai_response(
-        input="repo prefs",
-        model="test-model",
-        stream=True,
-        memory=MemoryToolConfig(owner_id="user-123"),
+        CreateResponseRequest(
+            input="repo prefs",
+            model="test-model",
+            stream=True,
+            memory=MemoryToolConfig(owner_id="user-123"),
+        )
     )
     chunks = [chunk async for chunk in result]
 
@@ -524,10 +527,12 @@ async def test_memory_disabled_does_not_search(
     openai_responses_impl.memory_config.enabled = True
 
     result = await openai_responses_impl.create_openai_response(
-        input="repo prefs",
-        model="test-model",
-        stream=True,
-        memory=MemoryToolConfig(enabled=False, owner_id="user-123"),
+        CreateResponseRequest(
+            input="repo prefs",
+            model="test-model",
+            stream=True,
+            memory=MemoryToolConfig(enabled=False, owner_id="user-123"),
+        )
     )
     _chunks = [chunk async for chunk in result]
 

--- a/tests/unit/providers/responses/builtin/test_openai_responses_memory.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_memory.py
@@ -32,8 +32,7 @@ from ogx_api import (
     VectorStoreNotFoundError,
 )
 from ogx_api.files.models import OpenAIFilePurpose
-from ogx_api.responses.models import MemoryToolConfig
-from ogx_api.responses.models import CreateResponseRequest
+from ogx_api.responses.models import CreateResponseRequest, MemoryToolConfig
 from ogx_api.vector_io.models import VectorStoreContent, VectorStoreSearchResponse, VectorStoreSearchResponsePage
 from tests.unit.providers.responses.builtin.memory_needle_cases import (
     MemoryNeedleCase,

--- a/tests/unit/providers/responses/builtin/test_openai_responses_memory_write_trigger.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_memory_write_trigger.py
@@ -11,7 +11,7 @@ from ogx.core.datatypes import User
 from ogx.core.request_headers import RequestProviderDataContext
 from ogx.providers.inline.responses.builtin.responses import openai_responses as openai_responses_module
 from ogx_api import ConversationItemList
-from ogx_api.responses.models import MemoryToolConfig
+from ogx_api.responses.models import CreateResponseRequest, MemoryToolConfig
 from tests.unit.providers.responses.builtin.test_openai_responses_helpers import fake_stream
 
 
@@ -51,11 +51,13 @@ async def test_memory_write_trigger_schedules_for_completed_stored_conversation(
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
 
     response = await openai_responses_impl.create_openai_response(
-        input="remember this preference",
-        model="test-model",
-        conversation=conv_id,
-        stream=False,
-        memory=MemoryToolConfig(owner_id="user-123"),
+        CreateResponseRequest(
+            input="remember this preference",
+            model="test-model",
+            conversation=conv_id,
+            stream=False,
+            memory=MemoryToolConfig(owner_id="user-123"),
+        ),
     )
     await asyncio.sleep(0)
 
@@ -248,12 +250,14 @@ async def test_memory_write_trigger_skips_when_store_false(
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
 
     response = await openai_responses_impl.create_openai_response(
-        input="remember this preference",
-        model="test-model",
-        store=False,
-        conversation=conv_id,
-        stream=False,
-        memory=MemoryToolConfig(owner_id="user-123"),
+        CreateResponseRequest(
+            input="remember this preference",
+            model="test-model",
+            store=False,
+            conversation=conv_id,
+            stream=False,
+            memory=MemoryToolConfig(owner_id="user-123"),
+        ),
     )
 
     assert response.status == "completed"

--- a/tests/unit/providers/responses/builtin/test_openai_responses_params.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_params.py
@@ -38,6 +38,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseText,
     OpenAIResponseTextFormat,
 )
+from ogx_api.responses.models import CreateResponseRequest
 from ogx_api.tools import ToolDef, ToolInvocationResult
 from tests.unit.providers.responses.builtin.test_openai_responses_helpers import fake_stream
 
@@ -54,11 +55,7 @@ async def test_create_openai_response_with_max_output_tokens_non_streaming(
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        max_output_tokens=max_tokens,
-        stream=False,
-        store=True,
+        CreateResponseRequest(input=input_text, model=model, max_output_tokens=max_tokens, stream=False, store=True)
     )
 
     # Verify response includes the max_output_tokens
@@ -91,11 +88,7 @@ async def test_create_openai_response_with_max_output_tokens_streaming(
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        max_output_tokens=max_tokens,
-        stream=True,
-        store=True,
+        CreateResponseRequest(input=input_text, model=model, max_output_tokens=max_tokens, stream=True, store=True)
     )
 
     # Collect all chunks
@@ -133,10 +126,7 @@ async def test_create_openai_response_with_max_output_tokens_boundary_value(open
 
     # Execute with minimum valid value
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        max_output_tokens=16,
-        stream=False,
+        CreateResponseRequest(input=input_text, model=model, max_output_tokens=16, stream=False)
     )
 
     # Verify it accepts 16
@@ -180,17 +170,19 @@ async def test_create_openai_response_with_max_output_tokens_and_tools(openai_re
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        max_output_tokens=max_tokens,
-        stream=False,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_weather",
-                description="Get weather information",
-                parameters={"location": "string"},
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            max_output_tokens=max_tokens,
+            stream=False,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={"location": "string"},
+                )
+            ],
+        )
     )
 
     # Verify max_output_tokens is preserved
@@ -304,13 +296,15 @@ async def test_params_passed_through_full_chain_to_backend_service(
             mock_chat_completions.return_value = mock_response
 
         result = await openai_responses_impl.create_openai_response(
-            **{
-                "input": "Test message",
-                "model": "fake-model",
-                "stream": stream,
-                "store": store,
-                param_name: param_value,
-            }
+            CreateResponseRequest(
+                **{
+                    "input": "Test message",
+                    "model": "fake-model",
+                    "stream": stream,
+                    "store": store,
+                    param_name: param_value,
+                }
+            )
         )
         if stream:
             chunks = [chunk async for chunk in result]
@@ -354,11 +348,9 @@ async def test_create_openai_response_with_truncation_disabled_streaming(
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        truncation=ResponseTruncation.disabled,
-        stream=True,
-        store=True,
+        CreateResponseRequest(
+            input=input_text, model=model, truncation=ResponseTruncation.disabled, stream=True, store=True
+        )
     )
 
     # Collect all chunks
@@ -394,11 +386,9 @@ async def test_create_openai_response_with_truncation_auto_streaming(
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        truncation=ResponseTruncation.auto,
-        stream=True,
-        store=True,
+        CreateResponseRequest(
+            input=input_text, model=model, truncation=ResponseTruncation.auto, stream=True, store=True
+        )
     )
 
     # Collect all chunks
@@ -455,11 +445,13 @@ async def test_create_openai_response_with_prompt_cache_key_and_previous_respons
 
     # Create a new response with the same cache key
     result = await openai_responses_impl.create_openai_response(
-        input="Second question",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        previous_response_id="resp-prev-123",
-        prompt_cache_key="conversation-cache-001",
-        store=True,
+        CreateResponseRequest(
+            input="Second question",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            previous_response_id="resp-prev-123",
+            prompt_cache_key="conversation-cache-001",
+            store=True,
+        )
     )
 
     # Verify cache key is preserved
@@ -485,10 +477,7 @@ async def test_create_openai_response_with_service_tier(openai_responses_impl, m
 
     # Execute - non-streaming to get final response directly
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        service_tier=service_tier,
-        stream=False,
+        CreateResponseRequest(input=input_text, model=model, service_tier=service_tier, stream=False)
     )
 
     # Verify service_tier is preserved in the response (as string)
@@ -528,10 +517,7 @@ async def test_create_openai_response_service_tier_auto_transformation(openai_re
 
     # Execute with "auto" service tier
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        service_tier=ServiceTier.auto,
-        stream=False,
+        CreateResponseRequest(input=input_text, model=model, service_tier=ServiceTier.auto, stream=False)
     )
 
     # Verify the response has the actual tier from provider, not "auto"
@@ -585,10 +571,7 @@ async def test_create_openai_response_service_tier_propagation_streaming(openai_
 
     # Execute with "auto" but provider returns "priority"
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        service_tier=ServiceTier.auto,
-        stream=True,
+        CreateResponseRequest(input=input_text, model=model, service_tier=ServiceTier.auto, stream=True)
     )
 
     # Collect all chunks
@@ -615,22 +598,14 @@ async def test_create_openai_response_with_top_logprobs_boundary_values(
     # Test with minimum value (0)
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        top_logprobs=0,
-        stream=False,
-        store=True,
+        CreateResponseRequest(input=input_text, model=model, top_logprobs=0, stream=False, store=True)
     )
     assert result.top_logprobs == 0
 
     # Test with maximum value (20)
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        top_logprobs=20,
-        stream=False,
-        store=True,
+        CreateResponseRequest(input=input_text, model=model, top_logprobs=20, stream=False, store=True)
     )
     assert result.top_logprobs == 20
 
@@ -644,9 +619,7 @@ async def test_create_openai_response_with_frequency_penalty_default(openai_resp
 
     # Execute without frequency_penalty
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=False,
+        CreateResponseRequest(input=input_text, model=model, stream=False)
     )
 
     # Verify response has 0.0 for frequency_penalty (non-null default for OpenResponses conformance)
@@ -668,9 +641,7 @@ async def test_create_openai_response_with_presence_penalty_default(openai_respo
 
     # Execute without presence_penalty
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=False,
+        CreateResponseRequest(input=input_text, model=model, stream=False)
     )
 
     # Verify presence_penalty is 0.0 (non-null default for OpenResponses conformance)
@@ -729,19 +700,21 @@ async def test_hallucinated_tool_call_does_not_cause_500(openai_responses_impl, 
     # The response should complete without raising InternalServerError, and the hallucinated
     # call should appear in the output as a function_call item so the client can handle it.
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_weather",
-                description="Get current temperature for a given location.",
-                parameters={
-                    "type": "object",
-                    "properties": {"location": {"type": "string"}},
-                    "required": ["location"],
-                },
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_weather",
+                    description="Get current temperature for a given location.",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                )
+            ],
+        )
     )
 
     assert result is not None
@@ -763,10 +736,7 @@ async def test_create_openai_response_with_stream_options_merges_with_default(
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream_options=stream_options,
-        stream=True,
+        CreateResponseRequest(input=input_text, model=model, stream_options=stream_options, stream=True)
     )
 
     # Collect chunks (consume the async iterator)
@@ -792,10 +762,7 @@ async def test_create_openai_response_with_empty_stream_options(openai_responses
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream_options=stream_options,
-        stream=True,
+        CreateResponseRequest(input=input_text, model=model, stream_options=stream_options, stream=True)
     )
 
     # Collect chunks (consume the async iterator)

--- a/tests/unit/providers/responses/builtin/test_openai_responses_prompts.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_prompts.py
@@ -25,6 +25,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseInputMessageContentText,
     OpenAIResponsePrompt,
 )
+from ogx_api.responses.models import CreateResponseRequest
 from tests.unit.providers.responses.builtin.test_openai_responses_helpers import fake_stream
 
 
@@ -54,9 +55,7 @@ async def test_create_openai_response_with_prompt(openai_responses_impl, mock_in
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
 
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        prompt=openai_response_prompt,
+        CreateResponseRequest(input=input_text, model=model, prompt=openai_response_prompt)
     )
 
     mock_prompts_api.get_prompt.assert_called_with(GetPromptRequest(prompt_id=prompt_id, version=1))
@@ -103,9 +102,7 @@ async def test_prepend_prompt_successful_without_variables(openai_responses_impl
     mock_inference_api.openai_chat_completion.return_value = fake_stream()
 
     await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        prompt=openai_response_prompt,
+        CreateResponseRequest(input=input_text, model=model, prompt=openai_response_prompt)
     )
 
     mock_prompts_api.get_prompt.assert_called_with(GetPromptRequest(prompt_id=prompt_id, version=1))

--- a/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_tools.py
@@ -30,6 +30,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseMessage,
     WebSearchToolTypes,
 )
+from ogx_api.responses.models import CreateResponseRequest
 from ogx_api.tools import ListToolDefsResponse, ToolDef, ToolInvocationResult
 from ogx_api.vector_io import (
     VectorStoreContent,
@@ -73,14 +74,16 @@ async def test_create_openai_response_with_string_input_with_tools(openai_respon
         openai_responses_impl.responses_store.upsert_response_object.reset_mock()
 
         result = await openai_responses_impl.create_openai_response(
-            input=input_text,
-            model=model,
-            temperature=0.1,
-            tools=[
-                OpenAIResponseInputToolWebSearch(
-                    type=tool_name,
-                )
-            ],
+            CreateResponseRequest(
+                input=input_text,
+                model=model,
+                temperature=0.1,
+                tools=[
+                    OpenAIResponseInputToolWebSearch(
+                        type=tool_name,
+                    )
+                ],
+            )
         )
 
         # Verify
@@ -143,19 +146,21 @@ async def test_create_openai_response_with_tool_call_type_none(openai_responses_
 
     # Execute
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        temperature=0.1,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_weather",
-                description="Get current temperature for a given location.",
-                parameters={
-                    "location": "string",
-                },
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            temperature=0.1,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_weather",
+                    description="Get current temperature for a given location.",
+                    parameters={
+                        "location": "string",
+                    },
+                )
+            ],
+        )
     )
 
     # Check that we got the content from our mocked tool execution result
@@ -241,15 +246,17 @@ async def test_create_openai_response_with_tool_call_function_arguments_none(ope
     # Function does not accept arguments
     mock_inference_api.openai_chat_completion.return_value = fake_stream_toolcall()
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        temperature=0.1,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_current_time", description="Get current time for system's timezone", parameters={}
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            temperature=0.1,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_current_time", description="Get current time for system's timezone", parameters={}
+                )
+            ],
+        )
     )
     chunks = [chunk async for chunk in result]
     assert [chunk.type for chunk in chunks] == [
@@ -265,17 +272,19 @@ async def test_create_openai_response_with_tool_call_function_arguments_none(ope
     # Function accepts optional arguments
     mock_inference_api.openai_chat_completion.return_value = fake_stream_toolcall()
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        temperature=0.1,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_current_time",
-                description="Get current time for system's timezone",
-                parameters={"timezone": "string"},
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            temperature=0.1,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_current_time",
+                    description="Get current time for system's timezone",
+                    parameters={"timezone": "string"},
+                )
+            ],
+        )
     )
     chunks = [chunk async for chunk in result]
     assert [chunk.type for chunk in chunks] == [
@@ -291,17 +300,19 @@ async def test_create_openai_response_with_tool_call_function_arguments_none(ope
     # Function accepts optional arguments with additional optional fields
     mock_inference_api.openai_chat_completion.return_value = fake_stream_toolcall()
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        temperature=0.1,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_current_time",
-                description="Get current time for system's timezone",
-                parameters={"timezone": "string", "location": "string"},
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            temperature=0.1,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_current_time",
+                    description="Get current time for system's timezone",
+                    parameters={"timezone": "string", "location": "string"},
+                )
+            ],
+        )
     )
     chunks = [chunk async for chunk in result]
     assert [chunk.type for chunk in chunks] == [
@@ -328,13 +339,15 @@ async def test_reuse_mcp_tool_list(
     )
 
     res1 = await openai_responses_impl.create_openai_response(
-        input="What is 2+2?",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        store=True,
-        tools=[
-            OpenAIResponseInputToolFunction(name="fake", parameters=None),
-            OpenAIResponseInputToolMCP(server_label="alabel", server_url="aurl"),
-        ],
+        CreateResponseRequest(
+            input="What is 2+2?",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            store=True,
+            tools=[
+                OpenAIResponseInputToolFunction(name="fake", parameters=None),
+                OpenAIResponseInputToolMCP(server_label="alabel", server_url="aurl"),
+            ],
+        )
     )
     args = mock_responses_store.upsert_response_object.call_args
     data = args.kwargs["response_object"].model_dump()
@@ -344,13 +357,15 @@ async def test_reuse_mcp_tool_list(
     mock_responses_store.get_response_object.return_value = stored
 
     res2 = await openai_responses_impl.create_openai_response(
-        previous_response_id=res1.id,
-        input="Now what is 3+3?",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        store=True,
-        tools=[
-            OpenAIResponseInputToolMCP(server_label="alabel", server_url="aurl"),
-        ],
+        CreateResponseRequest(
+            previous_response_id=res1.id,
+            input="Now what is 3+3?",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            store=True,
+            tools=[
+                OpenAIResponseInputToolMCP(server_label="alabel", server_url="aurl"),
+            ],
+        )
     )
     assert len(mock_inference_api.openai_chat_completion.call_args_list) == 2
     second_call = mock_inference_api.openai_chat_completion.call_args_list[1]
@@ -391,12 +406,14 @@ async def test_mcp_tool_connector_id_resolved_to_server_url(
 
     # Create a response using connector_id instead of server_url
     result = await openai_responses_impl.create_openai_response(
-        input="Test connector resolution",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        store=True,
-        tools=[
-            OpenAIResponseInputToolMCP(server_label="my-label", connector_id="my-mcp-connector"),
-        ],
+        CreateResponseRequest(
+            input="Test connector resolution",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            store=True,
+            tools=[
+                OpenAIResponseInputToolMCP(server_label="my-label", connector_id="my-mcp-connector"),
+            ],
+        )
     )
 
     # Verify the connector_id was resolved via the connectors API
@@ -659,17 +676,23 @@ async def test_tool_call_arguments_arrive_in_subsequent_delta(openai_responses_i
     mock_inference_api.openai_chat_completion.return_value = fake_stream_vllm_style()
 
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        temperature=0.1,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_weather",
-                description="Get current temperature for a given location.",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            temperature=0.1,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_weather",
+                    description="Get current temperature for a given location.",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                )
+            ],
+        )
     )
     chunks = [chunk async for chunk in result]
 
@@ -763,16 +786,22 @@ async def test_tool_call_arguments_split_across_multiple_deltas(openai_responses
     mock_inference_api.openai_chat_completion.return_value = fake_stream_split_args()
 
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_weather",
-                description="Get current temperature for a given location.",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_weather",
+                    description="Get current temperature for a given location.",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                )
+            ],
+        )
     )
     chunks = [chunk async for chunk in result]
 
@@ -820,16 +849,18 @@ async def test_tool_call_no_parameters_still_returns_empty_json(openai_responses
     mock_inference_api.openai_chat_completion.return_value = fake_stream_no_args()
 
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=True,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                name="get_current_time",
-                description="Get the current time",
-                parameters={},
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=True,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    name="get_current_time",
+                    description="Get the current time",
+                    parameters={},
+                )
+            ],
+        )
     )
     chunks = [chunk async for chunk in result]
 
@@ -854,18 +885,24 @@ async def test_function_tool_strict_field_excluded_when_none(openai_responses_im
 
     # Execute with function tool that has strict=None (default)
     await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=False,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                type="function",
-                name="get_weather",
-                description="Get weather information",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
-                # strict is None by default
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=False,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    type="function",
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                    # strict is None by default
+                )
+            ],
+        )
     )
 
     # Verify the call was made
@@ -899,18 +936,24 @@ async def test_function_tool_strict_field_included_when_set(openai_responses_imp
 
     # Execute with function tool that has strict=True
     await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=False,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                type="function",
-                name="get_weather",
-                description="Get weather information",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
-                strict=True,  # Explicitly set to True
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=False,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    type="function",
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                    strict=True,  # Explicitly set to True
+                )
+            ],
+        )
     )
 
     # Verify the call was made
@@ -941,18 +984,24 @@ async def test_function_tool_strict_false_included(openai_responses_impl, mock_i
 
     # Execute with function tool that has strict=False
     await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        stream=False,
-        tools=[
-            OpenAIResponseInputToolFunction(
-                type="function",
-                name="get_weather",
-                description="Get weather information",
-                parameters={"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]},
-                strict=False,  # Explicitly set to False
-            )
-        ],
+        CreateResponseRequest(
+            input=input_text,
+            model=model,
+            stream=False,
+            tools=[
+                OpenAIResponseInputToolFunction(
+                    type="function",
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                    strict=False,  # Explicitly set to False
+                )
+            ],
+        )
     )
 
     # Verify the call was made

--- a/tests/unit/providers/responses/builtin/test_openai_responses_web_search.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_web_search.py
@@ -7,6 +7,7 @@
 from ogx_api.openai_responses import (
     OpenAIResponseInputToolWebSearch,
 )
+from ogx_api.responses.models import CreateResponseRequest
 from ogx_api.tools import ToolDef, ToolInvocationResult
 from tests.unit.providers.responses.builtin.test_openai_responses_helpers import fake_stream
 
@@ -45,10 +46,9 @@ async def test_web_search_output_includes_action_with_sources(openai_responses_i
     ]
 
     result = await openai_responses_impl.create_openai_response(
-        input=input_text,
-        model=model,
-        temperature=0.1,
-        tools=[OpenAIResponseInputToolWebSearch(type="web_search")],
+        CreateResponseRequest(
+            input=input_text, model=model, temperature=0.1, tools=[OpenAIResponseInputToolWebSearch(type="web_search")]
+        )
     )
 
     # Find the web search tool call in output
@@ -85,17 +85,19 @@ async def test_web_search_with_filters_and_location(openai_responses_impl, mock_
     """Test that web search filters and user_location are passed to invoke_tool."""
     _setup_web_search_mocks(openai_responses_impl, mock_inference_api)
     await openai_responses_impl.create_openai_response(
-        input="What is the capital of Ireland?",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        temperature=0.1,
-        tools=[
-            OpenAIResponseInputToolWebSearch(
-                type="web_search",
-                search_context_size="high",
-                filters={"allowed_domains": ["arxiv.org", "scholar.google.com"]},
-                user_location={"type": "approximate", "country": "US", "city": "San Francisco"},
-            )
-        ],
+        CreateResponseRequest(
+            input="What is the capital of Ireland?",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            temperature=0.1,
+            tools=[
+                OpenAIResponseInputToolWebSearch(
+                    type="web_search",
+                    search_context_size="high",
+                    filters={"allowed_domains": ["arxiv.org", "scholar.google.com"]},
+                    user_location={"type": "approximate", "country": "US", "city": "San Francisco"},
+                )
+            ],
+        )
     )
     call_kwargs = openai_responses_impl.tool_runtime_api.invoke_tool.call_args.kwargs["kwargs"]
     assert call_kwargs["query"] == "What is the capital of Ireland?"
@@ -109,10 +111,12 @@ async def test_web_search_without_config_passes_only_query(openai_responses_impl
     """Test that web search without filters/location only passes query."""
     _setup_web_search_mocks(openai_responses_impl, mock_inference_api)
     await openai_responses_impl.create_openai_response(
-        input="What is the capital of Ireland?",
-        model="meta-llama/Llama-3.1-8B-Instruct",
-        temperature=0.1,
-        tools=[OpenAIResponseInputToolWebSearch(type="web_search")],
+        CreateResponseRequest(
+            input="What is the capital of Ireland?",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            temperature=0.1,
+            tools=[OpenAIResponseInputToolWebSearch(type="web_search")],
+        )
     )
     call_kwargs = openai_responses_impl.tool_runtime_api.invoke_tool.call_args.kwargs["kwargs"]
     assert call_kwargs["query"] == "What is the capital of Ireland?"


### PR DESCRIPTION
- `create_openai_response`: now takes `request: CreateResponseRequest` instead of 25+ individual fields
- `_create_background_response`: now takes `request`, `response_id` — extracts `extra_body` from `request.model_extra` internally
- `_create_streaming_response`: now takes `CreateResponseRequest` — extracts `extra_body` from `request.model_extra` internally, all other fields accessed via `request.xyz`
- `_run_background_response_loop`: constructs `CreateResponseRequest` from its queued kwargs, passes to `_create_streaming_response` which extracts `extra_body` from `request.model_extra`
- Removed all field-level unpacking/aliases: `stream`, `background`, `guardrails`, `input`, `model`, etc.
- Removed `bool()` cast on `request.guardrails` — truthy string values naturally evaluate as enabled
- `text` is no longer built at the top level and passed down — previously it was built twice, now built once from `request.text` at the call site
- Removed `background` and `enable_guardrails` params from `_create_background_response` — both were no-ops since the values are hardcoded or available on `request.guardrails`
- Removed `background_request_id` wrapper param from `_create_background_response` — `response_id` is now passed directly through the call chain
- `include` is mutated in-place instead of threaded as a parameter — `reasoning.encrypted_content` items are filtered before downstream methods see the list
