### PR TITLE
fix(nvidia): log when dynamic model listing fails instead of silently returning empty

### DIFF
--- a/src/ogx/providers/remote/inference/nvidia/nvidia.py
+++ b/src/ogx/providers/remote/inference/nvidia/nvidia.py
@@ -83,8 +83,15 @@ class NVIDIAInferenceAdapter(OpenAIMixin):
         dynamic_ids: Iterable[str] = []
         try:
             dynamic_ids = await super().list_provider_model_ids()
-        except Exception:
-            # If the dynamic listing fails, proceed with just configured rerank IDs
+        except Exception as e:
+            # Proceed with just the configured rerank IDs, but surface the failure so a
+            # misconfiguration (e.g. missing or invalid API key) is not silently reduced
+            # to an empty model list.
+            logger.warning(
+                "Failed to list dynamic models from NVIDIA endpoint; returning only configured rerank models",
+                base_url=str(self.config.base_url),
+                error=str(e),
+            )
             dynamic_ids = []
 
         configured_rerank_ids = list(self.config.rerank_model_to_url.keys())

--- a/tests/unit/providers/nvidia/test_rerank_inference.py
+++ b/tests/unit/providers/nvidia/test_rerank_inference.py
@@ -259,3 +259,19 @@ async def test_list_provider_model_ids_uses_configured_on_dynamic_failure():
     # Should still return configured rerank ids
     configured_ids = list(adapter.config.rerank_model_to_url.keys())
     assert set(ids) == set(configured_ids)
+
+
+async def test_list_provider_model_ids_logs_on_dynamic_failure():
+    """A dynamic listing failure is surfaced via a warning, not silently swallowed (issue #4320)."""
+    adapter = create_adapter()
+
+    error = Exception("401 invalid api key")
+    with (
+        patch.object(OpenAIMixin, "list_provider_model_ids", new=AsyncMock(side_effect=error)),
+        patch("ogx.providers.remote.inference.nvidia.nvidia.logger") as mock_logger,
+    ):
+        await adapter.list_provider_model_ids()
+
+    mock_logger.warning.assert_called_once()
+    # The original error text is included so the misconfiguration is diagnosable.
+    assert "401 invalid api key" in str(mock_logger.warning.call_args)


### PR DESCRIPTION
Fixes #4320.

`NVIDIAInferenceAdapter.list_provider_model_ids` wrapped the dynamic model listing in a bare `except Exception` that discarded the error and returned only the statically configured rerank models. The parent `OpenAIMixin.list_models` is designed to log and re-raise listing failures, but this override swallowed them, so a misconfiguration (e.g. missing or invalid `NVIDIA_API_KEY` on the hosted endpoint) produced an empty `/v1/models` response with only a startup-time log and no signal at query time. This matches the reproduction in the issue.

This logs a warning with the underlying error so the failure is diagnosable, while keeping the existing fallback to configured rerank models (so rerank still works even if the dynamic list is unavailable). Behavior is otherwise unchanged.

Test command and result:
`uv run pytest tests/unit/providers/nvidia/test_rerank_inference.py -q` -> 13 passed. Added `test_list_provider_model_ids_logs_on_dynamic_failure`, which asserts the failure is logged and the original error text is included. `ruff check` and `ruff format --check` pass on the changed files.