### PR TITLE
fix(testing): guard optional provider SDK imports in test registry

### DIFF
--- a/src/ogx/testing/providers/__init__.py
+++ b/src/ogx/testing/providers/__init__.py
@@ -16,11 +16,37 @@ To add a provider:
        sdk_module=mycloud_sdk,   # The SDK module (``import mycloud_sdk``)
        create_error=create_error,  # (status_code, body, message) -> Exception
    )
-3. Import the module below and add its PROVIDER to the build_providers call
+3. If the provider module imports an SDK that is a required (core) dependency,
+   import the module below and add its PROVIDER to the build_providers call.
+   If it imports an optional SDK, add it to _OPTIONAL_PROVIDERS instead so test
+   environments without that SDK can still load the registry.
 """
 
-from . import ollama, openai
+import importlib
+import importlib.util
+
+from . import openai
 from ._config import ProviderConfig, _validate_provider
+
+# Provider modules whose SDK is an optional dependency, keyed by the SDK package
+# they import at module load time. openai is a core dependency and is imported
+# directly above; these are skipped when their SDK is not installed so test
+# environments that exercise only a subset of providers need not install every
+# provider SDK.
+_OPTIONAL_PROVIDERS: dict[str, str] = {
+    "ollama": "ollama",  # provider module name -> required SDK package
+}
+
+
+def _load_optional_providers() -> list[ProviderConfig]:
+    """Import optional provider modules whose SDK is installed, skipping the rest."""
+    configs: list[ProviderConfig] = []
+    for module_name, sdk in _OPTIONAL_PROVIDERS.items():
+        if importlib.util.find_spec(sdk) is None:
+            continue
+        module = importlib.import_module(f"{__name__}.{module_name}")
+        configs.append(module.PROVIDER)
+    return configs
 
 
 def build_providers(*configs: ProviderConfig) -> dict[str, ProviderConfig]:
@@ -45,7 +71,7 @@ class GenericProviderError(Exception):
 
 PROVIDERS: dict[str, ProviderConfig] = build_providers(
     openai.PROVIDER,
-    ollama.PROVIDER,
+    *_load_optional_providers(),
 )
 
 

--- a/tests/unit/testing/providers/test_providers_init.py
+++ b/tests/unit/testing/providers/test_providers_init.py
@@ -6,6 +6,7 @@
 
 """Tests for provider registry and exception reconstruction dispatch."""
 
+import importlib.util
 import types
 from unittest.mock import patch
 
@@ -18,8 +19,11 @@ from ogx.testing.exception_utils import GenericProviderError
 from ogx.testing.providers import (
     PROVIDERS,
     ProviderConfig,
+    _load_optional_providers,
+    build_providers,
     create_provider_error,
     detect_provider,
+    openai,
 )
 from ogx.testing.providers._config import _validate_provider
 
@@ -158,3 +162,24 @@ class TestProviderValidation:
         config = ProviderConfig(name="x", sdk_module=self._fake_sdk_module(), create_error="not a function")
         with pytest.raises(ValueError, match="create_error must be callable"):
             _validate_provider(config)
+
+
+class TestOptionalProviderLoading:
+    """Providers whose SDK is optional are skipped when the SDK is not installed."""
+
+    def test_missing_optional_sdk_is_skipped(self):
+        """find_spec returning None for an optional SDK skips its provider, not the whole registry."""
+        with patch.object(importlib.util, "find_spec", return_value=None):
+            configs = _load_optional_providers()
+        assert configs == []
+
+    def test_installed_optional_sdk_is_loaded(self):
+        """An optional provider whose SDK is installed is loaded (ollama is present in the test env)."""
+        names = {config.name for config in _load_optional_providers()}
+        assert "ollama" in names
+
+    def test_registry_registers_core_provider_without_optional_sdks(self):
+        """The openai (core) provider is registered even when no optional providers load."""
+        providers = build_providers(openai.PROVIDER)
+        assert providers["openai"] is openai.PROVIDER
+        assert "ollama" not in providers


### PR DESCRIPTION
Fixes #5880.

The test recording/replay registry (`src/ogx/testing/providers/__init__.py`) imported the ollama provider module unconditionally, so any pytest run that touched the testing framework failed with `ModuleNotFoundError: No module named 'ollama'` unless the optional ollama SDK was installed, even when only OpenAI was under test. This change loads optional provider modules via `importlib.util.find_spec` (matching the existing pattern in `core/server/fastapi_router_registry.py`) and skips them when their SDK is absent; the core `openai` provider stays a direct import.

Test command and result:
`uv run pytest tests/unit/testing/ -q` -> 57 passed. Added `TestOptionalProviderLoading` covering the missing-SDK skip, the installed-SDK load, and core-provider registration.