### PR TITLE
fix(docs): remove stale inline_transformers sidebar reference

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -191,7 +191,6 @@ const sidebars: SidebarsConfig = {
           link: { type: 'doc', id: 'providers/inference/index' },
           items: [
             'providers/inference/inline_sentence-transformers',
-            'providers/inference/inline_transformers',
             'providers/inference/remote_anthropic',
             'providers/inference/remote_azure',
             'providers/inference/remote_bedrock',


### PR DESCRIPTION
## Summary

- Remove the `providers/inference/inline_transformers` entry from `sidebars.ts` — the doc file was deleted in #5882 but the sidebar reference was left behind, breaking **all docs site deploys since June 24** (8 consecutive failures on `ogx-ai.github.io`).

## Test plan

- [ ] Verify the `trigger-docs-deploy` workflow succeeds after merge
- [ ] Confirm the docs site is live and the blog post from #6118 is published