### PR TITLE
fix: Make id optional in OpenAIResponseOutputMessageWebSearchToolCall

### DIFF
--- a/src/ogx_api/openai_responses.py
+++ b/src/ogx_api/openai_responses.py
@@ -263,7 +263,7 @@ class WebSearchActionFind(BaseModel):
 class OpenAIResponseOutputMessageWebSearchToolCall(BaseModel):
     """Web search tool call output message for OpenAI responses."""
 
-    id: str
+    id: str | None = None
     status: str
     type: Literal["web_search_call"] = "web_search_call"
     action: WebSearchActionSearch | WebSearchActionOpenPage | WebSearchActionFind | None = None


### PR DESCRIPTION
## What does this PR do?

  Makes the `id` field optional in `OpenAIResponseOutputMessageWebSearchToolCall`. When Codex sends a follow-up
  `/v1/responses` request that includes a previous `web_search_call` output item as input, it does not include the
  `id` field. Since `id` was previously required (`id: str`), OGX failed to parse the request with a Pydantic
  validation error, breaking multi-turn conversations that involve web search.

  Setting `id: str | None = None` allows OGX to accept these requests and forward them to the upstream model
  correctly.

  ## Test Plan

  **Reproduction (before fix):**
  1. Start a conversation with a web search tool call
  2. Wait for the `web_search_call` output item to be returned
  3. Send a follow-up `/v1/responses` request from Codex that includes the previous `web_search_call` as input
  context
  4. Observe the error: Pydantic validation fails because `id` is missing on the `web_search_call` input item

  **Verification (after fix):**
  1. Same multi-turn conversation flow completes successfully
  2. The `web_search_call` input item is accepted without an `id`
  3. The model receives the full conversation context and responds correctly

  Example follow-up request from Codex that previously failed:
  ```bash
  curl -s https://your-ogx-endpoint/v1/responses \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer YOUR_KEY" \
    -d '{
      "model": "gpt-4o",
      "input": [
        {"role": "user", "content": "Search for London weather"},
        {
          "type": "web_search_call",
          "status": "completed",
          "action": {
            "type": "search",
            "query": "London weather",
            "sources": [{"type": "url", "url": "https://..."}]
          }
        },
        {"role": "user", "content": "What did you find?"}
      ],
      "tools": [{"type": "web_search"}]
    }' | python3 -m json.tool

  Before fix:
  pydantic_core._pydantic_core.ValidationError: 1 validation error for OpenAIResponseOutputMessageWebSearchToolCall
  id
    Field required [type=missing, input_value={...}, input_type=dict]

  After fix:
  {
    "id": "resp_...",
    "status": "completed",
    "output": [...]
  }