### PR TITLE
fix(watsonx): apply network config to IAM token and model spec requests

### DIFF
--- a/src/ogx/providers/remote/inference/watsonx/watsonx.py
+++ b/src/ogx/providers/remote/inference/watsonx/watsonx.py
@@ -14,6 +14,7 @@ from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 
 from ogx.log import get_logger
 from ogx.providers.remote.inference.watsonx.config import WatsonXConfig
+from ogx.providers.utils.inference.http_client import build_network_client_kwargs
 from ogx.providers.utils.inference.openai_mixin import OpenAIMixin
 from ogx_api import (
     Model,
@@ -105,7 +106,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
 
     async def _exchange_iam_token(self, api_key: str) -> str:
         try:
-            async with httpx.AsyncClient() as http_client:
+            async with httpx.AsyncClient(**build_network_client_kwargs(self.config.network)) as http_client:
                 resp = await http_client.post(
                     "https://iam.cloud.ibm.com/identity/token",
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -240,7 +241,7 @@ class WatsonXInferenceAdapter(OpenAIMixin):
     async def _fetch_model_specs(self) -> list[dict[str, Any]]:
         """Retrieve foundation model specifications from the WatsonX API."""
         url = f"{str(self.config.base_url)}/ml/v1/foundation_model_specs?version={WATSONX_API_VERSION}"
-        async with httpx.AsyncClient() as http_client:
+        async with httpx.AsyncClient(**build_network_client_kwargs(self.config.network)) as http_client:
             response = await http_client.get(url, headers={"Content-Type": "application/json"}, timeout=30)
             response.raise_for_status()
             data = response.json()

--- a/tests/unit/providers/inference/test_watsonx_token_refresh.py
+++ b/tests/unit/providers/inference/test_watsonx_token_refresh.py
@@ -13,8 +13,9 @@ from ogx.providers.remote.inference.watsonx.watsonx import WatsonXInferenceAdapt
 
 
 class _FailingIamClient:
-    def __init__(self, calls: list[int]) -> None:
+    def __init__(self, calls: list[int], client_kwargs: dict | None = None) -> None:
         self._calls = calls
+        self.client_kwargs = client_kwargs or {}
 
     async def __aenter__(self) -> "_FailingIamClient":
         return self
@@ -36,10 +37,38 @@ async def test_refresh_iam_token_deduplicates_concurrent_failures(monkeypatch):
 
     monkeypatch.setattr(
         "ogx.providers.remote.inference.watsonx.watsonx.httpx.AsyncClient",
-        lambda: _FailingIamClient(calls),
+        lambda **kwargs: _FailingIamClient(calls),
     )
 
     results = await asyncio.gather(*(adapter._refresh_iam_token("watsonx-api-key") for _ in range(3)))
 
     assert results == ["watsonx-api-key", "watsonx-api-key", "watsonx-api-key"]
     assert len(calls) == 1
+
+
+async def test_iam_token_exchange_applies_network_tls_config(monkeypatch):
+    """IAM token exchange builds its httpx client with the provider's network config (issue #6251)."""
+    from ogx.providers.utils.inference.model_registry import NetworkConfig, TLSConfig
+
+    adapter = WatsonXInferenceAdapter(
+        config=WatsonXConfig(
+            base_url="https://us-south.ml.cloud.ibm.com",
+            network=NetworkConfig(tls=TLSConfig(verify=False)),
+        ),
+    )
+    captured: dict = {}
+
+    def _make_client(**kwargs):
+        captured.update(kwargs)
+        return _FailingIamClient([], kwargs)
+
+    monkeypatch.setattr(
+        "ogx.providers.remote.inference.watsonx.watsonx.httpx.AsyncClient",
+        _make_client,
+    )
+
+    await adapter._exchange_iam_token("watsonx-api-key")
+
+    # The network config must reach the client (verify=False -> a "verify" kwarg is present),
+    # rather than the client being constructed with no TLS arguments.
+    assert "verify" in captured


### PR DESCRIPTION
Fixes #6251.

The WatsonX provider makes two HTTP calls with bare `httpx.AsyncClient()` that bypass the provider's `network` configuration:
- IAM token exchange (`_exchange_iam_token`)
- Foundation model spec fetch (`_fetch_model_specs`)

The rest of the adapter already applies TLS via `shared_ssl_context`/`DefaultAsyncHttpxClient`, so these two clients were inconsistent and ignored `network.tls` (and proxy/timeout). This builds both clients with `build_network_client_kwargs(self.config.network)`, the same helper `OpenAIMixin` uses. When `network` is unset the helper returns no kwargs, so behavior is unchanged for existing configs.

Test command and result:
`uv run pytest tests/unit/providers/inference/test_watsonx_token_refresh.py -q` -> 2 passed. Added `test_iam_token_exchange_applies_network_tls_config`, which sets `network.tls` and asserts the resulting httpx client receives a `verify` kwarg (it fails against the previous bare-client code). `ruff check` and `ruff format --check` pass on the changed files.