### PR TITLE
fix(letsgo): add insecure to stack_args to avoid AttributeError

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -466,6 +466,7 @@ async def _run_letsgo_cmd_impl(args: argparse.Namespace, parser: argparse.Argume
             port=args.port,
             enable_ui=args.enable_ui,
             providers=None,
+            insecure=False,  # todo: add ability to run in secure FIPS mode
         ),
     }
 


### PR DESCRIPTION
address internal api changes from #5603 

```
ERROR    {'category': 'cli', 'exc_info': True, 'event': 'Failed to start the stack server', 'level': 'error', 'logger': 
         'ogx.cli.stack.lets_go', 'timestamp': '2026-07-02T14:22:00.579642Z'}                                           
         ╭───────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────╮
         │ .../src/ogx/cli/stack/lets_go.py:483 in run_letsgo_cmd │
         │                                                                                                             │
         │   480 │   config_file: Path = result["config_file"]                                                         │
         │   481 │   stack_args: argparse.Namespace = result["stack_args"]                                             │
         │   482 │   try:                                                                                              │
         │ ❱ 483 │   │   _uvicorn_run(config_file, stack_args, parser)                                                 │
         │   484 │   except Exception:                                                                                 │
         │   485 │   │   logger.exception("Failed to start the stack server")                                          │
         │   486 │   │   raise                                                                                         │
         │                                                                                                             │
         │ .../src/ogx/cli/stack/run.py:161 in _uvicorn_run       │
         │                                                                                                             │
         │   158 │   config_file = resolve_config_or_distro(str(config_file))                                          │
         │   159 │   with open(config_file) as fp:                                                                     │
         │   160 │   │   config_contents = yaml.safe_load(fp)                                                          │
         │ ❱ 161 │   │   if args.insecure:                                                                             │
         │   162 │   │   │   if "server" not in config_contents:                                                       │
         │   163 │   │   │   │   config_contents["server"] = {}                                                        │
         │   164 │   │   │   config_contents["server"]["insecure"] = True                                              │
         ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
         AttributeError: 'Namespace' object has no attribute 'insecure'      
```