### PR TITLE
docs(bedrock): document required IAM actions

### DIFF
--- a/docs/docs/providers/inference/remote_bedrock.mdx
+++ b/docs/docs/providers/inference/remote_bedrock.mdx
@@ -10,6 +10,11 @@ title: remote::bedrock
 
 AWS Bedrock inference provider for the OpenAI-compatible runtime, with AWS credential-chain auth by default and an optional bearer-token override.
 
+When configuring your IAM policy, allow the following actions:
+- `bedrock:InvokeModel`
+- `bedrock:InvokeModelWithResponseStream`
+- `bedrock:ListFoundationModels`
+
 ## Configuration
 
 | Field | Type | Required | Default | Description |


### PR DESCRIPTION
Document the required IAM actions for Bedrock so administrators can write a least-privilege policy. (This is the same policy we use in live CI testing.)
