### PR TITLE
docs: fix remote-hosted endpoint URLs broken by the rename

### DIFF
--- a/docs/docs/distributions/remote_hosted_distro/index.mdx
+++ b/docs/docs/distributions/remote_hosted_distro/index.mdx
@@ -2,10 +2,10 @@
 
 Remote-hosted distributions are OGX endpoints hosted by partners that you can connect to directly.
 
-| Distribution | Description |
-|-------------|-------------|
-| [watsonx](./watsonx) | IBM watsonx-backed distribution (`remote::watsonx`) |
-| [OCI](./oci) | Oracle Cloud Infrastructure-backed distribution (`remote::oci`) |
+| Distribution | Endpoint | Inference |
+|-------------|----------|-----------|
+| Together | [https://llama-stack.together.ai](https://llama-stack.together.ai) | remote::together |
+| Fireworks | [https://llama-stack-preview.fireworks.ai](https://llama-stack-preview.fireworks.ai) | remote::fireworks |
 
 ## Connecting
 
@@ -15,8 +15,8 @@ Point any OpenAI-compatible client at the endpoint:
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://your-endpoint/v1",
-    api_key="your-api-key",
+    base_url="https://llama-stack.together.ai/v1",
+    api_key="your-together-api-key",
 )
 
 response = client.chat.completions.create(
@@ -30,6 +30,6 @@ Or use the CLI:
 
 ```bash
 pip install ogx-client
-ogx-client configure --endpoint https://your-endpoint
+ogx-client configure --endpoint https://llama-stack.together.ai
 ogx-client models list
 ```

--- a/docs/docs/distributions/remote_hosted_distro/index.mdx
+++ b/docs/docs/distributions/remote_hosted_distro/index.mdx
@@ -2,10 +2,10 @@
 
 Remote-hosted distributions are OGX endpoints hosted by partners that you can connect to directly.
 
-| Distribution | Endpoint | Inference |
-|-------------|----------|-----------|
-| Together | [https://ogx.together.ai](https://ogx.together.ai) | remote::together |
-| Fireworks | [https://ogx-preview.fireworks.ai](https://ogx-preview.fireworks.ai) | remote::fireworks |
+| Distribution | Description |
+|-------------|-------------|
+| [watsonx](./watsonx) | IBM watsonx-backed distribution (`remote::watsonx`) |
+| [OCI](./oci) | Oracle Cloud Infrastructure-backed distribution (`remote::oci`) |
 
 ## Connecting
 
@@ -15,8 +15,8 @@ Point any OpenAI-compatible client at the endpoint:
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://ogx.together.ai/v1",
-    api_key="your-together-api-key",
+    base_url="https://your-endpoint/v1",
+    api_key="your-api-key",
 )
 
 response = client.chat.completions.create(
@@ -30,6 +30,6 @@ Or use the CLI:
 
 ```bash
 pip install ogx-client
-ogx-client configure --endpoint https://ogx.together.ai
+ogx-client configure --endpoint https://your-endpoint
 ogx-client models list
 ```


### PR DESCRIPTION
Fixes #4610.

The Remote-Hosted Distributions page listed Together (`ogx.together.ai`) and Fireworks (`ogx-preview.fireworks.ai`) endpoints that return 404. A maintainer confirmed on the issue that these endpoints no longer exist and should be removed. This replaces them with the actual remote-hosted distributions already in the repo (watsonx and OCI) and uses a neutral placeholder endpoint in the connection examples.

Docs-only change to `docs/docs/distributions/remote_hosted_distro/index.mdx`; both new table links resolve to existing pages in the same directory.

Note: the same dead `ogx.together.ai` endpoint also appears as an illustrative example in two notebook tutorials (`docs/getting_started.ipynb`, `docs/zero_to_hero_guide/Tool_Calling101_Using_Together_Llama_Stack_Server.ipynb`). I left those out to keep this focused on the page from the issue, but happy to follow up if maintainers want them cleaned too.