### PR TITLE
fix(vector_io): align Milvus, ChromaDB, and SQLite-vec to upsert semantics

### DIFF
--- a/src/ogx/providers/remote/vector_io/chroma/chroma.py
+++ b/src/ogx/providers/remote/vector_io/chroma/chroma.py
@@ -83,7 +83,9 @@ class ChromaIndex(EmbeddingIndex):
 
         ids = [f"{c.metadata.get('document_id', '')}:{c.chunk_id}" for c in chunks]
         await maybe_await(
-            self.collection.add(documents=[chunk.model_dump_json() for chunk in chunks], embeddings=embeddings, ids=ids)
+            self.collection.upsert(
+                documents=[chunk.model_dump_json() for chunk in chunks], embeddings=embeddings, ids=ids
+            )
         )
 
     async def query_vector(

--- a/src/ogx/providers/remote/vector_io/milvus/milvus.py
+++ b/src/ogx/providers/remote/vector_io/milvus/milvus.py
@@ -147,10 +147,10 @@ class MilvusIndex(EmbeddingIndex):
                 }
             )
         try:
-            await asyncio.to_thread(self.client.insert, self.collection_name, data=data)
+            await asyncio.to_thread(self.client.upsert, self.collection_name, data=data)
         except Exception as e:
             logger.error(
-                "Error inserting chunks into Milvus collection", collection_name=self.collection_name, error=str(e)
+                "Failed to upsert chunks into Milvus collection", collection_name=self.collection_name, error=str(e)
             )
             raise e
 

--- a/src/ogx/providers/utils/memory/vector_store.py
+++ b/src/ogx/providers/utils/memory/vector_store.py
@@ -243,6 +243,10 @@ class EmbeddingIndex(ABC):
 
     @abstractmethod
     async def add_chunks(self, embedded_chunks: list[EmbeddedChunk]):
+        """Add embedded chunks to the index using upsert semantics.
+
+        If a chunk with the same ID already exists, it is replaced.
+        """
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/ogx_api/vector_io/api.py
+++ b/src/ogx_api/vector_io/api.py
@@ -59,7 +59,11 @@ class VectorIO(Protocol):
         self,
         request: InsertChunksRequest,
     ) -> None:
-        """Insert embedded chunks into a vector database."""
+        """Insert embedded chunks into a vector database.
+
+        Uses upsert semantics: if a chunk with the same chunk_id already exists,
+        it is replaced with the new data.
+        """
         ...
 
     async def query_chunks(


### PR DESCRIPTION
# What does this PR do?
Refers to, but does not finish: https://github.com/ogx-ai/ogx/issues/6256

Two VectorIO providers used pure insert semantics, causing silent duplication or errors when chunks with the same ID were re-ingested. This aligns them with the five providers that already upsert (PGVector, Qdrant, Elasticsearch, OCI 26AI, Infinispan) and documents the contract on the protocol and abstract base class.

- Milvus: swap client.insert → client.upsert (identical pymilvus API)
- ChromaDB: swap collection.add → collection.upsert (identical chromadb API)
- Document upsert semantics on VectorIO.insert_chunks and EmbeddingIndex.add_chunks docstrings

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
