### PR TITLE
feat: add resource attributes to distinguish by namespace and cluster

### DIFF
--- a/docs/docs/building_applications/telemetry.mdx
+++ b/docs/docs/building_applications/telemetry.mdx
@@ -272,9 +272,29 @@ Jaeger ingests traces only, not logs. If you set `OTEL_LOGS_EXPORTER=otlp` and p
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | *(none)* | OTLP endpoint URL. Metrics and traces are only exported when set. |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` | Transport protocol for OTLP export |
 | `OTEL_SERVICE_NAME` | `ogx` | Service name tag on all telemetry data |
+| `OTEL_SERVICE_NAMESPACE` | *(none)* | Namespace identity for this OGX instance (e.g. the Kubernetes namespace). Falls back to `NAMESPACE` env var if unset. |
+| `NAMESPACE` | *(none)* | Kubernetes namespace (typically injected via the downward API). Used as fallback when `OTEL_SERVICE_NAMESPACE` is not set. |
+| `CLUSTER_ID` | *(none)* | Cluster identity for multi-cluster metric aggregation. Sets the `k8s.cluster.uid` OTel Resource attribute. |
 | `OTEL_METRIC_EXPORT_INTERVAL` | `60000` | Metric export interval in milliseconds |
 | `OTEL_PYTHON_DISABLED_INSTRUMENTATIONS` | *(none)* | Comma-separated list of instrumentors to disable |
 | `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | `false` | Capture prompt/response text as log events |
+
+## Resource identity attributes
+
+OGX attaches [OTel Resource attributes](https://opentelemetry.io/docs/specs/semconv/resource/) to
+all metrics emitted by the MeterProvider. These attributes identify the OGX instance and appear on
+both the OTLP push and Prometheus scrape export paths.
+
+| Resource attribute | Source env var | Use case |
+|---|---|---|
+| `service.name` | `OTEL_SERVICE_NAME` (default `ogx`) | Identifies the service in dashboards and traces |
+| `service.namespace` | `OTEL_SERVICE_NAMESPACE` or `NAMESPACE` | Distinguishes OGX instances in multi-namespace Kubernetes deployments |
+| `k8s.cluster.uid` | `CLUSTER_ID` | Distinguishes clusters when aggregating metrics from multiple clusters into a single monitoring backend |
+
+All identity attributes are optional. When an env var is unset or empty, the corresponding attribute
+is omitted — it does not appear as an empty string. The `NAMESPACE` env var is typically injected by
+the Kubernetes downward API (`fieldRef: metadata.namespace`) and requires no manual configuration.
+
 
 ## Known issues
 

--- a/src/ogx/telemetry/__init__.py
+++ b/src/ogx/telemetry/__init__.py
@@ -143,7 +143,17 @@ def setup_telemetry() -> None:
             logger.info("OpenTelemetry metrics scrape reader configured")
 
         service_name = os.environ.get("OTEL_SERVICE_NAME", "ogx")
-        resource = Resource(attributes={"service.name": service_name})
+        attributes: dict[str, str] = {"service.name": service_name}
+
+        namespace = os.environ.get("OTEL_SERVICE_NAMESPACE", "").strip() or os.environ.get("NAMESPACE", "").strip()
+        if namespace:
+            attributes["service.namespace"] = namespace
+
+        cluster_id = os.environ.get("CLUSTER_ID", "").strip()
+        if cluster_id:
+            attributes["k8s.cluster.uid"] = cluster_id
+
+        resource = Resource(attributes=attributes)
 
         provider = MeterProvider(resource=resource, metric_readers=metric_readers)
         metrics.set_meter_provider(provider)

--- a/tests/unit/telemetry/test_prometheus_metrics.py
+++ b/tests/unit/telemetry/test_prometheus_metrics.py
@@ -144,3 +144,73 @@ class TestPrometheusExposition:
         assert 'api="models"' in output
         assert 'status="success"' in output
         assert "3.0" in output
+
+
+class TestResourceAttributes:
+    """setup_telemetry() must populate OTel Resource attributes from environment variables."""
+
+    def _get_created_provider(self, monkeypatch):
+        """Helper: run setup_telemetry() with a fresh provider path and return the MeterProvider."""
+        monkeypatch.setenv("OGX_METRICS_ENDPOINT_ENABLED", "1")
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        monkeypatch.setattr("opentelemetry.exporter.prometheus.PrometheusMetricReader", InMemoryMetricReader)
+
+        set_calls: list = []
+        monkeypatch.setattr(otel_metrics, "get_meter_provider", object)
+        monkeypatch.setattr(otel_metrics, "set_meter_provider", set_calls.append)
+
+        setup_telemetry()
+
+        assert len(set_calls) == 1
+        provider = set_calls[0]
+        return provider
+
+    def test_namespace_from_otel_service_namespace(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SERVICE_NAMESPACE", "prod-ns")
+        monkeypatch.delenv("NAMESPACE", raising=False)
+        provider = self._get_created_provider(monkeypatch)
+        assert provider._sdk_config.resource.attributes["service.namespace"] == "prod-ns"
+        provider.shutdown()
+
+    def test_namespace_falls_back_to_namespace_env(self, monkeypatch):
+        monkeypatch.delenv("OTEL_SERVICE_NAMESPACE", raising=False)
+        monkeypatch.setenv("NAMESPACE", "k8s-downward-ns")
+        provider = self._get_created_provider(monkeypatch)
+        assert provider._sdk_config.resource.attributes["service.namespace"] == "k8s-downward-ns"
+        provider.shutdown()
+
+    def test_otel_service_namespace_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SERVICE_NAMESPACE", "otel-ns")
+        monkeypatch.setenv("NAMESPACE", "k8s-ns")
+        provider = self._get_created_provider(monkeypatch)
+        assert provider._sdk_config.resource.attributes["service.namespace"] == "otel-ns"
+        provider.shutdown()
+
+    def test_cluster_id_set(self, monkeypatch):
+        monkeypatch.setenv("CLUSTER_ID", "cluster-abc-123")
+        monkeypatch.delenv("OTEL_SERVICE_NAMESPACE", raising=False)
+        monkeypatch.delenv("NAMESPACE", raising=False)
+        provider = self._get_created_provider(monkeypatch)
+        assert provider._sdk_config.resource.attributes["k8s.cluster.uid"] == "cluster-abc-123"
+        provider.shutdown()
+
+    def test_attributes_omitted_when_unset(self, monkeypatch):
+        monkeypatch.delenv("OTEL_SERVICE_NAMESPACE", raising=False)
+        monkeypatch.delenv("NAMESPACE", raising=False)
+        monkeypatch.delenv("CLUSTER_ID", raising=False)
+        provider = self._get_created_provider(monkeypatch)
+        attrs = dict(provider._sdk_config.resource.attributes)
+        assert "service.namespace" not in attrs
+        assert "k8s.cluster.uid" not in attrs
+        assert "service.name" in attrs
+        provider.shutdown()
+
+    def test_empty_string_treated_as_unset(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SERVICE_NAMESPACE", "  ")
+        monkeypatch.setenv("NAMESPACE", "")
+        monkeypatch.setenv("CLUSTER_ID", "  ")
+        provider = self._get_created_provider(monkeypatch)
+        attrs = dict(provider._sdk_config.resource.attributes)
+        assert "service.namespace" not in attrs
+        assert "k8s.cluster.uid" not in attrs
+        provider.shutdown()


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Adds optional fields `service.namespace` and `k8s.cluster.uid` as OTel Resource attributes on the MeterProvider, sourced from environment variables. 

This will allow customers who run OGX in multiple namespaces, or on multiple clusters, to aggregate metrics into a single Grafana instance. For example: running multi-namespace dashboards and multi-cluster monitoring.

<!-- If resolving an issue, uncomment and update the line below -->
Closes RHAIENG-5157

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
Built a new OGX starter distribution image, deployed via ogx-k8s-operator to an OpenShift 4.21 cluster for validation.

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
