### PR TITLE
fix: bump python-multipart>=0.0.27 for CVE-2026-42561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "termcolor",
     "tiktoken",
     "h11>=0.16.0",
-    "python-multipart>=0.0.22",                       # For fastapi Form
+    "python-multipart>=0.0.27",                       # For fastapi Form
     "uvicorn>=0.34.0",                                # server
     "opentelemetry-sdk>=1.30.0",                      # server
     "opentelemetry-exporter-otlp-proto-http>=1.30.0", # server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "termcolor",
     "tiktoken",
     "h11>=0.16.0",
-    "python-multipart>=0.0.27",                       # For fastapi Form
+    "python-multipart>=0.0.27",                       # For fastapi Form, >=0.0.27 for CVE-2026-42561
     "uvicorn>=0.34.0",                                # server
     "opentelemetry-sdk>=1.30.0",                      # server
     "opentelemetry-exporter-otlp-proto-http>=1.30.0", # server


### PR DESCRIPTION
Bump python-multipart>=0.0.27 to fix CVE-2026-42561 (DoS via excessive multipart part headers).