### PR TITLE
feat(telemetry): add agentic depth and RAG depth metrics

### DIFF
--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -22,6 +22,7 @@ from ogx.providers.utils.inference.inference_store import InferenceStore
 from ogx.telemetry.inference_metrics import (
     create_inference_metric_attributes,
     inference_duration,
+    inference_model_type_used_total,
     inference_time_to_first_token,
     inference_tokens_per_second,
 )
@@ -170,7 +171,11 @@ class InferenceRouter(Inference):
         self,
         params: RerankRequest,
     ) -> RerankResponse:
+        request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.rerank)
+        inference_model_type_used_total.add(
+            1, {"type": "reranker", "model": request_model_id, "provider": provider.__provider_id__}
+        )
         params.model = provider_resource_id
         return await provider.rerank(params)
 
@@ -186,6 +191,9 @@ class InferenceRouter(Inference):
         )
         request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
+        inference_model_type_used_total.add(
+            1, {"type": "completion", "model": request_model_id, "provider": provider.__provider_id__}
+        )
         params.model = provider_resource_id
 
         if params.stream:
@@ -207,6 +215,9 @@ class InferenceRouter(Inference):
         )
         request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
+        inference_model_type_used_total.add(
+            1, {"type": "completion", "model": request_model_id, "provider": provider.__provider_id__}
+        )
         params.model = provider_resource_id
 
         # Use the OpenAI client for a bit of extra input validation without
@@ -288,7 +299,11 @@ class InferenceRouter(Inference):
         handles mapping reasoning fields to/from the provider's format.
         If the provider doesn't support reasoning, raises an error.
         """
+        request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
+        inference_model_type_used_total.add(
+            1, {"type": "completion", "model": request_model_id, "provider": provider.__provider_id__}
+        )
         params.model = provider_resource_id
         # Not all providers implement openai_chat_completions_with_reasoning.
         # the Responses layer catches them and falls back to regular CC
@@ -308,6 +323,9 @@ class InferenceRouter(Inference):
         )
         request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.embedding)
+        inference_model_type_used_total.add(
+            1, {"type": "embedding", "model": request_model_id, "provider": provider.__provider_id__}
+        )
         params.model = provider_resource_id
 
         response = await provider.openai_embeddings(params)

--- a/src/ogx/core/routers/vector_io.py
+++ b/src/ogx/core/routers/vector_io.py
@@ -18,6 +18,7 @@ from ogx.telemetry.vector_io_metrics import (
     create_vector_metric_attributes,
     vector_chunks_processed_total,
     vector_deletes_total,
+    vector_documents_retrieved_total,
     vector_files_total,
     vector_insert_duration,
     vector_inserts_total,
@@ -239,6 +240,7 @@ class VectorIORouter(VectorIO):
             duration = time.perf_counter() - start_time
             success_attrs = {**metric_attrs, "status": "success"}
             vector_queries_total.add(1, success_attrs)
+            vector_documents_retrieved_total.add(len(result.chunks), success_attrs)
             vector_retrieval_duration.record(duration, metric_attrs)
             return result
         except asyncio.CancelledError:
@@ -503,6 +505,7 @@ class VectorIORouter(VectorIO):
             duration = time.perf_counter() - start_time
             success_attrs = {**metric_attrs, "status": "success"}
             vector_queries_total.add(1, success_attrs)
+            vector_documents_retrieved_total.add(len(result.data), success_attrs)
             vector_retrieval_duration.record(duration, metric_attrs)
             return result
         except asyncio.CancelledError:

--- a/src/ogx/providers/inline/responses/builtin/impl.py
+++ b/src/ogx/providers/inline/responses/builtin/impl.py
@@ -15,7 +15,11 @@ from opentelemetry import metrics
 from ogx.core.datatypes import AccessRule
 from ogx.log import get_logger
 from ogx.providers.utils.responses.responses_store import ResponsesStore
-from ogx.telemetry.constants import RESPONSES_PARAMETER_USAGE_TOTAL
+from ogx.telemetry.constants import (
+    RESPONSES_AGENTIC_CALLS_TOTAL,
+    RESPONSES_PARAMETER_USAGE_TOTAL,
+    RESPONSES_TOOL_TYPES_USED_TOTAL,
+)
 from ogx_api import (
     CancelResponseRequest,
     CompactResponseRequest,
@@ -39,6 +43,7 @@ from ogx_api import (
     ToolGroups,
     ToolRuntime,
     VectorIO,
+    WebSearchToolTypes,
 )
 
 from .config import BuiltinResponsesImplConfig
@@ -54,6 +59,18 @@ _parameter_usage_total = _meter.create_counter(
     unit="1",
 )
 
+_tool_types_used_total = _meter.create_counter(
+    name=RESPONSES_TOOL_TYPES_USED_TOTAL,
+    description="Counts tool types present in Responses API calls",
+    unit="1",
+)
+
+_agentic_calls_total = _meter.create_counter(
+    name=RESPONSES_AGENTIC_CALLS_TOTAL,
+    description="Total Responses API calls that include tools (agentic calls)",
+    unit="1",
+)
+
 _REQUIRED_FIELDS = {"input", "model"}
 
 
@@ -62,6 +79,21 @@ def _record_parameter_usage(request: CreateResponseRequest, operation: str) -> N
     declared_fields = set(request.model_fields.keys())
     for field_name in (request.model_fields_set & declared_fields) - _REQUIRED_FIELDS:
         _parameter_usage_total.add(1, {"operation": operation, "parameter": field_name})
+
+
+def _record_tool_usage(request: CreateResponseRequest) -> None:
+    """Record tool type usage and agentic call counts."""
+    if not request.tools:
+        return
+    _agentic_calls_total.add(1)
+    seen_types: set[str] = set()
+    for tool in request.tools:
+        tool_type = tool.type
+        if tool_type in WebSearchToolTypes:
+            tool_type = "web_search"
+        if tool_type not in seen_types:
+            seen_types.add(tool_type)
+            _tool_types_used_total.add(1, {"tool_type": tool_type})
 
 
 class BuiltinResponsesImpl(Responses):
@@ -140,6 +172,7 @@ class BuiltinResponsesImpl(Responses):
         yielding response stream events (streaming).
         """
         _record_parameter_usage(request, operation="create_response")
+        _record_tool_usage(request)
         assert self.openai_responses_impl is not None, "OpenAI responses not initialized"
         result = await self.openai_responses_impl.create_openai_response(request)
         return result

--- a/src/ogx/telemetry/constants.py
+++ b/src/ogx/telemetry/constants.py
@@ -33,6 +33,7 @@ VECTOR_DELETES_TOTAL = f"{VECTOR_IO_PREFIX}.deletes_total"
 VECTOR_STORES_TOTAL = f"{VECTOR_IO_PREFIX}.stores_total"
 VECTOR_FILES_TOTAL = f"{VECTOR_IO_PREFIX}.files_total"
 VECTOR_CHUNKS_PROCESSED_TOTAL = f"{VECTOR_IO_PREFIX}.chunks_processed_total"
+VECTOR_DOCUMENTS_RETRIEVED_TOTAL = f"{VECTOR_IO_PREFIX}.documents_retrieved_total"
 
 # Vector operation durations
 VECTOR_INSERT_DURATION = f"{VECTOR_IO_PREFIX}.insert_duration_seconds"
@@ -53,7 +54,10 @@ INFERENCE_PREFIX = f"{ogx_prefix}.inference"
 INFERENCE_DURATION = f"{INFERENCE_PREFIX}.duration_seconds"
 INFERENCE_TIME_TO_FIRST_TOKEN = f"{INFERENCE_PREFIX}.time_to_first_token_seconds"
 INFERENCE_TOKENS_PER_SECOND = f"{INFERENCE_PREFIX}.tokens_per_second"
+INFERENCE_MODEL_TYPE_USED_TOTAL = f"{INFERENCE_PREFIX}.model_type_used_total"
 
 # Responses API Metrics
 RESPONSES_PREFIX = f"{ogx_prefix}.responses"
 RESPONSES_PARAMETER_USAGE_TOTAL = f"{RESPONSES_PREFIX}.parameter_usage_total"
+RESPONSES_TOOL_TYPES_USED_TOTAL = f"{RESPONSES_PREFIX}.tool_types_used_total"
+RESPONSES_AGENTIC_CALLS_TOTAL = f"{RESPONSES_PREFIX}.agentic_calls_total"

--- a/src/ogx/telemetry/inference_metrics.py
+++ b/src/ogx/telemetry/inference_metrics.py
@@ -17,10 +17,11 @@ for consistent naming across the telemetry stack.
 """
 
 from opentelemetry import metrics
-from opentelemetry.metrics import Histogram
+from opentelemetry.metrics import Counter, Histogram
 
 from .constants import (
     INFERENCE_DURATION,
+    INFERENCE_MODEL_TYPE_USED_TOTAL,
     INFERENCE_TIME_TO_FIRST_TOKEN,
     INFERENCE_TOKENS_PER_SECOND,
 )
@@ -43,6 +44,12 @@ inference_time_to_first_token: Histogram = meter.create_histogram(
 inference_tokens_per_second: Histogram = meter.create_histogram(
     name=INFERENCE_TOKENS_PER_SECOND,
     description="Output token throughput (completion tokens / duration)",
+)
+
+inference_model_type_used_total: Counter = meter.create_counter(
+    name=INFERENCE_MODEL_TYPE_USED_TOTAL,
+    description="Total inference calls by model type (completion, embedding, reranker)",
+    unit="1",
 )
 
 

--- a/src/ogx/telemetry/vector_io_metrics.py
+++ b/src/ogx/telemetry/vector_io_metrics.py
@@ -22,6 +22,7 @@ from opentelemetry.metrics import Counter, Histogram
 from .constants import (
     VECTOR_CHUNKS_PROCESSED_TOTAL,
     VECTOR_DELETES_TOTAL,
+    VECTOR_DOCUMENTS_RETRIEVED_TOTAL,
     VECTOR_FILES_TOTAL,
     VECTOR_INSERT_DURATION,
     VECTOR_INSERTS_TOTAL,
@@ -67,6 +68,12 @@ vector_files_total: Counter = meter.create_counter(
 vector_chunks_processed_total: Counter = meter.create_counter(
     name=VECTOR_CHUNKS_PROCESSED_TOTAL,
     description="Total number of chunks processed across all insert operations",
+    unit="1",
+)
+
+vector_documents_retrieved_total: Counter = meter.create_counter(
+    name=VECTOR_DOCUMENTS_RETRIEVED_TOTAL,
+    description="Total number of documents/chunks retrieved across query operations",
     unit="1",
 )
 

--- a/tests/unit/telemetry/test_inference_metrics.py
+++ b/tests/unit/telemetry/test_inference_metrics.py
@@ -15,6 +15,7 @@ from ogx.core.routers.inference import InferenceRouter
 from ogx.telemetry.inference_metrics import (
     create_inference_metric_attributes,
     inference_duration,
+    inference_model_type_used_total,
     inference_time_to_first_token,
     inference_tokens_per_second,
 )
@@ -81,6 +82,15 @@ class TestInferenceMetricInstruments:
         assert inference_tokens_per_second is not None
         assert hasattr(inference_tokens_per_second, "record")
 
+    def test_inference_model_type_used_total_exists(self):
+        assert inference_model_type_used_total is not None
+        assert hasattr(inference_model_type_used_total, "add")
+
+    def test_inference_model_type_used_total_can_record(self):
+        inference_model_type_used_total.add(
+            1, {"type": "completion", "model": "openai/gpt-4o-mini", "provider": "openai"}
+        )
+
     def test_inference_duration_can_record(self):
         attrs = create_inference_metric_attributes(
             model="openai/gpt-4o-mini",
@@ -115,6 +125,7 @@ class TestInferenceMetricsConstants:
     def test_metric_names_follow_convention(self):
         from ogx.telemetry.constants import (
             INFERENCE_DURATION,
+            INFERENCE_MODEL_TYPE_USED_TOTAL,
             INFERENCE_TIME_TO_FIRST_TOKEN,
             INFERENCE_TOKENS_PER_SECOND,
         )
@@ -122,13 +133,16 @@ class TestInferenceMetricsConstants:
         assert INFERENCE_DURATION.startswith("ogx.")
         assert INFERENCE_TIME_TO_FIRST_TOKEN.startswith("ogx.")
         assert INFERENCE_TOKENS_PER_SECOND.startswith("ogx.")
+        assert INFERENCE_MODEL_TYPE_USED_TOTAL.startswith("ogx.")
 
         assert "inference" in INFERENCE_DURATION
         assert "inference" in INFERENCE_TIME_TO_FIRST_TOKEN
         assert "inference" in INFERENCE_TOKENS_PER_SECOND
+        assert "inference" in INFERENCE_MODEL_TYPE_USED_TOTAL
 
         assert INFERENCE_DURATION.endswith("_seconds")
         assert INFERENCE_TIME_TO_FIRST_TOKEN.endswith("_seconds")
+        assert INFERENCE_MODEL_TYPE_USED_TOTAL.endswith("_total")
 
 
 def _make_router_and_provider():
@@ -389,3 +403,86 @@ class TestStreamingInferenceMetrics:
             mock_record.assert_called_once()
             attrs = mock_record.call_args[1]["attributes"]
             assert attrs["status"] == "error"
+
+
+class TestModelTypeUsedMetrics:
+    """Test that inference router records model_type_used_total for each entry point."""
+
+    async def test_chat_completion_records_completion_type(self):
+        router, mock_provider = _make_router_and_provider()
+        mock_provider.openai_chat_completion = AsyncMock(return_value=_make_completion_response())
+        params = _make_chat_params(stream=False)
+
+        with patch.object(inference_model_type_used_total, "add") as mock_add:
+            await router.openai_chat_completion(params)
+
+            mock_add.assert_called_once()
+            attrs = mock_add.call_args[0][1]
+            assert attrs["type"] == "completion"
+            assert attrs["model"] == "openai/gpt-4o-mini"
+            assert attrs["provider"] == "openai"
+
+    async def test_embeddings_records_embedding_type(self):
+        routing_table = MagicMock()
+        mock_model = MagicMock()
+        mock_model.identifier = "openai/text-embedding-3-small"
+        mock_model.model_type = ModelType.embedding
+        mock_model.provider_resource_id = "text-embedding-3-small"
+
+        mock_provider = AsyncMock()
+        mock_provider.__provider_id__ = "openai"
+        mock_provider.openai_embeddings = AsyncMock(return_value=MagicMock(model="text-embedding-3-small"))
+
+        routing_table.get_object_by_identifier = AsyncMock(return_value=mock_model)
+        routing_table.get_provider_impl = AsyncMock(return_value=mock_provider)
+
+        router = InferenceRouter(routing_table=routing_table)
+
+        from ogx_api import OpenAIEmbeddingsRequestWithExtraBody
+
+        params = OpenAIEmbeddingsRequestWithExtraBody(
+            model="openai/text-embedding-3-small",
+            input="test text",
+        )
+
+        with patch.object(inference_model_type_used_total, "add") as mock_add:
+            await router.openai_embeddings(params)
+
+            mock_add.assert_called_once()
+            attrs = mock_add.call_args[0][1]
+            assert attrs["type"] == "embedding"
+            assert attrs["model"] == "openai/text-embedding-3-small"
+            assert attrs["provider"] == "openai"
+
+    async def test_rerank_records_reranker_type(self):
+        routing_table = MagicMock()
+        mock_model = MagicMock()
+        mock_model.identifier = "cohere/rerank-v3"
+        mock_model.model_type = ModelType.rerank
+        mock_model.provider_resource_id = "rerank-v3"
+
+        mock_provider = AsyncMock()
+        mock_provider.__provider_id__ = "cohere"
+        mock_provider.rerank = AsyncMock(return_value=MagicMock())
+
+        routing_table.get_object_by_identifier = AsyncMock(return_value=mock_model)
+        routing_table.get_provider_impl = AsyncMock(return_value=mock_provider)
+
+        router = InferenceRouter(routing_table=routing_table)
+
+        from ogx_api.inference.models import RerankRequest
+
+        params = RerankRequest(
+            model="cohere/rerank-v3",
+            query="test query",
+            items=["doc1", "doc2"],
+        )
+
+        with patch.object(inference_model_type_used_total, "add") as mock_add:
+            await router.rerank(params)
+
+            mock_add.assert_called_once()
+            attrs = mock_add.call_args[0][1]
+            assert attrs["type"] == "reranker"
+            assert attrs["model"] == "cohere/rerank-v3"
+            assert attrs["provider"] == "cohere"

--- a/tests/unit/telemetry/test_responses_metrics.py
+++ b/tests/unit/telemetry/test_responses_metrics.py
@@ -1,0 +1,161 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for responses API metrics (tool types and agentic calls)."""
+
+from unittest.mock import MagicMock, patch
+
+from ogx.providers.inline.responses.builtin.impl import (
+    _agentic_calls_total,
+    _record_tool_usage,
+    _tool_types_used_total,
+)
+
+
+class TestResponsesMetricInstruments:
+    """Test that metric instruments are properly defined."""
+
+    def test_tool_types_used_total_exists(self):
+        assert _tool_types_used_total is not None
+        assert hasattr(_tool_types_used_total, "add")
+
+    def test_agentic_calls_total_exists(self):
+        assert _agentic_calls_total is not None
+        assert hasattr(_agentic_calls_total, "add")
+
+    def test_counters_can_record(self):
+        _tool_types_used_total.add(1, {"tool_type": "function"})
+        _agentic_calls_total.add(1)
+
+
+class TestResponsesMetricsConstants:
+    """Test that metric constants follow naming conventions."""
+
+    def test_metric_names_follow_convention(self):
+        from ogx.telemetry.constants import (
+            RESPONSES_AGENTIC_CALLS_TOTAL,
+            RESPONSES_TOOL_TYPES_USED_TOTAL,
+        )
+
+        assert RESPONSES_TOOL_TYPES_USED_TOTAL.startswith("ogx.")
+        assert RESPONSES_AGENTIC_CALLS_TOTAL.startswith("ogx.")
+
+        assert "responses" in RESPONSES_TOOL_TYPES_USED_TOTAL
+        assert "responses" in RESPONSES_AGENTIC_CALLS_TOTAL
+
+        assert RESPONSES_TOOL_TYPES_USED_TOTAL.endswith("_total")
+        assert RESPONSES_AGENTIC_CALLS_TOTAL.endswith("_total")
+
+
+class TestRecordToolUsage:
+    """Test _record_tool_usage function."""
+
+    def test_no_tools_records_nothing(self):
+        request = MagicMock()
+        request.tools = None
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_not_called()
+            mock_types.assert_not_called()
+
+    def test_empty_tools_records_nothing(self):
+        request = MagicMock()
+        request.tools = []
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_not_called()
+            mock_types.assert_not_called()
+
+    def test_function_tool_records_both_counters(self):
+        tool = MagicMock()
+        tool.type = "function"
+        request = MagicMock()
+        request.tools = [tool]
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_called_once_with(1)
+            mock_types.assert_called_once_with(1, {"tool_type": "function"})
+
+    def test_multiple_tool_types_records_each_once(self):
+        func_tool = MagicMock()
+        func_tool.type = "function"
+        mcp_tool = MagicMock()
+        mcp_tool.type = "mcp"
+        request = MagicMock()
+        request.tools = [func_tool, mcp_tool]
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_called_once_with(1)
+            assert mock_types.call_count == 2
+            tool_types_recorded = {call[0][1]["tool_type"] for call in mock_types.call_args_list}
+            assert tool_types_recorded == {"function", "mcp"}
+
+    def test_duplicate_tool_types_deduplicated(self):
+        func1 = MagicMock()
+        func1.type = "function"
+        func2 = MagicMock()
+        func2.type = "function"
+        request = MagicMock()
+        request.tools = [func1, func2]
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_called_once_with(1)
+            mock_types.assert_called_once_with(1, {"tool_type": "function"})
+
+    def test_web_search_variants_normalized(self):
+        ws_preview = MagicMock()
+        ws_preview.type = "web_search_preview"
+        ws_regular = MagicMock()
+        ws_regular.type = "web_search"
+        request = MagicMock()
+        request.tools = [ws_preview, ws_regular]
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_called_once_with(1)
+            mock_types.assert_called_once_with(1, {"tool_type": "web_search"})
+
+    def test_all_four_tool_types(self):
+        tools = []
+        for t in ["web_search", "file_search", "function", "mcp"]:
+            tool = MagicMock()
+            tool.type = t
+            tools.append(tool)
+        request = MagicMock()
+        request.tools = tools
+
+        with (
+            patch.object(_agentic_calls_total, "add") as mock_agentic,
+            patch.object(_tool_types_used_total, "add") as mock_types,
+        ):
+            _record_tool_usage(request)
+            mock_agentic.assert_called_once_with(1)
+            assert mock_types.call_count == 4
+            tool_types_recorded = {call[0][1]["tool_type"] for call in mock_types.call_args_list}
+            assert tool_types_recorded == {"web_search", "file_search", "function", "mcp"}

--- a/tests/unit/telemetry/test_vector_io_metrics.py
+++ b/tests/unit/telemetry/test_vector_io_metrics.py
@@ -16,6 +16,7 @@ from ogx.telemetry.vector_io_metrics import (
     create_vector_metric_attributes,
     vector_chunks_processed_total,
     vector_deletes_total,
+    vector_documents_retrieved_total,
     vector_files_total,
     vector_insert_duration,
     vector_inserts_total,
@@ -70,6 +71,7 @@ class TestVectorMetricInstruments:
             vector_stores_total,
             vector_files_total,
             vector_chunks_processed_total,
+            vector_documents_retrieved_total,
         ]:
             assert counter is not None
             assert hasattr(counter, "add")
@@ -93,6 +95,7 @@ class TestVectorMetricInstruments:
         vector_stores_total.add(1, attrs)
         vector_files_total.add(1, attrs)
         vector_chunks_processed_total.add(10, attrs)
+        vector_documents_retrieved_total.add(3, attrs)
 
     def test_histograms_can_record(self):
         attrs = create_vector_metric_attributes(
@@ -111,6 +114,7 @@ class TestVectorMetricsConstants:
         from ogx.telemetry.constants import (
             VECTOR_CHUNKS_PROCESSED_TOTAL,
             VECTOR_DELETES_TOTAL,
+            VECTOR_DOCUMENTS_RETRIEVED_TOTAL,
             VECTOR_FILES_TOTAL,
             VECTOR_INSERT_DURATION,
             VECTOR_INSERTS_TOTAL,
@@ -126,6 +130,7 @@ class TestVectorMetricsConstants:
             VECTOR_STORES_TOTAL,
             VECTOR_FILES_TOTAL,
             VECTOR_CHUNKS_PROCESSED_TOTAL,
+            VECTOR_DOCUMENTS_RETRIEVED_TOTAL,
         ]:
             assert name.startswith("ogx.")
             assert "vector_io" in name
@@ -214,6 +219,7 @@ class TestVectorIORouterMetricsIntegration:
     async def test_query_chunks_records_metrics(self):
         router, mock_rt = self._create_mock_router()
         mock_result = MagicMock()
+        mock_result.chunks = [MagicMock() for _ in range(7)]
         mock_rt.query_chunks = AsyncMock(return_value=mock_result)
 
         mock_request = MagicMock()
@@ -223,6 +229,7 @@ class TestVectorIORouterMetricsIntegration:
 
         with (
             patch.object(vector_queries_total, "add") as mock_counter,
+            patch.object(vector_documents_retrieved_total, "add") as mock_docs,
             patch.object(vector_retrieval_duration, "record") as mock_duration,
         ):
             result = await router.query_chunks(mock_request)
@@ -234,11 +241,15 @@ class TestVectorIORouterMetricsIntegration:
             assert attrs["operation"] == "query"
             assert attrs["search_mode"] == "vector"
 
+            mock_docs.assert_called_once()
+            assert mock_docs.call_args[0][0] == 7
+
             mock_duration.assert_called_once()
 
     async def test_search_vector_store_records_metrics(self):
         router, mock_rt = self._create_mock_router()
         mock_result = MagicMock()
+        mock_result.data = [MagicMock() for _ in range(4)]
         mock_rt.openai_search_vector_store = AsyncMock(return_value=mock_result)
 
         mock_request = MagicMock()
@@ -249,6 +260,7 @@ class TestVectorIORouterMetricsIntegration:
 
         with (
             patch.object(vector_queries_total, "add") as mock_counter,
+            patch.object(vector_documents_retrieved_total, "add") as mock_docs,
             patch.object(vector_retrieval_duration, "record") as mock_duration,
         ):
             result = await router.openai_search_vector_store("vs_test", mock_request)
@@ -259,6 +271,9 @@ class TestVectorIORouterMetricsIntegration:
             assert attrs["status"] == "success"
             assert attrs["operation"] == "search"
             assert attrs["search_mode"] == "hybrid"
+
+            mock_docs.assert_called_once()
+            assert mock_docs.call_args[0][0] == 4
 
             mock_duration.assert_called_once()
 


### PR DESCRIPTION
## Summary

- Add `ogx.responses.tool_types_used_total{tool_type}` and `ogx.responses.agentic_calls_total` counters to track agentic tool usage in the Responses API
- Add `ogx.vector_io.documents_retrieved_total` counter to track chunks/documents returned from vector query operations
- Add `ogx.inference.model_type_used_total{type,model,provider}` counter to track inference calls by model type (completion, embedding, reranker)
- Web search tool type variants are normalized to `web_search` to keep cardinality at 4 values
- Tool types are deduplicated per request (each type counted once)

## Test plan

- [x] Unit tests for all four new counters (constants, instruments, integration)
- [x] New `test_responses_metrics.py` with 8 tests covering tool usage recording, deduplication, and normalization
- [x] Updated `test_vector_io_metrics.py` with documents_retrieved_total assertions
- [x] Updated `test_inference_metrics.py` with model_type_used_total for chat completion, embeddings, and rerank
- [x] All 97 telemetry tests pass
- [x] Pre-commit checks pass (including mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)