### PR TITLE
fix(vector_io): use pool factory in PGVectorIndex to survive server restarts

### DIFF
--- a/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
+++ b/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
@@ -8,6 +8,7 @@ import asyncio
 import heapq
 import json
 import re
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import asyncpg
@@ -172,23 +173,27 @@ class PGVectorIndex(EmbeddingIndex):
         self,
         vector_store: VectorStore,
         dimension: int,
-        pool: asyncpg.Pool,
+        pool_factory: Callable[[], Awaitable[asyncpg.Pool]],
         distance_metric: str,
         vector_index: PGVectorIndexConfig,
         kvstore: KVStore | None = None,
     ):
         self.vector_store = vector_store
         self.dimension = dimension
-        self.pool = pool
+        self._pool_factory = pool_factory
         self.kvstore = kvstore
         self.check_distance_metric_availability(distance_metric)
         self.distance_metric = distance_metric
         self.vector_index = vector_index
         self.table_name = None
 
+    async def _get_pool(self) -> asyncpg.Pool:
+        return await self._pool_factory()
+
     async def initialize(self) -> None:
         try:
-            async with self.pool.acquire() as conn:
+            pool = await self._get_pool()
+            async with pool.acquire() as conn:
                 # Sanitize the table name by replacing hyphens with underscores
                 # SQL doesn't allow hyphens in table names, and vector_store.identifier may contain hyphens
                 # when created with patterns like "test-vector-db-{uuid4()}"
@@ -253,7 +258,8 @@ class PGVectorIndex(EmbeddingIndex):
                 )
             )
 
-        async with self.pool.acquire() as conn:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
             await conn.executemany(
                 f"""
                 INSERT INTO {self._quoted_table} (id, document, embedding, content_text, tokenized_content)
@@ -292,7 +298,8 @@ class PGVectorIndex(EmbeddingIndex):
 
         pgvector_search_function = self.get_pgvector_search_function()
 
-        async with self.pool.acquire() as conn:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
             # Keep query-level search tuning transaction-local and scoped to the
             # same transaction as the SELECT statement.
             async with conn.transaction():
@@ -356,7 +363,8 @@ class PGVectorIndex(EmbeddingIndex):
         """
         filter_clause, filter_params, next_idx = self._translate_filters(filters, param_idx=2)
 
-        async with self.pool.acquire() as conn:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
             filter_sql = f" AND ({filter_clause})" if filter_clause else ""
 
             rows = await conn.fetch(
@@ -533,13 +541,15 @@ class PGVectorIndex(EmbeddingIndex):
         return operator.join(clauses), params, param_idx
 
     async def delete(self):
-        async with self.pool.acquire() as conn:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
             await conn.execute(f"DROP TABLE IF EXISTS {self._quoted_table}")
 
     async def delete_chunks(self, chunks_for_deletion: list[ChunkForDeletion]) -> None:
         """Remove chunks from the PostgreSQL table."""
         chunk_ids = [c.chunk_id for c in chunks_for_deletion]
-        async with self.pool.acquire() as conn:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
             await conn.execute(f"DELETE FROM {self._quoted_table} WHERE id = ANY($1::text[])", chunk_ids)
 
     def get_pgvector_index_operator_class(self) -> str:
@@ -857,7 +867,7 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
         await self.initialize_openai_vector_stores()
 
         try:
-            pool = await self._ensure_pool()
+            await self._ensure_pool()
         except Exception as e:
             log.exception("Could not connect to PGVector database server")
             raise RuntimeError("Could not connect to PGVector database server") from e
@@ -872,7 +882,7 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
                 pgvector_index = PGVectorIndex(
                     vector_store=vector_store,
                     dimension=vector_store.embedding_dimension,
-                    pool=pool,
+                    pool_factory=self._ensure_pool,
                     kvstore=self.kvstore,
                     distance_metric=self.config.distance_metric,
                     vector_index=self.config.vector_index,
@@ -912,7 +922,7 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
         pgvector_index = PGVectorIndex(
             vector_store=vector_store,
             dimension=vector_store.embedding_dimension,
-            pool=pool,
+            pool_factory=self._ensure_pool,
             kvstore=self.kvstore,
             distance_metric=self.config.distance_metric,
             vector_index=self.config.vector_index,
@@ -958,11 +968,11 @@ class PGVectorVectorIOAdapter(OpenAIVectorStoreMixin, VectorIO, VectorStoresProt
             raise VectorStoreNotFoundError(vector_store_id)
 
         vector_store = VectorStore.model_validate_json(vector_store_data)
-        pool = await self._ensure_pool()
         index = PGVectorIndex(
             vector_store,
             vector_store.embedding_dimension,
-            pool,
+            pool_factory=self._ensure_pool,
+            kvstore=self.kvstore,
             distance_metric=self.config.distance_metric,
             vector_index=self.config.vector_index,
         )

--- a/tests/unit/providers/vector_io/conftest.py
+++ b/tests/unit/providers/vector_io/conftest.py
@@ -262,10 +262,11 @@ async def pgvector_vec_index(embedding_dimension, mock_asyncpg_pool):
         provider_resource_id="pgvector:test-vector-db",
     )
 
+    pool_factory = AsyncMock(return_value=pool)
     index = PGVectorIndex(
         vector_store,
         embedding_dimension,
-        pool,
+        pool_factory=pool_factory,
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64, ef_search=40),
     )

--- a/tests/unit/providers/vector_io/test_pgvector_pool_factory.py
+++ b/tests/unit/providers/vector_io/test_pgvector_pool_factory.py
@@ -1,0 +1,190 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from ogx.providers.remote.vector_io.pgvector.config import PGVectorHNSWVectorIndex
+from ogx.providers.remote.vector_io.pgvector.pgvector import PGVectorIndex
+from ogx_api import VectorStore
+
+
+@pytest.fixture
+def mock_vector_store():
+    store = MagicMock(spec=VectorStore)
+    store.identifier = "test-store-123"
+    store.embedding_dimension = 128
+    return store
+
+
+@pytest.fixture
+def mock_pool():
+    pool = MagicMock()
+    conn = AsyncMock()
+    conn.execute = AsyncMock()
+    conn.executemany = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetchval = AsyncMock(return_value=0)
+
+    acm = AsyncMock()
+    acm.__aenter__ = AsyncMock(return_value=conn)
+    acm.__aexit__ = AsyncMock(return_value=False)
+    pool.acquire = MagicMock(return_value=acm)
+
+    txn_acm = AsyncMock()
+    txn_acm.__aenter__ = AsyncMock()
+    txn_acm.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn_acm)
+
+    return pool, conn
+
+
+@pytest.fixture
+def pool_factory(mock_pool):
+    pool, _ = mock_pool
+    factory = AsyncMock(return_value=pool)
+    return factory
+
+
+@pytest.fixture
+def pgvector_index(mock_vector_store, pool_factory):
+    return PGVectorIndex(
+        vector_store=mock_vector_store,
+        dimension=128,
+        pool_factory=pool_factory,
+        distance_metric="COSINE",
+        vector_index=PGVectorHNSWVectorIndex(),
+    )
+
+
+async def test_get_pool_calls_factory(pgvector_index, pool_factory, mock_pool):
+    """_get_pool delegates to the pool_factory callable."""
+    pool, _ = mock_pool
+    result = await pgvector_index._get_pool()
+    pool_factory.assert_awaited_once()
+    assert result is pool
+
+
+async def test_initialize_uses_pool_factory(pgvector_index, pool_factory):
+    """initialize() acquires pool via factory, not a stored reference."""
+    await pgvector_index.initialize()
+    pool_factory.assert_awaited()
+
+
+async def test_add_chunks_uses_pool_factory(pgvector_index, pool_factory):
+    """add_chunks() acquires pool via factory."""
+    chunk = MagicMock()
+    chunk.chunk_id = "chunk-1"
+    chunk.content = "test content"
+    chunk.embedding = [0.1] * 128
+    chunk.model_dump = MagicMock(return_value={"chunk_id": "chunk-1", "content": "test"})
+
+    with patch(
+        "ogx.providers.remote.vector_io.pgvector.pgvector.interleaved_content_as_str",
+        return_value="test content",
+    ):
+        await pgvector_index.initialize()
+        pool_factory.reset_mock()
+        await pgvector_index.add_chunks([chunk])
+
+    pool_factory.assert_awaited()
+
+
+async def test_query_vector_uses_pool_factory(pgvector_index, pool_factory):
+    """query_vector() acquires pool via factory."""
+    await pgvector_index.initialize()
+    pool_factory.reset_mock()
+
+    embedding = np.zeros(128)
+    result = await pgvector_index.query_vector(embedding, k=5, score_threshold=0.0)
+
+    pool_factory.assert_awaited()
+    assert result.chunks == []
+
+
+async def test_query_keyword_uses_pool_factory(pgvector_index, pool_factory):
+    """query_keyword() acquires pool via factory."""
+    await pgvector_index.initialize()
+    pool_factory.reset_mock()
+
+    result = await pgvector_index.query_keyword("test", k=5, score_threshold=0.0)
+
+    pool_factory.assert_awaited()
+    assert result.chunks == []
+
+
+async def test_delete_uses_pool_factory(pgvector_index, pool_factory):
+    """delete() acquires pool via factory."""
+    await pgvector_index.initialize()
+    pool_factory.reset_mock()
+
+    await pgvector_index.delete()
+    pool_factory.assert_awaited()
+
+
+async def test_delete_chunks_uses_pool_factory(pgvector_index, pool_factory):
+    """delete_chunks() acquires pool via factory."""
+    await pgvector_index.initialize()
+    pool_factory.reset_mock()
+
+    chunk = MagicMock()
+    chunk.chunk_id = "chunk-1"
+    await pgvector_index.delete_chunks([chunk])
+    pool_factory.assert_awaited()
+
+
+async def test_pool_factory_called_each_operation(pgvector_index, pool_factory):
+    """Each operation calls factory independently — stale pools get refreshed."""
+    await pgvector_index.initialize()
+    pool_factory.reset_mock()
+
+    embedding = np.zeros(128)
+    await pgvector_index.query_vector(embedding, k=5, score_threshold=0.0)
+    await pgvector_index.query_keyword("test", k=5, score_threshold=0.0)
+    await pgvector_index.delete()
+
+    assert pool_factory.await_count == 3
+
+
+async def test_pool_factory_recreation_on_new_pool(mock_vector_store):
+    """When factory returns a different pool (after recreation), operations use new pool."""
+    pool_a = MagicMock()
+    pool_b = MagicMock()
+
+    for pool in (pool_a, pool_b):
+        conn = AsyncMock()
+        conn.execute = AsyncMock()
+        conn.fetchrow = AsyncMock(return_value=None)
+        conn.fetchval = AsyncMock(return_value=0)
+
+        acm = AsyncMock()
+        acm.__aenter__ = AsyncMock(return_value=conn)
+        acm.__aexit__ = AsyncMock(return_value=False)
+        pool.acquire = MagicMock(return_value=acm)
+
+    call_count = 0
+
+    async def rotating_factory():
+        nonlocal call_count
+        call_count += 1
+        return pool_a if call_count <= 1 else pool_b
+
+    index = PGVectorIndex(
+        vector_store=mock_vector_store,
+        dimension=128,
+        pool_factory=rotating_factory,
+        distance_metric="COSINE",
+        vector_index=PGVectorHNSWVectorIndex(),
+    )
+
+    await index.initialize()
+    pool_a.acquire.assert_called()
+
+    await index.delete()
+    pool_b.acquire.assert_called()

--- a/tests/unit/providers/vector_io/test_vector_io_stores_config.py
+++ b/tests/unit/providers/vector_io/test_vector_io_stores_config.py
@@ -255,7 +255,7 @@ async def test_create_gin_index_executes_correct_sql():
     index = PGVectorIndex(
         vector_store=vector_store,
         dimension=768,
-        pool=pool,
+        pool_factory=AsyncMock(return_value=pool),
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64),
     )
@@ -289,7 +289,7 @@ async def test_create_gin_index_raises_runtime_error_on_db_error():
     index = PGVectorIndex(
         vector_store=vector_store,
         dimension=768,
-        pool=pool,
+        pool_factory=AsyncMock(return_value=pool),
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64),
     )
@@ -316,7 +316,7 @@ async def test_gin_index_creation_in_initialize_call():
     index = PGVectorIndex(
         vector_store=vector_store,
         dimension=768,
-        pool=pool,
+        pool_factory=AsyncMock(return_value=pool),
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64),
     )
@@ -341,7 +341,7 @@ async def test_set_ef_search_called_before_select_in_query_vector(mock_asyncpg_p
             provider_id="pgvector",
         ),
         dimension=embedding_dimension,
-        pool=pool,
+        pool_factory=AsyncMock(return_value=pool),
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64, ef_search=50),
     )
@@ -384,7 +384,7 @@ async def test_apply_default_ef_search_for_query_vector(mock_asyncpg_pool, embed
             provider_id="pgvector",
         ),
         dimension=embedding_dimension,
-        pool=pool,
+        pool_factory=AsyncMock(return_value=pool),
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64),
     )
@@ -419,7 +419,7 @@ async def test_add_chunks_does_not_run_analyze_on_write():
             provider_id="pgvector",
         ),
         dimension=2,
-        pool=pool,
+        pool_factory=AsyncMock(return_value=pool),
         distance_metric="COSINE",
         vector_index=PGVectorHNSWVectorIndex(m=16, ef_construction=64, ef_search=40),
     )


### PR DESCRIPTION
## Summary

- Replace direct `asyncpg.Pool` reference in `PGVectorIndex` with a `pool_factory` callable that delegates to `PGVectorVectorIOAdapter._ensure_pool()`
- Each pool access now goes through health check + event-loop-aware recreation, fixing `RuntimeError: Event loop is closed` after server restart
- Fix missing `kvstore` parameter in `_get_and_cache_vector_store_index()`

**Resolves**: [RHOAIENG-73448](https://issues.redhat.com/browse/RHOAIENG-73448) — [OGX] Can't retrieve the data from vector store after server restart while using PostgreSQL as storage backend

## Root Cause

`PGVectorIndex` stored a direct reference to an `asyncpg.Pool` object bound to a specific event loop. When the event loop changed (server restart, gunicorn worker recycling, multi-worker deployment), the pool's connections became stale — their protocol references a closed event loop.

The adapter (`PGVectorVectorIOAdapter`) already had `_ensure_pool()` which validates pool health and recreates if needed. But `PGVectorIndex` bypassed this entirely — it used `self.pool` directly in 7 places.

**Why listing works but search doesn't:**
- Listing reads from `self.openai_vector_stores` (in-memory dict loaded from kvstore on init) — no pgvector pool needed
- Search goes through `PGVectorIndex.query_vector()` which used the stale pool directly

## Test plan

- [x] Unit tests: 56 pgvector tests pass (`uv run pytest tests/unit/ -x -k pgvector`)
- [x] Pre-commit: all hooks pass
- [x] New tests: `test_pgvector_pool_factory.py` — 9 tests verifying pool factory called on every operation
- [x] Manual verification: create vector store → insert data → search → kill server → restart → search again → results returned (was HTTP 500 before fix)

### Manual test results

| Step | Action | Result |
|------|--------|--------|
| 1 | Create pgvector vector store | `vs_4115501c` created |
| 2-3 | Upload + attach file | Ingestion completed |
| 4 | Search "capital of France" | 1 chunk, score 3.10 |
| 5 | Kill server | Process terminated |
| 6 | Restart server (same DB) | Ready in 3s |
| 7 | **Search after restart** | **1 chunk, score 3.08** |
| 8 | List vector stores | Store persisted |

**Verdict**: PASS — search works after restart. Before this fix, Step 7 returned `RuntimeError: Event loop is closed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)