### PR TITLE
fix(docs): escape angle bracket in unstructured-api provider doc

### DIFF
--- a/docs/docs/providers/file_processors/remote_unstructured-api.mdx
+++ b/docs/docs/providers/file_processors/remote_unstructured-api.mdx
@@ -53,7 +53,7 @@ description: |
   ## Performance
 
   - Processing speed: ~1-2 seconds per page
-  - Best for: Documents <100 pages
+  - Best for: Documents under 100 pages
   - Cost: ~$0.01 per page (verify current pricing with Unstructured.io)
 
   ## Documentation
@@ -121,7 +121,7 @@ For faster processing with fewer formats, use `inline::docling` instead.
 ## Performance
 
 - Processing speed: ~1-2 seconds per page
-- Best for: Documents <100 pages
+- Best for: Documents under 100 pages
 - Cost: ~$0.01 per page (verify current pricing with Unstructured.io)
 
 ## Documentation

--- a/src/ogx/providers/registry/file_processors.py
+++ b/src/ogx/providers/registry/file_processors.py
@@ -377,7 +377,7 @@ For faster processing with fewer formats, use `inline::docling` instead.
 ## Performance
 
 - Processing speed: ~1-2 seconds per page
-- Best for: Documents <100 pages
+- Best for: Documents under 100 pages
 - Cost: ~$0.01 per page (verify current pricing with Unstructured.io)
 
 ## Documentation


### PR DESCRIPTION
## Summary

- Fix MDX compilation error in `remote_unstructured-api.mdx` where `<100` is interpreted as a JSX tag, breaking the Docusaurus build.
- This is the second blocker preventing docs site deploys (first was the stale sidebar reference fixed in #6229).

## Test plan

- [ ] Verify the `trigger-docs-deploy` workflow succeeds after merge
- [ ] Confirm the docs site is live and recent blog posts are published