### PR TITLE
fix(inference): lazily initialize asyncio locks in embedding mixin

### DIFF
--- a/src/ogx/providers/utils/inference/embedding_mixin.py
+++ b/src/ogx/providers/utils/inference/embedding_mixin.py
@@ -25,12 +25,27 @@ from ogx_api import (
 )
 
 EMBEDDING_MODELS: dict[tuple[str, bool], "SentenceTransformer"] = {}
-EMBEDDING_MODELS_LOCK = asyncio.Lock()
+_EMBEDDING_MODELS_LOCK: asyncio.Lock | None = None
+_EMBEDDING_ENCODE_LOCK: asyncio.Lock | None = None
 
 DARWIN = "Darwin"
 
 
 log = get_logger(name=__name__, category="providers::utils")
+
+
+def _get_embedding_models_lock() -> asyncio.Lock:
+    global _EMBEDDING_MODELS_LOCK
+    if _EMBEDDING_MODELS_LOCK is None:
+        _EMBEDDING_MODELS_LOCK = asyncio.Lock()
+    return _EMBEDDING_MODELS_LOCK
+
+
+def _get_embedding_encode_lock() -> asyncio.Lock:
+    global _EMBEDDING_ENCODE_LOCK
+    if _EMBEDDING_ENCODE_LOCK is None:
+        _EMBEDDING_ENCODE_LOCK = asyncio.Lock()
+    return _EMBEDDING_ENCODE_LOCK
 
 
 class SentenceTransformerEmbeddingMixin:
@@ -55,7 +70,8 @@ class SentenceTransformerEmbeddingMixin:
 
         # Get the model and generate embeddings
         embedding_model = await self._load_sentence_transformer_model(params.model, trust_remote_code)
-        embeddings = await asyncio.to_thread(embedding_model.encode, input_list, show_progress_bar=False)
+        async with _get_embedding_encode_lock():
+            embeddings = await asyncio.to_thread(embedding_model.encode, input_list, show_progress_bar=False)
 
         # Convert embeddings to the requested format
         data = []
@@ -91,7 +107,7 @@ class SentenceTransformerEmbeddingMixin:
         if loaded_model is not None:
             return loaded_model
 
-        async with EMBEDDING_MODELS_LOCK:
+        async with _get_embedding_models_lock():
             loaded_model = EMBEDDING_MODELS.get(cache_key)
             if loaded_model is not None:
                 return loaded_model


### PR DESCRIPTION
## Summary
- Defers `asyncio.Lock` creation from module import time to first use, fixing "attached to a different event loop" errors when the server's event loop differs from the import-time loop
- Adds a dedicated encode lock to serialize `SentenceTransformer.encode()` calls, preventing tensor size mismatches in models that use rotary position embeddings (RoPE) with a shared cos/sin cache

## What changed

`src/ogx/providers/utils/inference/embedding_mixin.py`:

**Bug 1 — Event loop mismatch:** `EMBEDDING_MODELS_LOCK = asyncio.Lock()` at module scope binds the lock to whatever event loop is active at import time. When the server starts its own loop, concurrent embedding requests hit `RuntimeError: Lock is bound to a different event loop`. Fixed by replacing the module-level lock with a lazy `_get_embedding_models_lock()` helper.

**Bug 2 — Thread-unsafe encode:** `SentenceTransformer` models using RoPE (e.g., nomic-embed-text-v1.5) maintain a shared rotary embedding cache (`cos_cached`, `sin_cached`). When multiple requests call `model.encode()` concurrently via `asyncio.to_thread`, one thread can resize the cache while another reads it, causing `RuntimeError: The size of tensor a (N) must match the size of tensor b (M)`. Fixed by adding `_get_embedding_encode_lock()` around the `encode()` call.

Both locks use the same lazy-initialization pattern to stay event-loop-safe.

## Test plan
- [ ] Verified fix locally by running concurrent embedding requests against an OGX server with `nomic-embed-text-v1.5` (the model that originally triggered both bugs)
- [ ] Pre-commit checks pass (`uv run pre-commit run --all-files`)
- [ ] Existing unit tests pass (`uv run pytest tests/unit/ -x --tb=short`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)