### PR TITLE
feat: Add --insecure flag to letsgo and auto-generate self-signed TLS certificate

### DIFF
--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -29,6 +29,7 @@ from ogx.cli.subcommand import Subcommand
 from ogx.core.build import get_provider_dependencies
 from ogx.core.datatypes import Provider, QualifiedModel, StackConfig, VectorStoresConfig
 from ogx.core.distribution import get_provider_registry
+from ogx.core.server_tls import generate_self_signed_cert
 from ogx.core.stack import extract_env_var_references, replace_env_vars, run_config_from_dynamic_config_spec
 from ogx.core.utils.config_dirs import DISTRIBS_BASE_DIR
 from ogx.core.utils.dynamic import instantiate_class_type
@@ -202,6 +203,12 @@ def add_letsgo_arguments(parser: argparse.ArgumentParser) -> None:
         "--debug",
         action="store_true",
         help="Enable debug logging during provider scanning and server startup.",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        default=False,
+        help="Allow running without TLS certificates. Disables FIPS enforcement. For local development only.",
     )
 
 
@@ -455,6 +462,15 @@ async def _run_letsgo_cmd_impl(args: argparse.Namespace, parser: argparse.Argume
 
     config_dict = run_config.model_dump(mode="json")
 
+    if not args.insecure:
+        cert_path, key_path = generate_self_signed_cert(distro_dir)
+        if "server" not in config_dict:
+            config_dict["server"] = {}
+        config_dict["server"]["tls_certfile"] = str(cert_path)
+        config_dict["server"]["tls_keyfile"] = str(key_path)
+        config_dict["server"]["insecure"] = False
+        cprint(f"  ✓ Generated self-signed TLS certificate → {cert_path}", color="green")
+
     config_file = distro_dir / "config.yaml"
     logger.info("Writing generated config to", config_file=config_file)
     with open(config_file, "w") as f:
@@ -466,7 +482,7 @@ async def _run_letsgo_cmd_impl(args: argparse.Namespace, parser: argparse.Argume
             port=args.port,
             enable_ui=args.enable_ui,
             providers=None,
-            insecure=False,  # todo: add ability to run in secure FIPS mode
+            insecure=args.insecure,
         ),
     }
 

--- a/src/ogx/core/server_tls.py
+++ b/src/ogx/core/server_tls.py
@@ -4,6 +4,13 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import datetime
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 from pydantic import BaseModel, Field
 
 FIPS_APPROVED_CIPHERS = [
@@ -45,3 +52,39 @@ def validate_fips_tls(
     elif invalid := set(tls_config.ciphers) - set(FIPS_APPROVED_CIPHERS):
         raise ValueError(f"FIPS-approved ciphers required. Invalid: {sorted(invalid)}")
     return tls_config
+
+
+def generate_self_signed_cert(base_dir: Path, domain: str = "localhost") -> tuple[Path, Path]:
+    """Generate a self-signed TLS certificate and key for local development."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, domain),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "OGX"),
+        ]
+    )
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.UTC))
+        .not_valid_after(datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=365))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(domain), x509.DNSName("*")]), critical=False)
+        .sign(key, hashes.SHA256())
+    )
+
+    cert_path = base_dir / "server.crt"
+    key_path = base_dir / "server.key"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return cert_path, key_path


### PR DESCRIPTION
## Summary

Addresses the TODO comment in `src/ogx/cli/stack/lets_go.py` that called for the ability to run in secure FIPS mode.

## Changes

- Added `generate_self_signed_cert()` function in `src/ogx/core/server_tls.py` that creates a self-signed TLS certificate and key with FIPS-approved settings (2048-bit RSA, SHA-256, 1-year validity, wildcard SAN)
- Added `--insecure` CLI flag to `ogx letsgo` command (matches existing `ogx stack run --insecure`)
- When `--insecure` is NOT passed to `letsgo`, the command now auto-generates a self-signed certificate and configures HTTPS with FIPS-approved ciphers
- Wires `args.insecure` through to `stack_args` instead of hardcoding `False`

## Testing

- Manual verification with `uv run ogx stack letsgo --help` confirms the flag is present
- All pre-commit checks pass (linting, mypy, file size, FIPS compliance)
- Unit tests for TLS config pass (`tests/unit/server/test_tls_config.py`)
- Manual integration test confirms cert/key generation and config roundtrip work correctly
