### PR TITLE
refactor: route Anthropic messages through InferenceProvider instead of hardcoded provider paths

### DIFF
--- a/docs/docs/providers/messages/inline_builtin.mdx
+++ b/docs/docs/providers/messages/inline_builtin.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Implements the Anthropic Messages API with two modes: native passthrough for providers that support /v1/messages natively (e.g. Ollama, vLLM), and automatic translation for all other providers by converting between Anthropic and OpenAI Chat Completions formats."
+description: "Implements the Anthropic Messages API by delegating to the inference API's anthropic_messages() method. OpenAIMixin provides default translation via openai_chat_completion. Providers with native /v1/messages support (e.g., Ollama, vLLM) override with direct passthrough. Message batch operations are implemented locally."
 sidebar_label: Builtin
 title: inline::builtin
 ---
@@ -8,7 +8,7 @@ title: inline::builtin
 
 ## Description
 
-Implements the Anthropic Messages API with two modes: native passthrough for providers that support /v1/messages natively (e.g. Ollama, vLLM), and automatic translation for all other providers by converting between Anthropic and OpenAI Chat Completions formats.
+Implements the Anthropic Messages API by delegating to the inference API's anthropic_messages() method. OpenAIMixin provides default translation via openai_chat_completion. Providers with native /v1/messages support (e.g., Ollama, vLLM) override with direct passthrough. Message batch operations are implemented locally.
 
 ## Configuration
 

--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -61,6 +61,13 @@ from ogx_api import (
     RoutingTable,
 )
 from ogx_api.inference.models import RerankRequest
+from ogx_api.messages.models import (
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest,
+    AnthropicMessageResponse,
+    AnthropicStreamEvent,
+)
 
 logger = get_logger(name=__name__, category="core::routers")
 
@@ -313,6 +320,22 @@ class InferenceRouter(Inference):
         response = await provider.openai_embeddings(params)
         response.model = request_model_id
         return response
+
+    async def anthropic_messages(
+        self,
+        params: AnthropicCreateMessageRequest,
+    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
+        params.model = provider_resource_id
+        return await provider.anthropic_messages(params)
+
+    async def anthropic_count_tokens(
+        self,
+        params: AnthropicCountTokensRequest,
+    ) -> AnthropicCountTokensResponse:
+        provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
+        params.model = provider_resource_id
+        return await provider.anthropic_count_tokens(params)
 
     async def list_chat_completions(
         self,

--- a/src/ogx/providers/inline/inference/sentence_transformers/sentence_transformers.py
+++ b/src/ogx/providers/inline/inference/sentence_transformers/sentence_transformers.py
@@ -241,6 +241,12 @@ class SentenceTransformersInferenceImpl(
             return value.text
         raise ValueError(f"Unsupported content type for reranking: {type(value)}. Only text is supported.")
 
+    async def anthropic_messages(self, params: Any) -> None:
+        raise NotImplementedError("SentenceTransformers provider does not support Anthropic messages")
+
+    async def anthropic_count_tokens(self, params: Any) -> None:
+        raise NotImplementedError("SentenceTransformers provider does not support Anthropic token counting")
+
     def format_instruction(self, instruction: str, query: str, document: str) -> str:
         """Format a query-document pair with instruction for the reranker model.
 

--- a/src/ogx/providers/inline/messages/impl.py
+++ b/src/ogx/providers/inline/messages/impl.py
@@ -6,10 +6,11 @@
 
 """Built-in Anthropic Messages API implementation.
 
-Translates Anthropic Messages format to/from OpenAI Chat Completions format,
-delegating to the inference API for actual model calls. When the underlying
-inference provider natively supports the Anthropic Messages API (e.g. Ollama),
-requests are forwarded directly without translation.
+Delegates to the inference API for model calls. Providers handle translation
+or native passthrough via the InferenceProvider.anthropic_messages() method.
+
+Message batch operations are implemented here as they require local state
+management and do not fit the inference provider model.
 """
 
 from __future__ import annotations
@@ -22,45 +23,18 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-import httpx
-
 from ogx.core.storage.kvstore import KVStore
 from ogx.log import get_logger
-from ogx_api import (
-    Inference,
-    OpenAIChatCompletion,
-    OpenAIChatCompletionChunk,
-    OpenAIChatCompletionRequestWithExtraBody,
-)
-from ogx_api.messages import (
-    Messages,
-)
+from ogx_api import Inference
+from ogx_api.messages import Messages
 from ogx_api.messages.models import (
-    ANTHROPIC_VERSION,
-    AnthropicBase64ImageSource,
-    AnthropicContentBlock,
     AnthropicCountTokensRequest,
     AnthropicCountTokensResponse,
     AnthropicCreateMessageRequest,
-    AnthropicCustomToolDef,
-    AnthropicImageBlock,
-    AnthropicMessage,
     AnthropicMessageResponse,
-    AnthropicRedactedThinkingBlock,
     AnthropicStreamEvent,
-    AnthropicTextBlock,
-    AnthropicThinkingBlock,
-    AnthropicTool,
-    AnthropicToolResultBlock,
-    AnthropicToolUseBlock,
-    AnthropicURLImageSource,
-    AnthropicUsage,
     CancelMessageBatchRequest,
-    ContentBlockDeltaEvent,
-    ContentBlockStartEvent,
-    ContentBlockStopEvent,
     CreateMessageBatchRequest,
-    ErrorStreamEvent,
     ListMessageBatchesRequest,
     ListMessageBatchesResponse,
     MessageBatch,
@@ -69,19 +43,9 @@ from ogx_api.messages.models import (
     MessageBatchIndividualResponse,
     MessageBatchRequestCounts,
     MessageBatchSucceededResult,
-    MessageDeltaEvent,
-    MessageStartEvent,
-    MessageStopEvent,
-    PingEvent,
     RetrieveMessageBatchRequest,
     RetrieveMessageBatchResultsRequest,
     _AnthropicErrorDetail,
-    _InputJsonDelta,
-    _MessageDelta,
-    _SignatureDelta,
-    _TextDelta,
-    _ThinkingDelta,
-    _ToolChoiceTool,
 )
 
 from .config import MessagesConfig
@@ -101,45 +65,8 @@ class _BatchContext:
     request: CreateMessageBatchRequest
 
 
-async def _empty_async_iter() -> AsyncIterator[MessageBatchIndividualResponse]:
-    return
-    yield  # make this an async generator
-
-
-async def _list_to_async_iter(
-    items: list[MessageBatchIndividualResponse],
-) -> AsyncIterator[MessageBatchIndividualResponse]:
-    for item in items:
-        yield item
-
-
-# Maps Anthropic stop_reason -> OpenAI finish_reason
-# Valid stop_reasons: end_turn, stop_sequence, tool_use, max_tokens, pause_turn, refusal
-_STOP_REASON_TO_FINISH = {
-    "end_turn": "stop",
-    "stop_sequence": "stop",
-    "tool_use": "tool_calls",
-    "max_tokens": "length",
-    "pause_turn": "stop",
-}
-
-# Maps OpenAI finish_reason -> Anthropic stop_reason
-_FINISH_TO_STOP_REASON = {
-    "stop": "end_turn",
-    "tool_calls": "tool_use",
-    "length": "max_tokens",
-    "content_filter": "end_turn",
-}
-
-
-def _image_source_to_url(source: AnthropicBase64ImageSource | AnthropicURLImageSource) -> str:
-    if isinstance(source, AnthropicBase64ImageSource):
-        return f"data:{source.media_type};base64,{source.data}"
-    return source.url
-
-
 class BuiltinMessagesImpl(Messages):
-    """Anthropic Messages API adapter that translates to the inference API."""
+    """Anthropic Messages API adapter that delegates to the inference API."""
 
     def __init__(self, config: MessagesConfig, inference_api: Inference, kvstore: KVStore):
         self.config = config
@@ -153,10 +80,9 @@ class BuiltinMessagesImpl(Messages):
         self._partial_results: dict[str, list[dict[str, Any]]] = {}
 
     async def initialize(self) -> None:
-        self._client = httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0))
+        pass
 
     async def shutdown(self) -> None:
-        await self._client.aclose()
         if self._processing_tasks:
             logger.info(
                 "Shutdown initiated with active batch processing tasks",
@@ -167,30 +93,13 @@ class BuiltinMessagesImpl(Messages):
         self,
         request: AnthropicCreateMessageRequest,
     ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
-        # Try native passthrough for providers that support /v1/messages directly
-        passthrough_url = await self._get_passthrough_url(request.model)
-        if passthrough_url:
-            return await self._passthrough_request(passthrough_url, request)
-
-        # Translation mode: convert Anthropic format to OpenAI format
-        openai_params = self._anthropic_to_openai(request)
-        openai_result = await self.inference_api.openai_chat_completion(openai_params)
-
-        if isinstance(openai_result, AsyncIterator):
-            return self._stream_openai_to_anthropic(openai_result, request.model)
-
-        return self._openai_to_anthropic(openai_result, request.model)
+        return await self.inference_api.anthropic_messages(request)
 
     async def count_message_tokens(
         self,
         request: AnthropicCountTokensRequest,
     ) -> AnthropicCountTokensResponse:
-        passthrough_url = await self._get_passthrough_url(request.model)
-        if passthrough_url:
-            return await self._passthrough_count_tokens(passthrough_url, request)
-
-        # Translation mode: use Inference API's count_tokens if available
-        raise NotImplementedError("Token counting via translation mode is not yet implemented")
+        return await self.inference_api.anthropic_count_tokens(request)
 
     # -- Message Batches --
 
@@ -201,7 +110,7 @@ class BuiltinMessagesImpl(Messages):
         seen_ids: set[str] = set()
         for req in request.requests:
             if req.custom_id in seen_ids:
-                raise ValueError(f"Duplicate custom_id: {req.custom_id}")
+                raise ValueError(f"Failed to create batch: duplicate custom_id '{req.custom_id}'")
             seen_ids.add(req.custom_id)
 
         now = datetime.now(UTC)
@@ -271,7 +180,7 @@ class BuiltinMessagesImpl(Messages):
         async with self._update_lock:
             batch = await self._load_batch(batch_id)
             if batch.processing_status == "ended":
-                raise ValueError(f"Cannot cancel batch '{batch_id}' that has already ended")
+                raise ValueError(f"Failed to cancel batch '{batch_id}': batch has already ended")
             if batch.processing_status != "canceling":
                 batch.processing_status = "canceling"
                 batch.cancel_initiated_at = datetime.now(UTC).isoformat()
@@ -291,15 +200,30 @@ class BuiltinMessagesImpl(Messages):
         batch = await self._load_batch(batch_id)
         if batch.processing_status != "ended":
             raise ValueError(
-                f"Results are not yet available for batch '{batch_id}' (status: {batch.processing_status})"
+                f"Failed to retrieve batch results for '{batch_id}': batch has not finished processing (status: {batch.processing_status})"
             )
 
         data = await self.kvstore.get(f"{_BATCH_RESULTS_PREFIX}{batch_id}")
         if data is None:
-            return _empty_async_iter()
 
-        results = json.loads(data)
-        return _list_to_async_iter([MessageBatchIndividualResponse.model_validate(item) for item in results])
+            async def _empty_iter() -> AsyncIterator[MessageBatchIndividualResponse]:
+                return
+                yield  # pragma: no cover — makes this an async generator
+
+            return _empty_iter()
+
+        parsed: list[dict[str, Any]] = json.loads(data)
+        results_list: list[MessageBatchIndividualResponse] = [
+            MessageBatchIndividualResponse.model_validate(item) for item in parsed
+        ]
+
+        async def _iter_results(
+            items: list[MessageBatchIndividualResponse],
+        ) -> AsyncIterator[MessageBatchIndividualResponse]:
+            for item in items:
+                yield item
+
+        return _iter_results(results_list)
 
     async def _process_message_batch(self, ctx: _BatchContext) -> None:
         try:
@@ -419,580 +343,41 @@ class BuiltinMessagesImpl(Messages):
         )
 
     async def _finalize_batch_error(self, ctx: _BatchContext) -> None:
+        # Preserve any partial results that completed before the error
+        results: list[dict[str, Any]] = list(self._partial_results.get(ctx.batch_id, []))
+        completed_ids = {r["custom_id"] for r in results}
+        succeeded = sum(1 for r in results if r["result"]["type"] == "succeeded")
+        errored = len(results) - succeeded
+
+        for req in ctx.request.requests:
+            if req.custom_id not in completed_ids:
+                results.append(
+                    MessageBatchIndividualResponse(
+                        custom_id=req.custom_id,
+                        result=MessageBatchErroredResult(
+                            error=_AnthropicErrorDetail(type="api_error", message="Batch processing failed"),
+                        ),
+                    ).model_dump()
+                )
+                errored += 1
+
+        await self.kvstore.set(f"{_BATCH_RESULTS_PREFIX}{ctx.batch_id}", json.dumps(results))
+
         async with self._update_lock:
             batch = await self._load_batch(ctx.batch_id)
             batch.processing_status = "ended"
             batch.ended_at = datetime.now(UTC).isoformat()
             batch.request_counts = MessageBatchRequestCounts(
                 processing=0,
-                errored=batch.request_counts.processing,
+                succeeded=succeeded,
+                errored=errored,
             )
+            batch.results_url = f"/v1/messages/batches/{ctx.batch_id}/results"
             await self.kvstore.set(f"{_BATCH_PREFIX}{ctx.batch_id}", batch.model_dump_json())
 
-    # -- Native passthrough for providers with /v1/messages support --
-
-    # Module paths of provider impls known to support /v1/messages natively
-    _NATIVE_MESSAGES_MODULES = {
-        "ogx.providers.remote.inference.ollama",
-        "ogx.providers.remote.inference.vllm",
-    }
-
-    async def _get_passthrough_url(self, model: str) -> str | None:
-        """Check if the model's provider supports /v1/messages natively.
-
-        Returns the base URL for passthrough, or None to use translation.
-        """
-        router = self.inference_api
-        if not hasattr(router, "routing_table"):
-            return None
-
-        try:
-            obj = await router.routing_table.get_object_by_identifier("model", model)
-            if not obj:
-                return None
-
-            provider_impl = await router.routing_table.get_provider_impl(obj.identifier)
-            provider_module = type(provider_impl).__module__
-            is_native = any(provider_module.startswith(m) for m in self._NATIVE_MESSAGES_MODULES)
-
-            if is_native and hasattr(provider_impl, "get_base_url"):
-                base_url = str(provider_impl.get_base_url()).rstrip("/")
-                # Ollama's /v1/messages sits at the root, not under /v1
-                if base_url.endswith("/v1"):
-                    base_url = base_url[:-3]
-                logger.info("Using native /v1/messages passthrough", model=model, base_url=base_url)
-                return base_url
-        except (KeyError, ValueError, AttributeError):
-            logger.debug("Failed to resolve passthrough, falling back to translation", model=model)
-
-        return None
-
-    async def _passthrough_request(
-        self,
-        base_url: str,
-        request: AnthropicCreateMessageRequest,
-    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
-        """Forward the request directly to the provider's /v1/messages endpoint."""
-        url = f"{base_url}/v1/messages"
-        # Use the provider_resource_id (model name without provider prefix)
-        provider_model = request.model
-        router = self.inference_api
-        api_key = "no-key-required"
-        if hasattr(router, "routing_table"):
-            try:
-                obj = await router.routing_table.get_object_by_identifier("model", request.model)
-                if obj:
-                    provider_model = obj.provider_resource_id
-                    provider_impl = await router.routing_table.get_provider_impl(obj.identifier)
-                    # TODO: this is a sever abstration violation. this all needs to be refactored
-                    #       to use a proper provider interface for messages
-                    if hasattr(provider_impl, "_get_api_key_from_config_or_provider_data"):
-                        key = provider_impl._get_api_key_from_config_or_provider_data()
-                    else:
-                        key = provider_impl.get_api_key() if hasattr(provider_impl, "get_api_key") else None
-                    if key:
-                        api_key = key
-            except (KeyError, ValueError, AttributeError):
-                logger.debug("Failed to resolve provider model name, using original", model=request.model)
-
-        body = request.model_dump(exclude_none=True)
-        body["model"] = provider_model
-        headers = {
-            "content-type": "application/json",
-            "anthropic-version": ANTHROPIC_VERSION,
-            "x-api-key": api_key,
-        }
-
-        if request.stream:
-            return self._passthrough_stream(url, headers, body)
-
-        resp = await self._client.post(url, json=body, headers=headers, timeout=300)
-        resp.raise_for_status()
-        return AnthropicMessageResponse(**resp.json())
-
-    async def _passthrough_stream(
-        self,
-        url: str,
-        headers: dict[str, str],
-        body: dict[str, Any],
-    ) -> AsyncIterator[AnthropicStreamEvent]:
-        """Stream SSE events directly from the provider."""
-        try:
-            async with self._client.stream("POST", url, json=body, headers=headers, timeout=300) as resp:
-                resp.raise_for_status()
-                event_type = None
-                async for line in resp.aiter_lines():
-                    line = line.strip()
-                    if line.startswith("event: "):
-                        event_type = line[7:]
-                    elif line.startswith("data: ") and event_type:
-                        data = json.loads(line[6:])
-                        event = self._parse_sse_event(event_type, data)
-                        if event:
-                            yield event
-                        event_type = None
-        except Exception:
-            logger.exception("Failed to stream passthrough response")
-            yield ErrorStreamEvent(
-                error=_AnthropicErrorDetail(type="api_error", message="Internal server error"),
-            )
-            return
-
-    def _parse_sse_event(self, event_type: str, data: dict[str, Any]) -> AnthropicStreamEvent | None:
-        """Parse an Anthropic SSE event from its type and data."""
-        if event_type == "message_start":
-            return MessageStartEvent(message=AnthropicMessageResponse(**data["message"]))
-        if event_type == "content_block_start":
-            block_data = data["content_block"]
-            content_block: (
-                AnthropicTextBlock | AnthropicToolUseBlock | AnthropicThinkingBlock | AnthropicRedactedThinkingBlock
-            )
-            block_type = block_data.get("type")
-            if block_type == "tool_use":
-                content_block = AnthropicToolUseBlock(**block_data)
-            elif block_type == "thinking":
-                content_block = AnthropicThinkingBlock(**block_data)
-            elif block_type == "redacted_thinking":
-                content_block = AnthropicRedactedThinkingBlock(**block_data)
-            else:
-                content_block = AnthropicTextBlock(**block_data)
-            return ContentBlockStartEvent(index=data["index"], content_block=content_block)
-        if event_type == "content_block_delta":
-            delta_data = data["delta"]
-            delta_type = delta_data.get("type")
-            delta: _TextDelta | _InputJsonDelta | _ThinkingDelta | _SignatureDelta
-            if delta_type == "text_delta":
-                delta = _TextDelta(text=delta_data["text"])
-            elif delta_type == "input_json_delta":
-                delta = _InputJsonDelta(partial_json=delta_data["partial_json"])
-            elif delta_type == "thinking_delta":
-                delta = _ThinkingDelta(thinking=delta_data["thinking"])
-            elif delta_type == "signature_delta":
-                delta = _SignatureDelta(signature=delta_data["signature"])
-            else:
-                return None
-            return ContentBlockDeltaEvent(index=data["index"], delta=delta)
-        if event_type == "content_block_stop":
-            return ContentBlockStopEvent(index=data["index"])
-        if event_type == "message_delta":
-            return MessageDeltaEvent(
-                delta=_MessageDelta(stop_reason=data["delta"].get("stop_reason")),
-                usage=AnthropicUsage(**data.get("usage", {})),
-            )
-        if event_type == "message_stop":
-            return MessageStopEvent()
-        if event_type == "ping":
-            return PingEvent()
-        if event_type == "error":
-            return ErrorStreamEvent(error=_AnthropicErrorDetail(**data["error"]))
-        return None
-
-    async def _passthrough_count_tokens(
-        self,
-        base_url: str,
-        request: AnthropicCountTokensRequest,
-    ) -> AnthropicCountTokensResponse:
-        """Forward the count_tokens request to the provider's /v1/messages/count_tokens endpoint."""
-        url = f"{base_url}/v1/messages/count_tokens"
-        # Use the provider_resource_id (model name without provider prefix)
-        provider_model = request.model
-        router = self.inference_api
-        api_key = "no-key-required"
-        if hasattr(router, "routing_table"):
-            try:
-                obj = await router.routing_table.get_object_by_identifier("model", request.model)
-                if obj:
-                    provider_model = obj.provider_resource_id
-                    provider_impl = await router.routing_table.get_provider_impl(obj.identifier)
-                    # TODO: this needs to be rafactored to avoid abstraction violations and remove
-                    #       duplicated logic with _passthrough_request
-                    if hasattr(provider_impl, "_get_api_key_from_config_or_provider_data"):
-                        key = provider_impl._get_api_key_from_config_or_provider_data()
-                    else:
-                        key = provider_impl.get_api_key() if hasattr(provider_impl, "get_api_key") else None
-                    if key:
-                        api_key = key
-            except (KeyError, ValueError, AttributeError):
-                logger.debug("Failed to resolve provider model name, using original", model=request.model)
-
-        body = request.model_dump(exclude_none=True)
-        body["model"] = provider_model
-        headers = {
-            "content-type": "application/json",
-            "anthropic-version": ANTHROPIC_VERSION,
-            "x-api-key": api_key,
-        }
-
-        resp = await self._client.post(url, json=body, headers=headers, timeout=30)
-        resp.raise_for_status()
-        return AnthropicCountTokensResponse(**resp.json())
-
-    # -- Request translation --
-
-    def _anthropic_to_openai(self, request: AnthropicCreateMessageRequest) -> OpenAIChatCompletionRequestWithExtraBody:
-        if request.thinking and request.thinking.type == "enabled":
-            raise ValueError(
-                "Failed to process thinking request: extended thinking requires a native "
-                "Anthropic-compatible provider; translation mode does not support it"
-            )
-
-        messages = self._convert_messages_to_openai(request.system, request.messages)
-        tools = self._convert_tools_to_openai(request.tools) if request.tools else None
-        # tool_choice without tools is an invalid combination for OpenAI-compatible backends.
-        # This happens when request.tools contains only server-side tools, which are all filtered out.
-        tool_choice = (
-            self._convert_tool_choice_to_openai(request.tool_choice) if tools and request.tool_choice else None
+        logger.info(
+            "Message batch errored",
+            batch_id=ctx.batch_id,
+            succeeded=succeeded,
+            errored=errored,
         )
-
-        parallel_tool_calls: bool | None = None
-        if request.tool_choice and getattr(request.tool_choice, "disable_parallel_tool_use", False):
-            parallel_tool_calls = False
-
-        extra_body: dict[str, Any] = {}
-        if request.top_k is not None:
-            extra_body["top_k"] = request.top_k
-
-        params = OpenAIChatCompletionRequestWithExtraBody(
-            model=request.model,
-            messages=messages,  # type: ignore[arg-type]
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            top_p=request.top_p,
-            stop=request.stop_sequences,
-            tools=tools,
-            tool_choice=tool_choice,
-            parallel_tool_calls=parallel_tool_calls,
-            stream=request.stream or False,
-            service_tier=request.service_tier,  # type: ignore[arg-type]
-            **(extra_body or {}),
-        )
-        return params
-
-    def _convert_messages_to_openai(
-        self,
-        system: str | list[AnthropicTextBlock] | None,
-        messages: list[AnthropicMessage],
-    ) -> list[dict[str, Any]]:
-        openai_messages: list[dict[str, Any]] = []
-
-        if system is not None:
-            if isinstance(system, str):
-                system_text = system
-            else:
-                system_text = "\n".join(block.text for block in system)
-            openai_messages.append({"role": "system", "content": system_text})
-
-        for msg in messages:
-            openai_messages.extend(self._convert_single_message(msg))
-
-        return openai_messages
-
-    def _convert_single_message(self, msg: AnthropicMessage) -> list[dict[str, Any]]:
-        """Convert a single Anthropic message to one or more OpenAI messages.
-
-        A single Anthropic user message with tool_result blocks may need to be
-        split into multiple OpenAI messages (tool messages).
-        """
-        if isinstance(msg.content, str):
-            return [{"role": msg.role, "content": msg.content}]
-
-        if msg.role == "assistant":
-            return [self._convert_assistant_message(msg.content)]
-
-        if msg.role == "system":
-            # System content blocks are text-only; concatenate to a single string.
-            system_text = "\n".join(block.text for block in msg.content if isinstance(block, AnthropicTextBlock))
-            return [{"role": "system", "content": system_text}]
-
-        # User message: may contain text and/or tool_result blocks
-        result: list[dict[str, Any]] = []
-        text_parts: list[dict[str, Any]] = []
-
-        for block in msg.content:
-            if isinstance(block, AnthropicToolResultBlock):
-                # Flush accumulated text first
-                if text_parts:
-                    if len(text_parts) == 1 and text_parts[0].get("type") == "text":
-                        flush_content: str | list[dict[str, Any]] = text_parts[0]["text"]
-                    else:
-                        flush_content = text_parts
-                    result.append({"role": "user", "content": flush_content})
-                    text_parts = []
-                # Tool results become separate tool messages.
-                # OpenAI tool messages only support text content, so image blocks
-                # from tool results are promoted to a follow-up user message.
-                tool_content = block.content
-                image_parts: list[dict[str, Any]] = []
-                if isinstance(tool_content, list):
-                    text_pieces = []
-                    for b in tool_content:
-                        if isinstance(b, AnthropicTextBlock):
-                            text_pieces.append(b.text)
-                        elif isinstance(b, AnthropicImageBlock):
-                            image_parts.append(
-                                {"type": "image_url", "image_url": {"url": _image_source_to_url(b.source)}}
-                            )
-                    tool_content = "\n".join(text_pieces)
-                result.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": block.tool_use_id,
-                        "content": tool_content,
-                    }
-                )
-                if image_parts:
-                    result.append({"role": "user", "content": image_parts})
-            elif isinstance(block, AnthropicTextBlock):
-                text_parts.append({"type": "text", "text": block.text})
-            elif isinstance(block, AnthropicImageBlock):
-                text_parts.append({"type": "image_url", "image_url": {"url": _image_source_to_url(block.source)}})
-
-        if text_parts:
-            # OpenAI content must be a string or a list, never a single dict
-            if len(text_parts) == 1 and text_parts[0].get("type") == "text":
-                user_content: str | list[dict[str, Any]] = text_parts[0]["text"]
-            else:
-                user_content = text_parts
-            result.append({"role": "user", "content": user_content})
-
-        return result if result else [{"role": "user", "content": ""}]
-
-    def _convert_assistant_message(self, content: list[AnthropicContentBlock]) -> dict[str, Any]:
-        """Convert an assistant message with content blocks to OpenAI format."""
-        text_parts: list[str] = []
-        tool_calls: list[dict[str, Any]] = []
-
-        for block in content:
-            if isinstance(block, AnthropicTextBlock):
-                text_parts.append(block.text)
-            elif isinstance(block, AnthropicToolUseBlock):
-                tool_calls.append(
-                    {
-                        "id": block.id,
-                        "type": "function",
-                        "function": {
-                            "name": block.name,
-                            "arguments": json.dumps(block.input),
-                        },
-                    }
-                )
-
-        msg: dict[str, Any] = {"role": "assistant"}
-        if text_parts:
-            msg["content"] = "\n".join(text_parts)
-        if tool_calls:
-            msg["tool_calls"] = tool_calls
-
-        return msg
-
-    def _convert_tools_to_openai(self, tools: list[AnthropicTool]) -> list[dict[str, Any]] | None:
-        result = []
-        for tool in tools:
-            if not isinstance(tool, AnthropicCustomToolDef):
-                logger.debug("Dropping server-side tool in translation mode", tool_type=tool.type)
-                continue
-            result.append(
-                {
-                    "type": "function",
-                    "function": {
-                        "name": tool.name,
-                        "description": tool.description or "",
-                        "parameters": tool.input_schema,
-                    },
-                }
-            )
-        return result or None
-
-    def _convert_tool_choice_to_openai(self, tool_choice: Any) -> Any:
-        if isinstance(tool_choice, _ToolChoiceTool):
-            return {"type": "function", "function": {"name": tool_choice.name}}
-
-        tc_type = tool_choice.type if hasattr(tool_choice, "type") else str(tool_choice)
-        if tc_type == "any":
-            return "required"
-        if tc_type == "none":
-            return "none"
-        return "auto"
-
-    # -- Response translation --
-
-    def _openai_to_anthropic(self, response: OpenAIChatCompletion, request_model: str) -> AnthropicMessageResponse:
-        content: list[AnthropicContentBlock] = []
-
-        if response.choices:
-            choice = response.choices[0]
-            message = choice.message
-
-            if message and message.content:
-                content.append(AnthropicTextBlock(text=message.content))
-
-            if message and message.tool_calls:
-                for tc in message.tool_calls:
-                    if not hasattr(tc, "function") or tc.function is None:
-                        continue
-                    try:
-                        tool_input = json.loads(tc.function.arguments) if tc.function.arguments else {}
-                    except json.JSONDecodeError:
-                        tool_input = {}
-
-                    content.append(
-                        AnthropicToolUseBlock(
-                            id=tc.id or f"toolu_{uuid.uuid4().hex[:24]}",
-                            name=tc.function.name or "",
-                            input=tool_input,
-                        )
-                    )
-
-            finish_reason = choice.finish_reason or "stop"
-            stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason, "end_turn")
-        else:
-            stop_reason = "end_turn"
-
-        usage = AnthropicUsage()
-        if response.usage:
-            cache_read = None
-            if response.usage.prompt_tokens_details and hasattr(response.usage.prompt_tokens_details, "cached_tokens"):
-                cache_read = response.usage.prompt_tokens_details.cached_tokens
-
-            usage = AnthropicUsage(
-                input_tokens=response.usage.prompt_tokens or 0,
-                output_tokens=response.usage.completion_tokens or 0,
-                cache_read_input_tokens=cache_read,
-            )
-
-        return AnthropicMessageResponse(
-            id=f"msg_{uuid.uuid4().hex[:24]}",
-            content=content,
-            model=request_model,
-            stop_reason=stop_reason,
-            usage=usage,
-        )
-
-    # -- Streaming translation --
-
-    async def _stream_openai_to_anthropic(
-        self,
-        openai_stream: AsyncIterator[OpenAIChatCompletionChunk],
-        request_model: str,
-    ) -> AsyncIterator[AnthropicStreamEvent]:
-        """Translate OpenAI streaming chunks to Anthropic streaming events."""
-
-        # Emit message_start
-        yield MessageStartEvent(
-            message=AnthropicMessageResponse(
-                id=f"msg_{uuid.uuid4().hex[:24]}",
-                content=[],
-                model=request_model,
-                stop_reason=None,
-                usage=AnthropicUsage(input_tokens=0, output_tokens=0),
-            ),
-        )
-        yield PingEvent()
-
-        content_block_index = 0
-        in_text_block = False
-        in_tool_blocks: dict[int, bool] = {}  # tool_call_index -> started
-        tool_call_index_to_block_index: dict[int, int] = {}
-        output_tokens = 0
-        input_tokens = 0
-        cache_read_tokens: int | None = None
-        stop_reason = "end_turn"
-
-        try:
-            async for chunk in openai_stream:
-                if not chunk.choices:
-                    # Usage-only chunk
-                    if chunk.usage:
-                        input_tokens = chunk.usage.prompt_tokens or 0
-                        output_tokens = chunk.usage.completion_tokens or 0
-                        if chunk.usage.prompt_tokens_details and hasattr(
-                            chunk.usage.prompt_tokens_details, "cached_tokens"
-                        ):
-                            cache_read_tokens = chunk.usage.prompt_tokens_details.cached_tokens
-                    continue
-
-                choice = chunk.choices[0]
-                delta = choice.delta
-
-                if delta and delta.content:
-                    if not in_text_block:
-                        yield ContentBlockStartEvent(
-                            index=content_block_index,
-                            content_block=AnthropicTextBlock(text=""),
-                        )
-                        in_text_block = True
-
-                    yield ContentBlockDeltaEvent(
-                        index=content_block_index,
-                        delta=_TextDelta(text=delta.content),
-                    )
-
-                if delta and delta.tool_calls:
-                    for tc_delta in delta.tool_calls:
-                        tc_idx = tc_delta.index if tc_delta.index is not None else 0
-
-                        if tc_idx not in in_tool_blocks:
-                            # Close text block if open
-                            if in_text_block:
-                                yield ContentBlockStopEvent(index=content_block_index)
-                                yield PingEvent()
-                                content_block_index += 1
-                                in_text_block = False
-
-                            # Start new tool_use block
-                            in_tool_blocks[tc_idx] = True
-                            tool_call_index_to_block_index[tc_idx] = content_block_index
-
-                            yield ContentBlockStartEvent(
-                                index=content_block_index,
-                                content_block=AnthropicToolUseBlock(
-                                    id=tc_delta.id or f"toolu_{uuid.uuid4().hex[:24]}",
-                                    name=tc_delta.function.name if tc_delta.function and tc_delta.function.name else "",
-                                    input={},
-                                ),
-                            )
-                            content_block_index += 1
-
-                        if tc_delta.function and tc_delta.function.arguments:
-                            block_idx = tool_call_index_to_block_index[tc_idx]
-                            yield ContentBlockDeltaEvent(
-                                index=block_idx,
-                                delta=_InputJsonDelta(partial_json=tc_delta.function.arguments),
-                            )
-
-                if choice.finish_reason:
-                    stop_reason = _FINISH_TO_STOP_REASON.get(choice.finish_reason, "end_turn")
-
-                if chunk.usage:
-                    input_tokens = chunk.usage.prompt_tokens or 0
-                    output_tokens = chunk.usage.completion_tokens or 0
-                    if chunk.usage.prompt_tokens_details and hasattr(
-                        chunk.usage.prompt_tokens_details, "cached_tokens"
-                    ):
-                        cache_read_tokens = chunk.usage.prompt_tokens_details.cached_tokens
-        except Exception:
-            logger.exception("Failed to stream translation response")
-            yield ErrorStreamEvent(
-                error=_AnthropicErrorDetail(type="api_error", message="Internal server error"),
-            )
-            return
-
-        # Close any open blocks
-        if in_text_block:
-            yield ContentBlockStopEvent(index=content_block_index)
-            yield PingEvent()
-
-        for _tc_idx, block_idx in tool_call_index_to_block_index.items():
-            yield ContentBlockStopEvent(index=block_idx)
-            yield PingEvent()
-
-        # Final events
-        yield MessageDeltaEvent(
-            delta=_MessageDelta(stop_reason=stop_reason),
-            usage=AnthropicUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cache_read_input_tokens=cache_read_tokens,
-            ),
-        )
-        yield MessageStopEvent()

--- a/src/ogx/providers/registry/messages.py
+++ b/src/ogx/providers/registry/messages.py
@@ -25,9 +25,11 @@ def available_providers() -> list[ProviderSpec]:
                 Api.inference,
             ],
             description=(
-                "Implements the Anthropic Messages API with two modes: native passthrough for providers "
-                "that support /v1/messages natively (e.g. Ollama, vLLM), and automatic translation for "
-                "all other providers by converting between Anthropic and OpenAI Chat Completions formats."
+                "Implements the Anthropic Messages API by delegating to the inference API's "
+                "anthropic_messages() method. OpenAIMixin provides default translation via "
+                "openai_chat_completion. Providers with native /v1/messages support "
+                "(e.g., Ollama, vLLM) override with direct passthrough. Message batch "
+                "operations are implemented locally."
             ),
         ),
     ]

--- a/src/ogx/providers/remote/inference/ollama/ollama.py
+++ b/src/ogx/providers/remote/inference/ollama/ollama.py
@@ -6,8 +6,11 @@
 
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
+from typing import Any
 
+import httpx
 from ollama import AsyncClient as AsyncOllamaClient
 
 from ogx.log import get_logger
@@ -15,6 +18,7 @@ from ogx.providers.inline.responses.builtin.responses.types import (
     AssistantMessageWithReasoning,
 )
 from ogx.providers.remote.inference.ollama.config import OllamaImplConfig
+from ogx.providers.utils.inference.anthropic_translation import parse_anthropic_sse_event
 from ogx.providers.utils.inference.openai_mixin import OpenAIMixin
 from ogx_api import (
     HealthResponse,
@@ -26,6 +30,14 @@ from ogx_api import (
     OpenAIChatCompletionWithReasoning,
     OpenAIMessageParam,
     UnsupportedModelError,
+)
+from ogx_api.messages.models import (
+    ANTHROPIC_VERSION,
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest,
+    AnthropicMessageResponse,
+    AnthropicStreamEvent,
 )
 
 logger = get_logger(name=__name__, category="inference::ollama")
@@ -136,6 +148,87 @@ class OllamaInferenceAdapter(OpenAIMixin):
                 )
 
         return _wrap_chunks()
+
+    def _get_ollama_base_url(self) -> str:
+        """Get the Ollama base URL without trailing /v1 suffix."""
+        base_url_str = str(self.config.base_url)
+        if base_url_str.endswith("/v1"):
+            return base_url_str[:-3]
+        return base_url_str
+
+    async def _passthrough_anthropic_messages(
+        self,
+        request: AnthropicCreateMessageRequest,
+    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        """Forward the request directly to Ollama's /v1/messages endpoint."""
+        url = f"{self._get_ollama_base_url()}/v1/messages"
+        body = request.model_dump(exclude_none=True)
+        body["model"] = request.model
+        headers = {
+            "content-type": "application/json",
+            "anthropic-version": ANTHROPIC_VERSION,
+        }
+
+        api_key = self._get_api_key_from_config_or_provider_data() or "no-key-required"
+        headers["x-api-key"] = api_key
+
+        if request.stream:
+            return self._passthrough_anthropic_stream(url, headers, body)
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(300.0)) as client:
+            resp = await client.post(url, json=body, headers=headers)
+            resp.raise_for_status()
+            return AnthropicMessageResponse(**resp.json())
+
+    async def _passthrough_anthropic_stream(
+        self,
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+    ) -> AsyncIterator[AnthropicStreamEvent]:
+        """Stream SSE events directly from Ollama."""
+        async with httpx.AsyncClient(timeout=httpx.Timeout(300.0)) as client:
+            async with client.stream("POST", url, json=body, headers=headers) as resp:
+                resp.raise_for_status()
+                event_type: str | None = None
+                async for line in resp.aiter_lines():
+                    line = line.strip()
+                    if line.startswith("event: "):
+                        event_type = line[7:]
+                    elif line.startswith("data: ") and event_type:
+                        data = json.loads(line[6:])
+                        event = parse_anthropic_sse_event(event_type, data)
+                        if event:
+                            yield event
+                        event_type = None
+
+    async def anthropic_messages(
+        self,
+        params: AnthropicCreateMessageRequest,
+    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        """Handle Anthropic Messages via native /v1/messages endpoint."""
+        return await self._passthrough_anthropic_messages(params)
+
+    async def anthropic_count_tokens(
+        self,
+        params: AnthropicCountTokensRequest,
+    ) -> AnthropicCountTokensResponse:
+        """Forward count_tokens to Ollama's /v1/messages/count_tokens endpoint."""
+        url = f"{self._get_ollama_base_url()}/v1/messages/count_tokens"
+        body = params.model_dump(exclude_none=True)
+        body["model"] = params.model
+        headers = {
+            "content-type": "application/json",
+            "anthropic-version": ANTHROPIC_VERSION,
+        }
+
+        api_key = self._get_api_key_from_config_or_provider_data() or "no-key-required"
+        headers["x-api-key"] = api_key
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+            resp = await client.post(url, json=body, headers=headers)
+            resp.raise_for_status()
+            return AnthropicCountTokensResponse(**resp.json())
 
     async def initialize(self) -> None:
         logger.info("checking connectivity to Ollama", base_url=self.config.base_url)

--- a/src/ogx/providers/remote/inference/vllm/vllm.py
+++ b/src/ogx/providers/remote/inference/vllm/vllm.py
@@ -17,6 +17,7 @@ from ogx.log import get_logger
 from ogx.providers.inline.responses.builtin.responses.types import (
     AssistantMessageWithReasoning,
 )
+from ogx.providers.utils.inference.anthropic_translation import parse_anthropic_sse_event
 from ogx.providers.utils.inference.http_client import (
     build_network_client_kwargs as _build_network_client_kwargs,
 )
@@ -39,6 +40,14 @@ from ogx_api import (
     RerankResponse,
 )
 from ogx_api.inference import RerankRequest
+from ogx_api.messages.models import (
+    ANTHROPIC_VERSION,
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest,
+    AnthropicMessageResponse,
+    AnthropicStreamEvent,
+)
 
 from .config import VLLMInferenceAdapterConfig
 
@@ -223,6 +232,72 @@ class VLLMInferenceAdapter(OpenAIMixin):
                 )
 
         return _wrap_chunks()
+
+    async def anthropic_messages(
+        self,
+        params: AnthropicCreateMessageRequest,
+    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        """Handle Anthropic Messages via native /v1/messages endpoint."""
+        import json
+
+        url = f"{self.get_base_url()}/v1/messages"
+        body = params.model_dump(exclude_none=True)
+        body["model"] = params.model
+        headers = {
+            "content-type": "application/json",
+            "anthropic-version": ANTHROPIC_VERSION,
+        }
+
+        api_key = self._get_api_key_from_config_or_provider_data()
+        if api_key and api_key != "NO KEY REQUIRED":
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        if params.stream:
+
+            async def _stream() -> AsyncIterator[AnthropicStreamEvent]:
+                async with httpx.AsyncClient(**self._build_httpx_client_kwargs()) as client:
+                    async with client.stream("POST", url, json=body, headers=headers, timeout=300) as resp:
+                        resp.raise_for_status()
+                        event_type: str | None = None
+                        async for line in resp.aiter_lines():
+                            line = line.strip()
+                            if line.startswith("event: "):
+                                event_type = line[7:]
+                            elif line.startswith("data: ") and event_type:
+                                data = json.loads(line[6:])
+                                event = parse_anthropic_sse_event(event_type, data)
+                                if event:
+                                    yield event
+                                event_type = None
+
+            return _stream()
+
+        async with httpx.AsyncClient(**self._build_httpx_client_kwargs()) as client:
+            resp = await client.post(url, json=body, headers=headers, timeout=300)
+            resp.raise_for_status()
+            return AnthropicMessageResponse(**resp.json())
+
+    async def anthropic_count_tokens(
+        self,
+        params: AnthropicCountTokensRequest,
+    ) -> AnthropicCountTokensResponse:
+        """Forward count_tokens to vLLM's /v1/messages/count_tokens endpoint."""
+        url = f"{self.get_base_url()}/v1/messages/count_tokens"
+        body = params.model_dump(exclude_none=True)
+        body["model"] = params.model
+        headers = {
+            "content-type": "application/json",
+            "anthropic-version": ANTHROPIC_VERSION,
+        }
+
+        api_key = self._get_api_key_from_config_or_provider_data()
+        if api_key and api_key != "NO KEY REQUIRED":
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        async with httpx.AsyncClient(**self._build_httpx_client_kwargs()) as client:
+            resp = await client.post(url, json=body, headers=headers, timeout=30)
+            resp.raise_for_status()
+            return AnthropicCountTokensResponse(**resp.json())
 
     def construct_model_from_identifier(self, identifier: str) -> Model:
         # vLLM's /v1/models response does not expose a model task/type field,

--- a/src/ogx/providers/utils/inference/anthropic_translation.py
+++ b/src/ogx/providers/utils/inference/anthropic_translation.py
@@ -1,0 +1,490 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Anthropic Messages to/from OpenAI Chat Completions translation utilities.
+
+Shared by:
+- OpenAIMixin (default translation implementation)
+- Native passthrough providers (Ollama, vLLM) for SSE event parsing
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from ogx.log import get_logger
+from ogx_api import (
+    OpenAIChatCompletion,
+    OpenAIChatCompletionChunk,
+    OpenAIChatCompletionRequestWithExtraBody,
+)
+from ogx_api.messages.models import (
+    AnthropicBase64ImageSource,
+    AnthropicContentBlock,
+    AnthropicCreateMessageRequest,
+    AnthropicCustomToolDef,
+    AnthropicImageBlock,
+    AnthropicMessage,
+    AnthropicMessageResponse,
+    AnthropicRedactedThinkingBlock,
+    AnthropicStreamEvent,
+    AnthropicTextBlock,
+    AnthropicThinkingBlock,
+    AnthropicTool,
+    AnthropicToolResultBlock,
+    AnthropicToolUseBlock,
+    AnthropicURLImageSource,
+    AnthropicUsage,
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    ErrorStreamEvent,
+    MessageDeltaEvent,
+    MessageStartEvent,
+    MessageStopEvent,
+    PingEvent,
+    _AnthropicErrorDetail,
+    _InputJsonDelta,
+    _MessageDelta,
+    _SignatureDelta,
+    _TextDelta,
+    _ThinkingDelta,
+    _ToolChoiceTool,
+)
+
+logger = get_logger(name=__name__, category="providers::utils")
+
+# Maps Anthropic stop_reason -> OpenAI finish_reason
+_STOP_REASON_TO_FINISH = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "tool_use": "tool_calls",
+    "max_tokens": "length",
+    "pause_turn": "stop",
+}
+
+# Maps OpenAI finish_reason -> Anthropic stop_reason
+_FINISH_TO_STOP_REASON = {
+    "stop": "end_turn",
+    "tool_calls": "tool_use",
+    "length": "max_tokens",
+    "content_filter": "end_turn",
+}
+
+
+def _image_source_to_url(source: AnthropicBase64ImageSource | AnthropicURLImageSource) -> str:
+    if isinstance(source, AnthropicBase64ImageSource):
+        return f"data:{source.media_type};base64,{source.data}"
+    return source.url
+
+
+def convert_messages_to_openai(
+    system: str | list[AnthropicTextBlock] | None,
+    messages: list[AnthropicMessage],
+) -> list[dict[str, Any]]:
+    openai_messages: list[dict[str, Any]] = []
+
+    if system is not None:
+        if isinstance(system, str):
+            system_text = system
+        else:
+            system_text = "\n".join(block.text for block in system)
+        openai_messages.append({"role": "system", "content": system_text})
+
+    for msg in messages:
+        openai_messages.extend(convert_single_message(msg))
+
+    return openai_messages
+
+
+def convert_single_message(msg: AnthropicMessage) -> list[dict[str, Any]]:
+    """Convert a single Anthropic message to one or more OpenAI messages.
+
+    A single Anthropic user message with tool_result blocks may need to be
+    split into multiple OpenAI messages (tool messages).
+    """
+    if isinstance(msg.content, str):
+        return [{"role": msg.role, "content": msg.content}]
+
+    if msg.role == "assistant":
+        return [convert_assistant_message(msg.content)]
+
+    if msg.role == "system":
+        system_text = "\n".join(block.text for block in msg.content if isinstance(block, AnthropicTextBlock))
+        return [{"role": "system", "content": system_text}]
+
+    # User message: may contain text and/or tool_result blocks
+    result: list[dict[str, Any]] = []
+    text_parts: list[dict[str, Any]] = []
+
+    for block in msg.content:
+        if isinstance(block, AnthropicToolResultBlock):
+            # Flush accumulated text first
+            if text_parts:
+                if len(text_parts) == 1 and text_parts[0].get("type") == "text":
+                    flush_content: str | list[dict[str, Any]] = text_parts[0]["text"]
+                else:
+                    flush_content = text_parts
+                result.append({"role": "user", "content": flush_content})
+                text_parts = []
+            # Tool results become separate tool messages.
+            # OpenAI tool messages only support text content, so image blocks
+            # from tool results are promoted to a follow-up user message.
+            tool_content = block.content
+            image_parts: list[dict[str, Any]] = []
+            if isinstance(tool_content, list):
+                text_pieces = []
+                for b in tool_content:
+                    if isinstance(b, AnthropicTextBlock):
+                        text_pieces.append(b.text)
+                    elif isinstance(b, AnthropicImageBlock):
+                        image_parts.append({"type": "image_url", "image_url": {"url": _image_source_to_url(b.source)}})
+                tool_content = "\n".join(text_pieces)
+            result.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": block.tool_use_id,
+                    "content": tool_content,
+                }
+            )
+            if image_parts:
+                result.append({"role": "user", "content": image_parts})
+        elif isinstance(block, AnthropicTextBlock):
+            text_parts.append({"type": "text", "text": block.text})
+        elif isinstance(block, AnthropicImageBlock):
+            text_parts.append({"type": "image_url", "image_url": {"url": _image_source_to_url(block.source)}})
+
+    if text_parts:
+        if len(text_parts) == 1 and text_parts[0].get("type") == "text":
+            user_content: str | list[dict[str, Any]] = text_parts[0]["text"]
+        else:
+            user_content = text_parts
+        result.append({"role": "user", "content": user_content})
+
+    return result if result else [{"role": "user", "content": ""}]
+
+
+def convert_assistant_message(content: list[AnthropicContentBlock]) -> dict[str, Any]:
+    """Convert an assistant message with content blocks to OpenAI format."""
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for block in content:
+        if isinstance(block, AnthropicTextBlock):
+            text_parts.append(block.text)
+        elif isinstance(block, AnthropicToolUseBlock):
+            tool_calls.append(
+                {
+                    "id": block.id,
+                    "type": "function",
+                    "function": {
+                        "name": block.name,
+                        "arguments": json.dumps(block.input),
+                    },
+                }
+            )
+
+    msg: dict[str, Any] = {"role": "assistant"}
+    if text_parts:
+        msg["content"] = "\n".join(text_parts)
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+
+    return msg
+
+
+def convert_tools_to_openai(tools: list[AnthropicTool]) -> list[dict[str, Any]] | None:
+    result = []
+    for tool in tools:
+        if not isinstance(tool, AnthropicCustomToolDef):
+            logger.debug("Dropping server-side tool in translation mode", tool_type=tool.type)
+            continue
+        result.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description or "",
+                    "parameters": tool.input_schema,
+                },
+            }
+        )
+    return result or None
+
+
+def convert_tool_choice_to_openai(tool_choice: Any) -> Any:
+    if isinstance(tool_choice, _ToolChoiceTool):
+        return {"type": "function", "function": {"name": tool_choice.name}}
+
+    tc_type = tool_choice.type if hasattr(tool_choice, "type") else str(tool_choice)
+    if tc_type == "any":
+        return "required"
+    if tc_type == "none":
+        return "none"
+    return "auto"
+
+
+def anthropic_request_to_openai(request: AnthropicCreateMessageRequest) -> OpenAIChatCompletionRequestWithExtraBody:
+    """Convert an Anthropic CreateMessage request to OpenAI chat completion params."""
+    if request.thinking and request.thinking.type == "enabled":
+        raise ValueError(
+            "Failed to process thinking request: extended thinking requires a native "
+            "Anthropic-compatible provider; translation mode does not support it"
+        )
+
+    messages = convert_messages_to_openai(request.system, request.messages)
+    tools = convert_tools_to_openai(request.tools) if request.tools else None
+    tool_choice = convert_tool_choice_to_openai(request.tool_choice) if tools and request.tool_choice else None
+
+    parallel_tool_calls: bool | None = None
+    if request.tool_choice and getattr(request.tool_choice, "disable_parallel_tool_use", False):
+        parallel_tool_calls = False
+
+    extra_body: dict[str, Any] = {}
+    if request.top_k is not None:
+        extra_body["top_k"] = request.top_k
+
+    return OpenAIChatCompletionRequestWithExtraBody(
+        model=request.model,
+        messages=messages,  # type: ignore[arg-type]
+        max_tokens=request.max_tokens,
+        temperature=request.temperature,
+        top_p=request.top_p,
+        stop=request.stop_sequences,
+        tools=tools,
+        tool_choice=tool_choice,
+        parallel_tool_calls=parallel_tool_calls,
+        stream=request.stream or False,
+        service_tier=request.service_tier,  # type: ignore[arg-type]
+        **(extra_body or {}),
+    )
+
+
+def openai_response_to_anthropic(response: OpenAIChatCompletion, request_model: str) -> AnthropicMessageResponse:
+    """Convert an OpenAI ChatCompletion response to Anthropic message format."""
+    content: list[AnthropicContentBlock] = []
+
+    if response.choices:
+        choice = response.choices[0]
+        message = choice.message
+
+        if message and message.content:
+            content.append(AnthropicTextBlock(text=message.content))
+
+        if message and message.tool_calls:
+            for tc in message.tool_calls:
+                if not hasattr(tc, "function") or tc.function is None:
+                    continue
+                try:
+                    tool_input = json.loads(tc.function.arguments) if tc.function.arguments else {}
+                except json.JSONDecodeError:
+                    tool_input = {}
+
+                content.append(
+                    AnthropicToolUseBlock(
+                        id=tc.id or f"toolu_{uuid.uuid4().hex[:24]}",
+                        name=tc.function.name or "",
+                        input=tool_input,
+                    )
+                )
+
+        finish_reason = choice.finish_reason or "stop"
+        stop_reason = _FINISH_TO_STOP_REASON.get(finish_reason, "end_turn")
+    else:
+        stop_reason = "end_turn"
+
+    usage = AnthropicUsage()
+    if response.usage:
+        cache_read = None
+        if response.usage.prompt_tokens_details and hasattr(response.usage.prompt_tokens_details, "cached_tokens"):
+            cache_read = response.usage.prompt_tokens_details.cached_tokens
+
+        usage = AnthropicUsage(
+            input_tokens=response.usage.prompt_tokens or 0,
+            output_tokens=response.usage.completion_tokens or 0,
+            cache_read_input_tokens=cache_read,
+        )
+
+    return AnthropicMessageResponse(
+        id=f"msg_{uuid.uuid4().hex[:24]}",
+        content=content,
+        model=request_model,
+        stop_reason=stop_reason,
+        usage=usage,
+    )
+
+
+async def openai_stream_to_anthropic(
+    openai_stream: AsyncIterator[OpenAIChatCompletionChunk],
+    request_model: str,
+) -> AsyncIterator[AnthropicStreamEvent]:
+    """Translate OpenAI streaming chunks to Anthropic streaming events."""
+
+    yield MessageStartEvent(
+        message=AnthropicMessageResponse(
+            id=f"msg_{uuid.uuid4().hex[:24]}",
+            content=[],
+            model=request_model,
+            stop_reason=None,
+            usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+        ),
+    )
+    yield PingEvent()
+
+    content_block_index = 0
+    in_text_block = False
+    in_tool_blocks: dict[int, bool] = {}
+    tool_call_index_to_block_index: dict[int, int] = {}
+    output_tokens = 0
+    input_tokens = 0
+    cache_read_tokens: int | None = None
+    stop_reason = "end_turn"
+
+    try:
+        async for chunk in openai_stream:
+            if not chunk.choices:
+                if chunk.usage:
+                    input_tokens = chunk.usage.prompt_tokens or 0
+                    output_tokens = chunk.usage.completion_tokens or 0
+                    if chunk.usage.prompt_tokens_details and hasattr(
+                        chunk.usage.prompt_tokens_details, "cached_tokens"
+                    ):
+                        cache_read_tokens = chunk.usage.prompt_tokens_details.cached_tokens
+                continue
+
+            choice = chunk.choices[0]
+            delta = choice.delta
+
+            if delta and delta.content:
+                if not in_text_block:
+                    yield ContentBlockStartEvent(
+                        index=content_block_index,
+                        content_block=AnthropicTextBlock(text=""),
+                    )
+                    in_text_block = True
+
+                yield ContentBlockDeltaEvent(
+                    index=content_block_index,
+                    delta=_TextDelta(text=delta.content),
+                )
+
+            if delta and delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    tc_idx = tc_delta.index if tc_delta.index is not None else 0
+
+                    if tc_idx not in in_tool_blocks:
+                        if in_text_block:
+                            yield ContentBlockStopEvent(index=content_block_index)
+                            yield PingEvent()
+                            content_block_index += 1
+                            in_text_block = False
+
+                        in_tool_blocks[tc_idx] = True
+                        tool_call_index_to_block_index[tc_idx] = content_block_index
+
+                        yield ContentBlockStartEvent(
+                            index=content_block_index,
+                            content_block=AnthropicToolUseBlock(
+                                id=tc_delta.id or f"toolu_{uuid.uuid4().hex[:24]}",
+                                name=tc_delta.function.name if tc_delta.function and tc_delta.function.name else "",
+                                input={},
+                            ),
+                        )
+                        content_block_index += 1
+
+                    if tc_delta.function and tc_delta.function.arguments:
+                        block_idx = tool_call_index_to_block_index[tc_idx]
+                        yield ContentBlockDeltaEvent(
+                            index=block_idx,
+                            delta=_InputJsonDelta(partial_json=tc_delta.function.arguments),
+                        )
+
+            if choice.finish_reason:
+                stop_reason = _FINISH_TO_STOP_REASON.get(choice.finish_reason, "end_turn")
+
+            if chunk.usage:
+                input_tokens = chunk.usage.prompt_tokens or 0
+                output_tokens = chunk.usage.completion_tokens or 0
+                if chunk.usage.prompt_tokens_details and hasattr(chunk.usage.prompt_tokens_details, "cached_tokens"):
+                    cache_read_tokens = chunk.usage.prompt_tokens_details.cached_tokens
+    except Exception:
+        logger.exception("Failed to stream translation response")
+        yield ErrorStreamEvent(
+            error=_AnthropicErrorDetail(type="api_error", message="Internal server error"),
+        )
+        return
+
+    # Close any open blocks
+    if in_text_block:
+        yield ContentBlockStopEvent(index=content_block_index)
+        yield PingEvent()
+
+    for _tc_idx, block_idx in tool_call_index_to_block_index.items():
+        yield ContentBlockStopEvent(index=block_idx)
+        yield PingEvent()
+
+    yield MessageDeltaEvent(
+        delta=_MessageDelta(stop_reason=stop_reason),
+        usage=AnthropicUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_tokens,
+        ),
+    )
+    yield MessageStopEvent()
+
+
+def parse_anthropic_sse_event(event_type: str, data: dict[str, Any]) -> AnthropicStreamEvent | None:
+    """Parse an Anthropic SSE event from its type and data."""
+    if event_type == "message_start":
+        return MessageStartEvent(message=AnthropicMessageResponse(**data["message"]))
+    if event_type == "content_block_start":
+        block_data = data["content_block"]
+        content_block: (
+            AnthropicTextBlock | AnthropicToolUseBlock | AnthropicThinkingBlock | AnthropicRedactedThinkingBlock
+        )
+        block_type = block_data.get("type")
+        if block_type == "tool_use":
+            content_block = AnthropicToolUseBlock(**block_data)
+        elif block_type == "thinking":
+            content_block = AnthropicThinkingBlock(**block_data)
+        elif block_type == "redacted_thinking":
+            content_block = AnthropicRedactedThinkingBlock(**block_data)
+        else:
+            content_block = AnthropicTextBlock(**block_data)
+        return ContentBlockStartEvent(index=data["index"], content_block=content_block)
+    if event_type == "content_block_delta":
+        delta_data = data["delta"]
+        delta_type = delta_data.get("type")
+        delta: _TextDelta | _InputJsonDelta | _ThinkingDelta | _SignatureDelta
+        if delta_type == "text_delta":
+            delta = _TextDelta(text=delta_data["text"])
+        elif delta_type == "input_json_delta":
+            delta = _InputJsonDelta(partial_json=delta_data["partial_json"])
+        elif delta_type == "thinking_delta":
+            delta = _ThinkingDelta(thinking=delta_data["thinking"])
+        elif delta_type == "signature_delta":
+            delta = _SignatureDelta(signature=delta_data["signature"])
+        else:
+            return None
+        return ContentBlockDeltaEvent(index=data["index"], delta=delta)
+    if event_type == "content_block_stop":
+        return ContentBlockStopEvent(index=data["index"])
+    if event_type == "message_delta":
+        return MessageDeltaEvent(
+            delta=_MessageDelta(stop_reason=data["delta"].get("stop_reason")),
+            usage=AnthropicUsage(**data.get("usage", {})),
+        )
+    if event_type == "message_stop":
+        return MessageStopEvent()
+    if event_type == "ping":
+        return PingEvent()
+    if event_type == "error":
+        return ErrorStreamEvent(error=_AnthropicErrorDetail(**data["error"]))
+    return None

--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -44,6 +44,13 @@ from ogx_api import (
     OpenAIMessageParam,
     validate_embeddings_input_is_text,
 )
+from ogx_api.messages.models import (
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest,
+    AnthropicMessageResponse,
+    AnthropicStreamEvent,
+)
 
 logger = get_logger(name=__name__, category="providers::utils")
 
@@ -616,6 +623,34 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
 
     async def should_refresh_models(self) -> bool:
         return self.config.refresh_models
+
+    async def anthropic_messages(
+        self,
+        params: AnthropicCreateMessageRequest,
+    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        """Handle Anthropic Messages API via translation to OpenAI chat completions."""
+        from ogx.providers.utils.inference.anthropic_translation import (
+            anthropic_request_to_openai,
+            openai_response_to_anthropic,
+            openai_stream_to_anthropic,
+        )
+
+        openai_params = anthropic_request_to_openai(params)
+        openai_params.model = await self._get_provider_model_id(openai_params.model)
+        self._validate_model_allowed(openai_params.model)
+
+        result = await self.openai_chat_completion(openai_params)
+
+        if isinstance(result, AsyncIterator):
+            return openai_stream_to_anthropic(result, params.model)
+
+        return openai_response_to_anthropic(result, params.model)
+
+    async def anthropic_count_tokens(
+        self,
+        params: AnthropicCountTokensRequest,
+    ) -> AnthropicCountTokensResponse:
+        raise NotImplementedError("anthropic_count_tokens via translation not yet implemented")
 
     #
     # The model_dump implementations are to avoid serializing the extra fields,

--- a/src/ogx_api/inference/api.py
+++ b/src/ogx_api/inference/api.py
@@ -7,6 +7,13 @@
 from collections.abc import AsyncIterator
 from typing import Protocol, runtime_checkable
 
+from ogx_api.messages.models import (
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest,
+    AnthropicMessageResponse,
+    AnthropicStreamEvent,
+)
 from ogx_api.models import Model
 
 from .models import (
@@ -92,6 +99,28 @@ class InferenceProvider(Protocol):
     ) -> OpenAIEmbeddingsResponse:
         """Generate OpenAI-compatible embeddings for the given input using the specified model."""
         ...
+
+    async def anthropic_messages(
+        self,
+        params: AnthropicCreateMessageRequest,
+    ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
+        """Handle Anthropic Messages API requests.
+
+        Default raises NotImplementedError. OpenAIMixin provides translation via
+        openai_chat_completion. Providers with native /v1/messages support
+        (e.g., Ollama, vLLM) override with direct passthrough.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not support anthropic messages")
+
+    async def anthropic_count_tokens(
+        self,
+        params: AnthropicCountTokensRequest,
+    ) -> AnthropicCountTokensResponse:
+        """Count tokens for an Anthropic Messages API request.
+
+        Default raises NotImplementedError.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not support anthropic count tokens")
 
 
 class Inference(InferenceProvider):

--- a/tests/integration/fixtures/common.py
+++ b/tests/integration/fixtures/common.py
@@ -182,7 +182,7 @@ def client_with_models(
     model_ids = {m.id for m in client.models.list().data}
 
     if text_model_id and text_model_id not in model_ids:
-        raise ValueError(f"text_model_id {text_model_id} not found")
+        raise ValueError(f"text_model_id {text_model_id} not found in {model_ids}")
     if vision_model_id and vision_model_id not in model_ids:
         raise ValueError(f"vision_model_id {vision_model_id} not found")
     if judge_model_id and judge_model_id not in model_ids:

--- a/tests/unit/providers/inline/messages/test_impl.py
+++ b/tests/unit/providers/inline/messages/test_impl.py
@@ -4,10 +4,10 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-"""Unit tests for the BuiltinMessagesImpl translation logic."""
+"""Unit tests for BuiltinMessagesImpl — batch operations and inference delegation."""
 
-import json
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -15,888 +15,183 @@ from ogx.core.storage.datatypes import KVStoreReference
 from ogx.providers.inline.messages.config import MessagesConfig
 from ogx.providers.inline.messages.impl import BuiltinMessagesImpl
 from ogx_api.messages.models import (
-    AnthropicBase64ImageSource,
-    AnthropicBashTool,
-    AnthropicCacheControl,
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
     AnthropicCreateMessageRequest,
-    AnthropicCustomToolDef,
-    AnthropicImageBlock,
     AnthropicMessage,
-    AnthropicRedactedThinkingBlock,
-    AnthropicTextBlock,
-    AnthropicTextEditorTool,
-    AnthropicThinkingBlock,
-    AnthropicThinkingConfig,
-    AnthropicToolDef,
-    AnthropicToolResultBlock,
-    AnthropicToolUseBlock,
-    AnthropicURLImageSource,
-    AnthropicWebSearchTool,
-    _ToolChoiceAny,
-    _ToolChoiceAuto,
-    _ToolChoiceNone,
-    _ToolChoiceTool,
+    AnthropicMessageResponse,
+    AnthropicUsage,
+    CancelMessageBatchRequest,
+    CreateMessageBatchRequest,
+    MessageBatch,
+    MessageBatchRequestParams,
+    RetrieveMessageBatchResultsRequest,
 )
-
-
-def _msg_to_dict(msg):
-    """Convert a Pydantic message model to dict for easy assertion."""
-    if hasattr(msg, "model_dump"):
-        return msg.model_dump(exclude_none=True)
-    return dict(msg)
 
 
 @pytest.fixture
 def impl():
     mock_inference = AsyncMock()
-    mock_kvstore = MagicMock()
+    mock_kvstore = AsyncMock()
     config = MessagesConfig(kvstore=KVStoreReference(backend="kv_default", namespace="test"))
     return BuiltinMessagesImpl(config=config, inference_api=mock_inference, kvstore=mock_kvstore)
 
 
-class TestRequestTranslation:
-    def test_simple_text_message(self, impl):
+class TestCreateMessageDelegation:
+    async def test_create_message_delegates_to_inference_api(self, impl):
         request = AnthropicCreateMessageRequest(
             model="claude-sonnet-4-20250514",
             messages=[AnthropicMessage(role="user", content="Hello")],
             max_tokens=100,
         )
-        result = impl._anthropic_to_openai(request)
+        expected_response = AnthropicMessageResponse(
+            id="msg_abc",
+            content=[],
+            model="claude-sonnet-4-20250514",
+            stop_reason="end_turn",
+            usage=AnthropicUsage(input_tokens=10, output_tokens=5),
+        )
+        impl.inference_api.anthropic_messages.return_value = expected_response
 
-        assert result.model == "claude-sonnet-4-20250514"
-        assert result.max_tokens == 100
-        assert len(result.messages) == 1
-        m = _msg_to_dict(result.messages[0])
-        assert m["role"] == "user"
-        assert m["content"] == "Hello"
+        result = await impl.create_message(request)
 
-    def test_system_string(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
+        impl.inference_api.anthropic_messages.assert_awaited_once_with(request)
+        assert result is expected_response
+
+
+class TestCountTokensDelegation:
+    async def test_count_message_tokens_delegates_to_inference_api(self, impl):
+        request = AnthropicCountTokensRequest(
+            model="claude-sonnet-4-20250514",
             system="You are helpful.",
-        )
-        result = impl._anthropic_to_openai(request)
-
-        m0 = _msg_to_dict(result.messages[0])
-        m1 = _msg_to_dict(result.messages[1])
-        assert m0["role"] == "system"
-        assert m0["content"] == "You are helpful."
-        assert m1["role"] == "user"
-
-    def test_system_text_blocks(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            system=[
-                AnthropicTextBlock(text="Line 1."),
-                AnthropicTextBlock(text="Line 2."),
-            ],
-        )
-        result = impl._anthropic_to_openai(request)
-
-        m0 = _msg_to_dict(result.messages[0])
-        assert m0["role"] == "system"
-        assert m0["content"] == "Line 1.\nLine 2."
-
-    def test_inline_system_message_string(self, impl):
-        # Clients such as the Claude Code CLI interleave system-role messages
-        # inside the conversation rather than using the top-level system field.
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(role="user", content="Hi"),
-                AnthropicMessage(role="system", content="Stay terse."),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        m1 = _msg_to_dict(result.messages[1])
-        assert m1["role"] == "system"
-        assert m1["content"] == "Stay terse."
-
-    def test_inline_system_message_text_blocks(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(role="user", content="Hi"),
-                AnthropicMessage(
-                    role="system",
-                    content=[
-                        AnthropicTextBlock(text="Line 1."),
-                        AnthropicTextBlock(text="Line 2."),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        m1 = _msg_to_dict(result.messages[1])
-        assert m1["role"] == "system"
-        assert m1["content"] == "Line 1.\nLine 2."
-
-    def test_tool_definitions(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[
-                AnthropicToolDef(
-                    name="get_weather",
-                    description="Get weather",
-                    input_schema={"type": "object", "properties": {"location": {"type": "string"}}},
-                ),
-            ],
-        )
-        result = impl._anthropic_to_openai(request)
-
-        assert len(result.tools) == 1
-        tool = result.tools[0]
-        assert tool["type"] == "function"
-        assert tool["function"]["name"] == "get_weather"
-        assert tool["function"]["parameters"]["type"] == "object"
-
-    def test_tool_choice_any(self, impl):
-        assert impl._convert_tool_choice_to_openai(_ToolChoiceAny()) == "required"
-
-    def test_tool_choice_none(self, impl):
-        assert impl._convert_tool_choice_to_openai(_ToolChoiceNone()) == "none"
-
-    def test_tool_choice_auto(self, impl):
-        assert impl._convert_tool_choice_to_openai(_ToolChoiceAuto()) == "auto"
-
-    def test_tool_choice_specific(self, impl):
-        result = impl._convert_tool_choice_to_openai(_ToolChoiceTool(name="get_weather"))
-        assert result == {"type": "function", "function": {"name": "get_weather"}}
-
-    def test_tool_choice_string_coerced_to_model(self):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tool_choice="auto",
-        )
-        assert isinstance(request.tool_choice, _ToolChoiceAuto)
-
-    def test_tool_choice_dict_parsed_to_model(self):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tool_choice={"type": "auto", "disable_parallel_tool_use": True},
-        )
-        assert isinstance(request.tool_choice, _ToolChoiceAuto)
-        assert request.tool_choice.disable_parallel_tool_use is True
-
-    def test_disable_parallel_tool_use_translated(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[
-                AnthropicToolDef(
-                    name="search",
-                    description="Search",
-                    input_schema={"type": "object", "properties": {}},
-                ),
-            ],
-            tool_choice={"type": "auto", "disable_parallel_tool_use": True},
-        )
-        result = impl._anthropic_to_openai(request)
-        assert result.parallel_tool_calls is False
-
-    def test_parallel_tool_calls_default_when_not_disabled(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tool_choice={"type": "auto"},
-        )
-        result = impl._anthropic_to_openai(request)
-        assert result.parallel_tool_calls is None
-
-    def test_stop_sequences(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            stop_sequences=["STOP", "END"],
-        )
-        result = impl._anthropic_to_openai(request)
-        assert result.stop == ["STOP", "END"]
-
-    def test_tool_use_in_assistant_message(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="assistant",
-                    content=[
-                        AnthropicTextBlock(text="Let me check the weather."),
-                        AnthropicToolUseBlock(
-                            id="toolu_123",
-                            name="get_weather",
-                            input={"location": "SF"},
-                        ),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        msg = _msg_to_dict(result.messages[0])
-        assert msg["role"] == "assistant"
-        assert msg["content"] == "Let me check the weather."
-        assert len(msg["tool_calls"]) == 1
-        assert msg["tool_calls"][0]["id"] == "toolu_123"
-        assert msg["tool_calls"][0]["function"]["name"] == "get_weather"
-        assert json.loads(msg["tool_calls"][0]["function"]["arguments"]) == {"location": "SF"}
-
-    def test_tool_result_in_user_message(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="user",
-                    content=[
-                        AnthropicToolResultBlock(
-                            tool_use_id="toolu_123",
-                            content="72F and sunny",
-                        ),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        msg = _msg_to_dict(result.messages[0])
-        assert msg["role"] == "tool"
-        assert msg["tool_call_id"] == "toolu_123"
-        assert msg["content"] == "72F and sunny"
-
-    def test_base64_image_in_user_message(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="user",
-                    content=[
-                        AnthropicTextBlock(text="What is in this image?"),
-                        AnthropicImageBlock(
-                            source=AnthropicBase64ImageSource(
-                                media_type="image/png",
-                                data="abc123",
-                            )
-                        ),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        assert len(result.messages) == 1
-        msg = _msg_to_dict(result.messages[0])
-        assert msg["role"] == "user"
-        assert isinstance(msg["content"], list)
-        assert msg["content"][0] == {"type": "text", "text": "What is in this image?"}
-        assert msg["content"][1] == {
-            "type": "image_url",
-            "image_url": {"url": "data:image/png;base64,abc123"},
-        }
-
-    def test_url_image_in_user_message(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="user",
-                    content=[
-                        AnthropicImageBlock(source=AnthropicURLImageSource(url="https://example.com/img.jpg")),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        assert len(result.messages) == 1
-        msg = _msg_to_dict(result.messages[0])
-        assert msg["content"] == [{"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}]
-
-    def test_image_in_tool_result_promoted_to_user_message(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="user",
-                    content=[
-                        AnthropicToolResultBlock(
-                            tool_use_id="toolu_abc",
-                            content=[
-                                AnthropicTextBlock(text="Screenshot taken"),
-                                AnthropicImageBlock(
-                                    source=AnthropicBase64ImageSource(
-                                        media_type="image/png",
-                                        data="screenshotdata",
-                                    )
-                                ),
-                            ],
-                        ),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        # First message: tool result with text only
-        assert len(result.messages) == 2
-        tool_msg = _msg_to_dict(result.messages[0])
-        assert tool_msg["role"] == "tool"
-        assert tool_msg["tool_call_id"] == "toolu_abc"
-        assert tool_msg["content"] == "Screenshot taken"
-        # Second message: image promoted to user message
-        image_msg = _msg_to_dict(result.messages[1])
-        assert image_msg["role"] == "user"
-        assert image_msg["content"] == [
-            {"type": "image_url", "image_url": {"url": "data:image/png;base64,screenshotdata"}}
-        ]
-
-    def test_top_k_passed_as_extra(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            top_k=40,
-        )
-        result = impl._anthropic_to_openai(request)
-        assert result.model_extra.get("top_k") == 40
-
-    def test_redacted_thinking_skipped_in_assistant_message(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="assistant",
-                    content=[
-                        AnthropicThinkingBlock(thinking="reasoning here", signature="sig123"),
-                        AnthropicRedactedThinkingBlock(data="opaque-data"),
-                        AnthropicTextBlock(text="The answer is 42."),
-                    ],
-                ),
-            ],
-            max_tokens=100,
-        )
-        result = impl._anthropic_to_openai(request)
-
-        msg = _msg_to_dict(result.messages[0])
-        assert msg["role"] == "assistant"
-        assert msg["content"] == "The answer is 42."
-        assert "tool_calls" not in msg
-
-    def test_cache_control_on_text_block_parses(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[
-                AnthropicMessage(
-                    role="user",
-                    content=[AnthropicTextBlock(text="Hello", cache_control=AnthropicCacheControl())],
-                )
-            ],
-            max_tokens=100,
-            system=[AnthropicTextBlock(text="You are helpful.", cache_control=AnthropicCacheControl())],
-        )
-        result = impl._anthropic_to_openai(request)
-        assert len(result.messages) == 2
-        assert _msg_to_dict(result.messages[0])["role"] == "system"
-
-    def test_cache_control_on_tool_def_parses(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[
-                AnthropicCustomToolDef(
-                    name="get_weather",
-                    description="Get weather",
-                    input_schema={"type": "object", "properties": {}},
-                    cache_control=AnthropicCacheControl(),
-                )
-            ],
-        )
-        result = impl._anthropic_to_openai(request)
-        assert len(result.tools) == 1
-        assert result.tools[0]["function"]["name"] == "get_weather"
-
-    def test_server_tools_accepted_in_request(self):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[
-                AnthropicCustomToolDef(
-                    name="get_weather",
-                    input_schema={"type": "object", "properties": {}},
-                ),
-                AnthropicWebSearchTool(),
-                AnthropicBashTool(),
-                AnthropicTextEditorTool(type="text_editor_20250728", name="str_replace_based_edit_tool"),
-            ],
-        )
-        assert len(request.tools) == 4
-
-    def test_server_tools_dropped_in_translation(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[
-                AnthropicCustomToolDef(
-                    name="get_weather",
-                    input_schema={"type": "object", "properties": {}},
-                ),
-                AnthropicWebSearchTool(),
-                AnthropicBashTool(),
-            ],
-        )
-        result = impl._anthropic_to_openai(request)
-        assert len(result.tools) == 1
-        assert result.tools[0]["function"]["name"] == "get_weather"
-
-    def test_only_server_tools_yields_no_tools_in_translation(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[AnthropicWebSearchTool(), AnthropicBashTool()],
-        )
-        result = impl._anthropic_to_openai(request)
-        assert result.tools is None
-
-    def test_tool_choice_dropped_when_all_tools_filtered(self, impl):
-        # tool_choice without tools is invalid for OpenAI backends; it must be dropped
-        # when request.tools contains only server-side tools.
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hi")],
-            max_tokens=100,
-            tools=[AnthropicWebSearchTool()],
-            tool_choice="any",
-        )
-        result = impl._anthropic_to_openai(request)
-        assert result.tools is None
-        assert result.tool_choice is None
-
-
-class TestResponseTranslation:
-    def test_simple_text_response(self, impl):
-        openai_resp = MagicMock()
-        openai_resp.choices = [MagicMock()]
-        openai_resp.choices[0].message = MagicMock()
-        openai_resp.choices[0].message.content = "Hello!"
-        openai_resp.choices[0].message.tool_calls = None
-        openai_resp.choices[0].finish_reason = "stop"
-        openai_resp.usage = MagicMock()
-        openai_resp.usage.prompt_tokens = 10
-        openai_resp.usage.completion_tokens = 5
-
-        result = impl._openai_to_anthropic(openai_resp, "claude-sonnet-4-20250514")
-
-        assert result.id.startswith("msg_")
-        assert result.type == "message"
-        assert result.role == "assistant"
-        assert result.model == "claude-sonnet-4-20250514"
-        assert result.stop_reason == "end_turn"
-        assert len(result.content) == 1
-        assert result.content[0].type == "text"
-        assert result.content[0].text == "Hello!"
-        assert result.usage.input_tokens == 10
-        assert result.usage.output_tokens == 5
-
-    def test_tool_call_response(self, impl):
-        tc = MagicMock()
-        tc.id = "call_123"
-        tc.function.name = "get_weather"
-        tc.function.arguments = '{"location": "SF"}'
-
-        openai_resp = MagicMock()
-        openai_resp.choices = [MagicMock()]
-        openai_resp.choices[0].message = MagicMock()
-        openai_resp.choices[0].message.content = None
-        openai_resp.choices[0].message.tool_calls = [tc]
-        openai_resp.choices[0].finish_reason = "tool_calls"
-        openai_resp.usage = MagicMock()
-        openai_resp.usage.prompt_tokens = 20
-        openai_resp.usage.completion_tokens = 10
-
-        result = impl._openai_to_anthropic(openai_resp, "m")
-
-        assert result.stop_reason == "tool_use"
-        assert len(result.content) == 1
-        assert result.content[0].type == "tool_use"
-        assert result.content[0].name == "get_weather"
-        assert result.content[0].input == {"location": "SF"}
-
-    def test_length_stop_reason(self, impl):
-        openai_resp = MagicMock()
-        openai_resp.choices = [MagicMock()]
-        openai_resp.choices[0].message = MagicMock()
-        openai_resp.choices[0].message.content = "truncated"
-        openai_resp.choices[0].message.tool_calls = None
-        openai_resp.choices[0].finish_reason = "length"
-        openai_resp.usage = MagicMock()
-        openai_resp.usage.prompt_tokens = 5
-        openai_resp.usage.completion_tokens = 100
-
-        result = impl._openai_to_anthropic(openai_resp, "m")
-        assert result.stop_reason == "max_tokens"
-
-    def test_cache_metrics_mapping(self, impl):
-        openai_resp = MagicMock()
-        openai_resp.choices = [MagicMock()]
-        openai_resp.choices[0].message = MagicMock()
-        openai_resp.choices[0].message.content = "response"
-        openai_resp.choices[0].message.tool_calls = None
-        openai_resp.choices[0].finish_reason = "stop"
-        openai_resp.usage = MagicMock()
-        openai_resp.usage.prompt_tokens = 100
-        openai_resp.usage.completion_tokens = 50
-        openai_resp.usage.prompt_tokens_details = MagicMock()
-        openai_resp.usage.prompt_tokens_details.cached_tokens = 75
-
-        result = impl._openai_to_anthropic(openai_resp, "m")
-        assert result.usage.input_tokens == 100
-        assert result.usage.output_tokens == 50
-        assert result.usage.cache_read_input_tokens == 75
-        assert result.usage.cache_creation_input_tokens is None
-
-    def test_cache_metrics_missing(self, impl):
-        openai_resp = MagicMock()
-        openai_resp.choices = [MagicMock()]
-        openai_resp.choices[0].message = MagicMock()
-        openai_resp.choices[0].message.content = "response"
-        openai_resp.choices[0].message.tool_calls = None
-        openai_resp.choices[0].finish_reason = "stop"
-        openai_resp.usage = MagicMock()
-        openai_resp.usage.prompt_tokens = 100
-        openai_resp.usage.completion_tokens = 50
-        openai_resp.usage.prompt_tokens_details = None
-
-        result = impl._openai_to_anthropic(openai_resp, "m")
-        assert result.usage.input_tokens == 100
-        assert result.usage.output_tokens == 50
-        assert result.usage.cache_read_input_tokens is None
-        assert result.usage.cache_creation_input_tokens is None
-
-
-class TestStreamingTranslation:
-    async def test_text_streaming(self, impl):
-        chunks = []
-
-        for i, text in enumerate(["Hello", " world", "!"]):
-            chunk = MagicMock()
-            chunk.choices = [MagicMock()]
-            chunk.choices[0].delta = MagicMock()
-            chunk.choices[0].delta.content = text
-            chunk.choices[0].delta.tool_calls = None
-            chunk.choices[0].finish_reason = "stop" if i == 2 else None
-            chunk.usage = None
-            chunks.append(chunk)
-
-        async def mock_stream():
-            for c in chunks:
-                yield c
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(mock_stream(), "m"):
-            events.append(event)
-
-        assert events[0].type == "message_start"
-        assert events[1].type == "ping"
-        assert events[2].type == "content_block_start"
-        assert events[2].content_block.type == "text"
-        assert events[3].type == "content_block_delta"
-        assert events[3].delta.text == "Hello"
-        assert events[4].type == "content_block_delta"
-        assert events[4].delta.text == " world"
-        assert events[5].type == "content_block_delta"
-        assert events[5].delta.text == "!"
-        assert events[6].type == "content_block_stop"
-        assert events[7].type == "ping"
-        assert events[8].type == "message_delta"
-        assert events[8].delta.stop_reason == "end_turn"
-        assert events[9].type == "message_stop"
-
-    async def test_tool_call_streaming(self, impl):
-        chunks = []
-
-        # Tool call start
-        tc_delta = MagicMock()
-        tc_delta.index = 0
-        tc_delta.id = "call_abc"
-        tc_delta.function = MagicMock()
-        tc_delta.function.name = "search"
-        tc_delta.function.arguments = None
-        tc_delta.type = "function"
-
-        chunk1 = MagicMock()
-        chunk1.choices = [MagicMock()]
-        chunk1.choices[0].delta = MagicMock()
-        chunk1.choices[0].delta.content = None
-        chunk1.choices[0].delta.tool_calls = [tc_delta]
-        chunk1.choices[0].finish_reason = None
-        chunk1.usage = None
-        chunks.append(chunk1)
-
-        # Tool call arguments
-        tc_delta2 = MagicMock()
-        tc_delta2.index = 0
-        tc_delta2.id = None
-        tc_delta2.function = MagicMock()
-        tc_delta2.function.name = None
-        tc_delta2.function.arguments = '{"query": "test"}'
-
-        chunk2 = MagicMock()
-        chunk2.choices = [MagicMock()]
-        chunk2.choices[0].delta = MagicMock()
-        chunk2.choices[0].delta.content = None
-        chunk2.choices[0].delta.tool_calls = [tc_delta2]
-        chunk2.choices[0].finish_reason = "tool_calls"
-        chunk2.usage = None
-        chunks.append(chunk2)
-
-        async def mock_stream():
-            for c in chunks:
-                yield c
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(mock_stream(), "m"):
-            events.append(event)
-
-        assert events[0].type == "message_start"
-        tool_start = [e for e in events if e.type == "content_block_start" and hasattr(e.content_block, "name")]
-        assert len(tool_start) == 1
-        assert tool_start[0].content_block.name == "search"
-
-        json_deltas = [e for e in events if e.type == "content_block_delta" and hasattr(e.delta, "partial_json")]
-        assert len(json_deltas) == 1
-        assert json_deltas[0].delta.partial_json == '{"query": "test"}'
-
-        msg_delta = [e for e in events if e.type == "message_delta"]
-        assert msg_delta[0].delta.stop_reason == "tool_use"
-
-
-class TestSSEParsing:
-    def test_signature_delta_parsed(self, impl):
-        event = impl._parse_sse_event(
-            "content_block_delta",
-            {
-                "index": 0,
-                "delta": {"type": "signature_delta", "signature": "ErUBCkYIAxgCIkA"},
-            },
-        )
-        assert event is not None
-        assert event.type == "content_block_delta"
-        assert event.delta.type == "signature_delta"
-        assert event.delta.signature == "ErUBCkYIAxgCIkA"
-
-    def test_redacted_thinking_block_start_parsed(self, impl):
-        event = impl._parse_sse_event(
-            "content_block_start",
-            {
-                "index": 0,
-                "content_block": {
-                    "type": "redacted_thinking",
-                    "data": "opaque-redacted-data-string",
-                },
-            },
-        )
-        assert event is not None
-        assert event.type == "content_block_start"
-        assert event.content_block.type == "redacted_thinking"
-        assert event.content_block.data == "opaque-redacted-data-string"
-
-    def test_pause_turn_stop_reason_passthrough(self, impl):
-        event = impl._parse_sse_event(
-            "message_delta",
-            {
-                "delta": {"stop_reason": "pause_turn"},
-                "usage": {"output_tokens": 10},
-            },
-        )
-        assert event is not None
-        assert event.type == "message_delta"
-        assert event.delta.stop_reason == "pause_turn"
-
-
-class TestThinkingConfig:
-    def test_budget_tokens_below_minimum_rejected(self):
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            AnthropicThinkingConfig(type="enabled", budget_tokens=500)
-
-    def test_budget_tokens_at_minimum_accepted(self):
-        config = AnthropicThinkingConfig(type="enabled", budget_tokens=1024)
-        assert config.budget_tokens == 1024
-
-    def test_budget_tokens_above_minimum_accepted(self):
-        config = AnthropicThinkingConfig(type="enabled", budget_tokens=4096)
-        assert config.budget_tokens == 4096
-
-    def test_thinking_enabled_raises_in_translation_mode(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Think about this")],
-            max_tokens=8192,
-            thinking=AnthropicThinkingConfig(type="enabled", budget_tokens=4096),
-        )
-        with pytest.raises(ValueError, match="extended thinking requires a native Anthropic-compatible provider"):
-            impl._anthropic_to_openai(request)
-
-    def test_thinking_disabled_allowed_in_translation_mode(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
             messages=[AnthropicMessage(role="user", content="Hello")],
-            max_tokens=100,
-            thinking=AnthropicThinkingConfig(type="disabled"),
         )
-        result = impl._anthropic_to_openai(request)
-        assert result.model == "m"
+        expected_response = AnthropicCountTokensResponse(input_tokens=10)
+        impl.inference_api.anthropic_count_tokens.return_value = expected_response
 
-    def test_thinking_none_allowed_in_translation_mode(self, impl):
-        request = AnthropicCreateMessageRequest(
-            model="m",
-            messages=[AnthropicMessage(role="user", content="Hello")],
-            max_tokens=100,
+        result = await impl.count_message_tokens(request)
+
+        impl.inference_api.anthropic_count_tokens.assert_awaited_once_with(request)
+        assert result is expected_response
+
+
+class TestMessageBatchCreation:
+    async def test_create_batch_detects_duplicate_custom_ids(self, impl):
+        request = CreateMessageBatchRequest(
+            requests=[
+                MessageBatchRequestParams(
+                    custom_id="dup-1",
+                    params=AnthropicCreateMessageRequest(
+                        model="m",
+                        messages=[AnthropicMessage(role="user", content="Hi")],
+                        max_tokens=100,
+                    ),
+                ),
+                MessageBatchRequestParams(
+                    custom_id="dup-1",
+                    params=AnthropicCreateMessageRequest(
+                        model="m",
+                        messages=[AnthropicMessage(role="user", content="Hi")],
+                        max_tokens=100,
+                    ),
+                ),
+            ],
         )
-        result = impl._anthropic_to_openai(request)
-        assert result.model == "m"
 
+        with pytest.raises(ValueError, match="duplicate custom_id"):
+            await impl.create_message_batch(request)
 
-class TestPingEvents:
-    async def test_ping_after_message_start_in_text_stream(self, impl):
-        chunk = MagicMock()
-        chunk.choices = [MagicMock()]
-        chunk.choices[0].delta = MagicMock()
-        chunk.choices[0].delta.content = "Hi"
-        chunk.choices[0].delta.tool_calls = None
-        chunk.choices[0].finish_reason = "stop"
-        chunk.usage = None
-
-        async def mock_stream():
-            yield chunk
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(mock_stream(), "m"):
-            events.append(event)
-
-        assert events[0].type == "message_start"
-        assert events[1].type == "ping"
-        assert events[2].type == "content_block_start"
-
-    async def test_ping_after_content_block_stop_in_text_stream(self, impl):
-        chunk = MagicMock()
-        chunk.choices = [MagicMock()]
-        chunk.choices[0].delta = MagicMock()
-        chunk.choices[0].delta.content = "Hi"
-        chunk.choices[0].delta.tool_calls = None
-        chunk.choices[0].finish_reason = "stop"
-        chunk.usage = None
-
-        async def mock_stream():
-            yield chunk
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(mock_stream(), "m"):
-            events.append(event)
-
-        stop_indices = [i for i, e in enumerate(events) if e.type == "content_block_stop"]
-        for idx in stop_indices:
-            assert events[idx + 1].type == "ping"
-
-    async def test_ping_after_content_block_stop_in_tool_stream(self, impl):
-        tc_delta = MagicMock()
-        tc_delta.index = 0
-        tc_delta.id = "call_abc"
-        tc_delta.function = MagicMock()
-        tc_delta.function.name = "search"
-        tc_delta.function.arguments = '{"q": "x"}'
-
-        chunk = MagicMock()
-        chunk.choices = [MagicMock()]
-        chunk.choices[0].delta = MagicMock()
-        chunk.choices[0].delta.content = None
-        chunk.choices[0].delta.tool_calls = [tc_delta]
-        chunk.choices[0].finish_reason = "tool_calls"
-        chunk.usage = None
-
-        async def mock_stream():
-            yield chunk
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(mock_stream(), "m"):
-            events.append(event)
-
-        stop_indices = [i for i, e in enumerate(events) if e.type == "content_block_stop"]
-        assert len(stop_indices) >= 1
-        for idx in stop_indices:
-            assert events[idx + 1].type == "ping"
-
-
-class TestErrorStreamEvent:
-    async def test_error_event_on_mid_stream_exception(self, impl):
-        async def failing_stream():
-            chunk = MagicMock()
-            chunk.choices = [MagicMock()]
-            chunk.choices[0].delta = MagicMock()
-            chunk.choices[0].delta.content = "partial"
-            chunk.choices[0].delta.tool_calls = None
-            chunk.choices[0].finish_reason = None
-            chunk.usage = None
-            yield chunk
-            raise RuntimeError("connection lost")
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(failing_stream(), "m"):
-            events.append(event)
-
-        assert events[0].type == "message_start"
-        assert events[-1].type == "error"
-        assert events[-1].error.type == "api_error"
-
-    async def test_error_event_terminates_stream(self, impl):
-        async def failing_stream():
-            raise RuntimeError("immediate failure")
-            yield  # unreachable — makes this an async generator
-
-        events = []
-        async for event in impl._stream_openai_to_anthropic(failing_stream(), "m"):
-            events.append(event)
-
-        assert events[0].type == "message_start"
-        assert events[1].type == "ping"
-        assert events[2].type == "error"
-        assert len(events) == 3
-
-    def test_ping_event_parsed(self, impl):
-        event = impl._parse_sse_event("ping", {})
-        assert event is not None
-        assert event.type == "ping"
-
-    def test_error_event_parsed(self, impl):
-        event = impl._parse_sse_event(
-            "error",
-            {"error": {"type": "api_error", "message": "something broke"}},
+    async def test_create_batch_returns_in_progress_status(self, impl):
+        request = CreateMessageBatchRequest(
+            requests=[
+                MessageBatchRequestParams(
+                    custom_id="req-1",
+                    params=AnthropicCreateMessageRequest(
+                        model="m",
+                        messages=[AnthropicMessage(role="user", content="Hi")],
+                        max_tokens=100,
+                    ),
+                ),
+            ],
         )
-        assert event is not None
-        assert event.type == "error"
-        assert event.error.type == "api_error"
-        assert event.error.message == "something broke"
+
+        batch = await impl.create_message_batch(request)
+
+        assert batch.id.startswith("msgbatch_")
+        assert batch.processing_status == "in_progress"
+        assert batch.request_counts.processing == 1
+
+    async def test_cancel_already_ended_batch_raises(self, impl):
+        request = CreateMessageBatchRequest(
+            requests=[
+                MessageBatchRequestParams(
+                    custom_id="req-1",
+                    params=AnthropicCreateMessageRequest(
+                        model="m",
+                        messages=[AnthropicMessage(role="user", content="Hi")],
+                        max_tokens=100,
+                    ),
+                ),
+            ],
+        )
+
+        batch = await impl.create_message_batch(request)
+        batch_id = batch.id
+
+        from datetime import UTC, datetime
+
+        ended_batch = MessageBatch(
+            id=batch_id,
+            processing_status="ended",
+            request_counts=batch.request_counts,
+            created_at=batch.created_at,
+            expires_at=batch.expires_at,
+            ended_at=datetime.now(UTC).isoformat(),
+        )
+        impl.kvstore.get = AsyncMock(return_value=ended_batch.model_dump_json())
+
+        with pytest.raises(ValueError, match="batch has already ended"):
+            await impl.cancel_message_batch(CancelMessageBatchRequest(batch_id=batch_id))
+
+    async def test_retrieve_results_not_ended_raises(self, impl):
+        request = CreateMessageBatchRequest(
+            requests=[
+                MessageBatchRequestParams(
+                    custom_id="req-1",
+                    params=AnthropicCreateMessageRequest(
+                        model="m",
+                        messages=[AnthropicMessage(role="user", content="Hi")],
+                        max_tokens=100,
+                    ),
+                ),
+            ],
+        )
+
+        batch = await impl.create_message_batch(request)
+        batch_id = batch.id
+
+        # Cancel the background processing task so it doesn't interfere with mocks
+        task = impl._processing_tasks.pop(batch_id, None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Mock kvstore to return an in-progress batch
+        impl.kvstore.get = AsyncMock(
+            return_value=MessageBatch(
+                id=batch_id,
+                processing_status="in_progress",
+                request_counts=batch.request_counts,
+                created_at=batch.created_at,
+                expires_at=batch.expires_at,
+            ).model_dump_json()
+        )
+
+        with pytest.raises(ValueError, match="batch has not finished processing"):
+            results_iter = await impl.retrieve_message_batch_results(
+                RetrieveMessageBatchResultsRequest(batch_id=batch_id)
+            )
+            await results_iter.__anext__()

--- a/tests/unit/providers/utils/inference/test_anthropic_translation.py
+++ b/tests/unit/providers/utils/inference/test_anthropic_translation.py
@@ -1,0 +1,894 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for Anthropic<->OpenAI translation utilities in anthropic_translation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ogx.providers.utils.inference.anthropic_translation import (
+    anthropic_request_to_openai,
+    convert_tool_choice_to_openai,
+    openai_response_to_anthropic,
+    openai_stream_to_anthropic,
+    parse_anthropic_sse_event,
+)
+from ogx_api.messages.models import (
+    AnthropicBase64ImageSource,
+    AnthropicBashTool,
+    AnthropicCacheControl,
+    AnthropicCreateMessageRequest,
+    AnthropicCustomToolDef,
+    AnthropicImageBlock,
+    AnthropicMessage,
+    AnthropicRedactedThinkingBlock,
+    AnthropicTextBlock,
+    AnthropicTextEditorTool,
+    AnthropicThinkingBlock,
+    AnthropicThinkingConfig,
+    AnthropicToolResultBlock,
+    AnthropicToolUseBlock,
+    AnthropicURLImageSource,
+    AnthropicWebSearchTool,
+    _ToolChoiceAny,
+    _ToolChoiceAuto,
+    _ToolChoiceNone,
+    _ToolChoiceTool,
+)
+
+
+def _msg_to_dict(msg):
+    """Convert a Pydantic message model to dict for easy assertion."""
+    if hasattr(msg, "model_dump"):
+        return msg.model_dump(exclude_none=True)
+    return dict(msg)
+
+
+# -- Request (Anthropic -> OpenAI) --
+
+
+class TestRequestTranslation:
+    def test_simple_text_message(self):
+        request = AnthropicCreateMessageRequest(
+            model="claude-sonnet-4-20250514",
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        assert result.model == "claude-sonnet-4-20250514"
+        assert result.max_tokens == 100
+        assert len(result.messages) == 1
+        m = _msg_to_dict(result.messages[0])
+        assert m["role"] == "user"
+        assert m["content"] == "Hello"
+
+    def test_system_string(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            system="You are helpful.",
+        )
+        result = anthropic_request_to_openai(request)
+
+        m0 = _msg_to_dict(result.messages[0])
+        m1 = _msg_to_dict(result.messages[1])
+        assert m0["role"] == "system"
+        assert m0["content"] == "You are helpful."
+        assert m1["role"] == "user"
+
+    def test_system_text_blocks(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            system=[
+                AnthropicTextBlock(text="Line 1."),
+                AnthropicTextBlock(text="Line 2."),
+            ],
+        )
+        result = anthropic_request_to_openai(request)
+
+        m0 = _msg_to_dict(result.messages[0])
+        assert m0["role"] == "system"
+        assert m0["content"] == "Line 1.\nLine 2."
+
+    def test_inline_system_message_string(self):
+        # Clients such as the Claude Code CLI interleave system-role messages
+        # inside the conversation rather than using the top-level system field.
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(role="user", content="Hi"),
+                AnthropicMessage(role="system", content="Stay terse."),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        m1 = _msg_to_dict(result.messages[1])
+        assert m1["role"] == "system"
+        assert m1["content"] == "Stay terse."
+
+    def test_inline_system_message_text_blocks(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(role="user", content="Hi"),
+                AnthropicMessage(
+                    role="system",
+                    content=[
+                        AnthropicTextBlock(text="Line 1."),
+                        AnthropicTextBlock(text="Line 2."),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        m1 = _msg_to_dict(result.messages[1])
+        assert m1["role"] == "system"
+        assert m1["content"] == "Line 1.\nLine 2."
+
+    def test_tool_definitions(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[
+                AnthropicCustomToolDef(
+                    name="get_weather",
+                    description="Get weather",
+                    input_schema={"type": "object", "properties": {"location": {"type": "string"}}},
+                ),
+            ],
+        )
+        result = anthropic_request_to_openai(request)
+
+        assert len(result.tools) == 1
+        tool = result.tools[0]
+        assert tool["type"] == "function"
+        assert tool["function"]["name"] == "get_weather"
+        assert tool["function"]["parameters"]["type"] == "object"
+
+    def test_tool_choice_any(self):
+        assert convert_tool_choice_to_openai(_ToolChoiceAny()) == "required"
+
+    def test_tool_choice_none(self):
+        assert convert_tool_choice_to_openai(_ToolChoiceNone()) == "none"
+
+    def test_tool_choice_auto(self):
+        assert convert_tool_choice_to_openai(_ToolChoiceAuto()) == "auto"
+
+    def test_tool_choice_specific(self):
+        result = convert_tool_choice_to_openai(_ToolChoiceTool(name="get_weather"))
+        assert result == {"type": "function", "function": {"name": "get_weather"}}
+
+    def test_disable_parallel_tool_use_translated(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[
+                AnthropicCustomToolDef(
+                    name="search",
+                    description="Search",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+            ],
+            tool_choice={"type": "auto", "disable_parallel_tool_use": True},
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.parallel_tool_calls is False
+
+    def test_parallel_tool_calls_default_when_not_disabled(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tool_choice={"type": "auto"},
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.parallel_tool_calls is None
+
+    def test_stop_sequences(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            stop_sequences=["STOP", "END"],
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.stop == ["STOP", "END"]
+
+    def test_tool_use_in_assistant_message(self):
+        import json
+
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        AnthropicTextBlock(text="Let me check the weather."),
+                        AnthropicToolUseBlock(
+                            id="toolu_123",
+                            name="get_weather",
+                            input={"location": "SF"},
+                        ),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Let me check the weather."
+        assert len(msg["tool_calls"]) == 1
+        assert msg["tool_calls"][0]["id"] == "toolu_123"
+        assert msg["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert json.loads(msg["tool_calls"][0]["function"]["arguments"]) == {"location": "SF"}
+
+    def test_tool_result_in_user_message(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicToolResultBlock(
+                            tool_use_id="toolu_123",
+                            content="72F and sunny",
+                        ),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "toolu_123"
+        assert msg["content"] == "72F and sunny"
+
+    def test_base64_image_in_user_message(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicTextBlock(text="What is in this image?"),
+                        AnthropicImageBlock(
+                            source=AnthropicBase64ImageSource(
+                                media_type="image/png",
+                                data="abc123",
+                            )
+                        ),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        assert len(result.messages) == 1
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["role"] == "user"
+        assert isinstance(msg["content"], list)
+        assert msg["content"][0] == {"type": "text", "text": "What is in this image?"}
+        assert msg["content"][1] == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,abc123"},
+        }
+
+    def test_url_image_in_user_message(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicImageBlock(source=AnthropicURLImageSource(url="https://example.com/img.jpg")),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        assert len(result.messages) == 1
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["content"] == [{"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}]
+
+    def test_image_in_tool_result_promoted_to_user_message(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicToolResultBlock(
+                            tool_use_id="toolu_abc",
+                            content=[
+                                AnthropicTextBlock(text="Screenshot taken"),
+                                AnthropicImageBlock(
+                                    source=AnthropicBase64ImageSource(
+                                        media_type="image/png",
+                                        data="screenshotdata",
+                                    )
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        assert len(result.messages) == 2
+        tool_msg = _msg_to_dict(result.messages[0])
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "toolu_abc"
+        assert tool_msg["content"] == "Screenshot taken"
+        image_msg = _msg_to_dict(result.messages[1])
+        assert image_msg["role"] == "user"
+        assert image_msg["content"] == [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,screenshotdata"}}
+        ]
+
+    def test_top_k_passed_as_extra(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            top_k=40,
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.model_extra.get("top_k") == 40
+
+    def test_redacted_thinking_skipped_in_assistant_message(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        AnthropicThinkingBlock(thinking="reasoning here", signature="sig123"),
+                        AnthropicRedactedThinkingBlock(data="opaque-data"),
+                        AnthropicTextBlock(text="The answer is 42."),
+                    ],
+                ),
+            ],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+
+        msg = _msg_to_dict(result.messages[0])
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "The answer is 42."
+        assert "tool_calls" not in msg
+
+    def test_cache_control_on_text_block_parses(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[AnthropicTextBlock(text="Hello", cache_control=AnthropicCacheControl())],
+                )
+            ],
+            max_tokens=100,
+            system=[AnthropicTextBlock(text="You are helpful.", cache_control=AnthropicCacheControl())],
+        )
+        result = anthropic_request_to_openai(request)
+        assert len(result.messages) == 2
+        assert _msg_to_dict(result.messages[0])["role"] == "system"
+
+    def test_cache_control_on_tool_def_parses(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[
+                AnthropicCustomToolDef(
+                    name="get_weather",
+                    description="Get weather",
+                    input_schema={"type": "object", "properties": {}},
+                    cache_control=AnthropicCacheControl(),
+                )
+            ],
+        )
+        result = anthropic_request_to_openai(request)
+        assert len(result.tools) == 1
+        assert result.tools[0]["function"]["name"] == "get_weather"
+
+    def test_server_tools_accepted_in_request(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[
+                AnthropicCustomToolDef(
+                    name="get_weather",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+                AnthropicWebSearchTool(),
+                AnthropicBashTool(),
+                AnthropicTextEditorTool(type="text_editor_20250728", name="str_replace_based_edit_tool"),
+            ],
+        )
+        assert len(request.tools) == 4
+
+    def test_server_tools_dropped_in_translation(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[
+                AnthropicCustomToolDef(
+                    name="get_weather",
+                    input_schema={"type": "object", "properties": {}},
+                ),
+                AnthropicWebSearchTool(),
+                AnthropicBashTool(),
+            ],
+        )
+        result = anthropic_request_to_openai(request)
+        assert len(result.tools) == 1
+        assert result.tools[0]["function"]["name"] == "get_weather"
+
+    def test_only_server_tools_yields_no_tools_in_translation(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[AnthropicWebSearchTool(), AnthropicBashTool()],
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.tools is None
+
+    def test_tool_choice_dropped_when_all_tools_filtered(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            tools=[AnthropicWebSearchTool()],
+            tool_choice="any",
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.tools is None
+        assert result.tool_choice is None
+
+
+# -- Response (OpenAI -> Anthropic) --
+
+
+class TestResponseTranslation:
+    def test_simple_text_response(self):
+        openai_resp = MagicMock()
+        openai_resp.choices = [MagicMock()]
+        openai_resp.choices[0].message = MagicMock()
+        openai_resp.choices[0].message.content = "Hello!"
+        openai_resp.choices[0].message.tool_calls = None
+        openai_resp.choices[0].finish_reason = "stop"
+        openai_resp.usage = MagicMock()
+        openai_resp.usage.prompt_tokens = 10
+        openai_resp.usage.completion_tokens = 5
+
+        result = openai_response_to_anthropic(openai_resp, "claude-sonnet-4-20250514")
+
+        assert result.id.startswith("msg_")
+        assert result.type == "message"
+        assert result.role == "assistant"
+        assert result.model == "claude-sonnet-4-20250514"
+        assert result.stop_reason == "end_turn"
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        assert result.content[0].text == "Hello!"
+        assert result.usage.input_tokens == 10
+        assert result.usage.output_tokens == 5
+
+    def test_tool_call_response(self):
+        tc = MagicMock()
+        tc.id = "call_123"
+        tc.function.name = "get_weather"
+        tc.function.arguments = '{"location": "SF"}'
+
+        openai_resp = MagicMock()
+        openai_resp.choices = [MagicMock()]
+        openai_resp.choices[0].message = MagicMock()
+        openai_resp.choices[0].message.content = None
+        openai_resp.choices[0].message.tool_calls = [tc]
+        openai_resp.choices[0].finish_reason = "tool_calls"
+        openai_resp.usage = MagicMock()
+        openai_resp.usage.prompt_tokens = 20
+        openai_resp.usage.completion_tokens = 10
+
+        result = openai_response_to_anthropic(openai_resp, "m")
+
+        assert result.stop_reason == "tool_use"
+        assert len(result.content) == 1
+        assert result.content[0].type == "tool_use"
+        assert result.content[0].name == "get_weather"
+        assert result.content[0].input == {"location": "SF"}
+
+    def test_length_stop_reason(self):
+        openai_resp = MagicMock()
+        openai_resp.choices = [MagicMock()]
+        openai_resp.choices[0].message = MagicMock()
+        openai_resp.choices[0].message.content = "truncated"
+        openai_resp.choices[0].message.tool_calls = None
+        openai_resp.choices[0].finish_reason = "length"
+        openai_resp.usage = MagicMock()
+        openai_resp.usage.prompt_tokens = 5
+        openai_resp.usage.completion_tokens = 100
+
+        result = openai_response_to_anthropic(openai_resp, "m")
+        assert result.stop_reason == "max_tokens"
+
+    def test_cache_metrics_mapping(self):
+        openai_resp = MagicMock()
+        openai_resp.choices = [MagicMock()]
+        openai_resp.choices[0].message = MagicMock()
+        openai_resp.choices[0].message.content = "response"
+        openai_resp.choices[0].message.tool_calls = None
+        openai_resp.choices[0].finish_reason = "stop"
+        openai_resp.usage = MagicMock()
+        openai_resp.usage.prompt_tokens = 100
+        openai_resp.usage.completion_tokens = 50
+        openai_resp.usage.prompt_tokens_details = MagicMock()
+        openai_resp.usage.prompt_tokens_details.cached_tokens = 75
+
+        result = openai_response_to_anthropic(openai_resp, "m")
+        assert result.usage.input_tokens == 100
+        assert result.usage.output_tokens == 50
+        assert result.usage.cache_read_input_tokens == 75
+        assert result.usage.cache_creation_input_tokens is None
+
+    def test_cache_metrics_missing(self):
+        openai_resp = MagicMock()
+        openai_resp.choices = [MagicMock()]
+        openai_resp.choices[0].message = MagicMock()
+        openai_resp.choices[0].message.content = "response"
+        openai_resp.choices[0].message.tool_calls = None
+        openai_resp.choices[0].finish_reason = "stop"
+        openai_resp.usage = MagicMock()
+        openai_resp.usage.prompt_tokens = 100
+        openai_resp.usage.completion_tokens = 50
+        openai_resp.usage.prompt_tokens_details = None
+
+        result = openai_response_to_anthropic(openai_resp, "m")
+        assert result.usage.input_tokens == 100
+        assert result.usage.output_tokens == 50
+        assert result.usage.cache_read_input_tokens is None
+        assert result.usage.cache_creation_input_tokens is None
+
+
+# -- Streaming (OpenAI -> Anthropic) --
+
+
+class TestStreamingTranslation:
+    async def test_text_streaming(self):
+        chunks = []
+
+        for i, text in enumerate(["Hello", " world", "!"]):
+            chunk = MagicMock()
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta = MagicMock()
+            chunk.choices[0].delta.content = text
+            chunk.choices[0].delta.tool_calls = None
+            chunk.choices[0].finish_reason = "stop" if i == 2 else None
+            chunk.usage = None
+            chunks.append(chunk)
+
+        async def mock_stream():
+            for c in chunks:
+                yield c
+
+        events = []
+        async for event in openai_stream_to_anthropic(mock_stream(), "m"):
+            events.append(event)
+
+        assert events[0].type == "message_start"
+        assert events[1].type == "ping"
+        assert events[2].type == "content_block_start"
+        assert events[2].content_block.type == "text"
+        assert events[3].type == "content_block_delta"
+        assert events[3].delta.text == "Hello"
+        assert events[4].type == "content_block_delta"
+        assert events[4].delta.text == " world"
+        assert events[5].type == "content_block_delta"
+        assert events[5].delta.text == "!"
+        assert events[6].type == "content_block_stop"
+        assert events[7].type == "ping"
+        assert events[8].type == "message_delta"
+        assert events[8].delta.stop_reason == "end_turn"
+        assert events[9].type == "message_stop"
+
+    async def test_tool_call_streaming(self):
+        chunks = []
+
+        tc_delta = MagicMock()
+        tc_delta.index = 0
+        tc_delta.id = "call_abc"
+        tc_delta.function = MagicMock()
+        tc_delta.function.name = "search"
+        tc_delta.function.arguments = None
+        tc_delta.type = "function"
+
+        chunk1 = MagicMock()
+        chunk1.choices = [MagicMock()]
+        chunk1.choices[0].delta = MagicMock()
+        chunk1.choices[0].delta.content = None
+        chunk1.choices[0].delta.tool_calls = [tc_delta]
+        chunk1.choices[0].finish_reason = None
+        chunk1.usage = None
+        chunks.append(chunk1)
+
+        tc_delta2 = MagicMock()
+        tc_delta2.index = 0
+        tc_delta2.id = None
+        tc_delta2.function = MagicMock()
+        tc_delta2.function.name = None
+        tc_delta2.function.arguments = '{"query": "test"}'
+
+        chunk2 = MagicMock()
+        chunk2.choices = [MagicMock()]
+        chunk2.choices[0].delta = MagicMock()
+        chunk2.choices[0].delta.content = None
+        chunk2.choices[0].delta.tool_calls = [tc_delta2]
+        chunk2.choices[0].finish_reason = "tool_calls"
+        chunk2.usage = None
+        chunks.append(chunk2)
+
+        async def mock_stream():
+            for c in chunks:
+                yield c
+
+        events = []
+        async for event in openai_stream_to_anthropic(mock_stream(), "m"):
+            events.append(event)
+
+        assert events[0].type == "message_start"
+        tool_start = [e for e in events if e.type == "content_block_start" and hasattr(e.content_block, "name")]
+        assert len(tool_start) == 1
+        assert tool_start[0].content_block.name == "search"
+
+        json_deltas = [e for e in events if e.type == "content_block_delta" and hasattr(e.delta, "partial_json")]
+        assert len(json_deltas) == 1
+        assert json_deltas[0].delta.partial_json == '{"query": "test"}'
+
+        msg_delta = [e for e in events if e.type == "message_delta"]
+        assert msg_delta[0].delta.stop_reason == "tool_use"
+
+
+# -- SSE Parsing --
+
+
+class TestSSEParsing:
+    def test_signature_delta_parsed(self):
+        event = parse_anthropic_sse_event(
+            "content_block_delta",
+            {
+                "index": 0,
+                "delta": {"type": "signature_delta", "signature": "ErUBCkYIAxgCIkA"},
+            },
+        )
+        assert event is not None
+        assert event.type == "content_block_delta"
+        assert event.delta.type == "signature_delta"
+        assert event.delta.signature == "ErUBCkYIAxgCIkA"
+
+    def test_redacted_thinking_block_start_parsed(self):
+        event = parse_anthropic_sse_event(
+            "content_block_start",
+            {
+                "index": 0,
+                "content_block": {
+                    "type": "redacted_thinking",
+                    "data": "opaque-redacted-data-string",
+                },
+            },
+        )
+        assert event is not None
+        assert event.type == "content_block_start"
+        assert event.content_block.type == "redacted_thinking"
+        assert event.content_block.data == "opaque-redacted-data-string"
+
+    def test_pause_turn_stop_reason_passthrough(self):
+        event = parse_anthropic_sse_event(
+            "message_delta",
+            {
+                "delta": {"stop_reason": "pause_turn"},
+                "usage": {"output_tokens": 10},
+            },
+        )
+        assert event is not None
+        assert event.type == "message_delta"
+        assert event.delta.stop_reason == "pause_turn"
+
+    def test_ping_event_parsed(self):
+        event = parse_anthropic_sse_event("ping", {})
+        assert event is not None
+        assert event.type == "ping"
+
+    def test_error_event_parsed(self):
+        event = parse_anthropic_sse_event(
+            "error",
+            {"error": {"type": "api_error", "message": "something broke"}},
+        )
+        assert event is not None
+        assert event.type == "error"
+        assert event.error.type == "api_error"
+        assert event.error.message == "something broke"
+
+
+# -- Thinking Config --
+
+
+class TestThinkingConfig:
+    def test_budget_tokens_below_minimum_rejected(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AnthropicThinkingConfig(type="enabled", budget_tokens=500)
+
+    def test_budget_tokens_at_minimum_accepted(self):
+        config = AnthropicThinkingConfig(type="enabled", budget_tokens=1024)
+        assert config.budget_tokens == 1024
+
+    def test_budget_tokens_above_minimum_accepted(self):
+        config = AnthropicThinkingConfig(type="enabled", budget_tokens=4096)
+        assert config.budget_tokens == 4096
+
+    def test_thinking_enabled_raises_in_translation_mode(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Think about this")],
+            max_tokens=8192,
+            thinking=AnthropicThinkingConfig(type="enabled", budget_tokens=4096),
+        )
+        with pytest.raises(ValueError, match="extended thinking requires a native Anthropic-compatible provider"):
+            anthropic_request_to_openai(request)
+
+    def test_thinking_disabled_allowed_in_translation_mode(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            max_tokens=100,
+            thinking=AnthropicThinkingConfig(type="disabled"),
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.model == "m"
+
+    def test_thinking_none_allowed_in_translation_mode(self):
+        request = AnthropicCreateMessageRequest(
+            model="m",
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            max_tokens=100,
+        )
+        result = anthropic_request_to_openai(request)
+        assert result.model == "m"
+
+
+# -- Ping Events --
+
+
+class TestPingEvents:
+    async def test_ping_after_message_start_in_text_stream(self):
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = "Hi"
+        chunk.choices[0].delta.tool_calls = None
+        chunk.choices[0].finish_reason = "stop"
+        chunk.usage = None
+
+        async def mock_stream():
+            yield chunk
+
+        events = []
+        async for event in openai_stream_to_anthropic(mock_stream(), "m"):
+            events.append(event)
+
+        assert events[0].type == "message_start"
+        assert events[1].type == "ping"
+        assert events[2].type == "content_block_start"
+
+    async def test_ping_after_content_block_stop_in_text_stream(self):
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = "Hi"
+        chunk.choices[0].delta.tool_calls = None
+        chunk.choices[0].finish_reason = "stop"
+        chunk.usage = None
+
+        async def mock_stream():
+            yield chunk
+
+        events = []
+        async for event in openai_stream_to_anthropic(mock_stream(), "m"):
+            events.append(event)
+
+        stop_indices = [i for i, e in enumerate(events) if e.type == "content_block_stop"]
+        for idx in stop_indices:
+            assert events[idx + 1].type == "ping"
+
+    async def test_ping_after_content_block_stop_in_tool_stream(self):
+        tc_delta = MagicMock()
+        tc_delta.index = 0
+        tc_delta.id = "call_abc"
+        tc_delta.function = MagicMock()
+        tc_delta.function.name = "search"
+        tc_delta.function.arguments = '{"q": "x"}'
+
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = None
+        chunk.choices[0].delta.tool_calls = [tc_delta]
+        chunk.choices[0].finish_reason = "tool_calls"
+        chunk.usage = None
+
+        async def mock_stream():
+            yield chunk
+
+        events = []
+        async for event in openai_stream_to_anthropic(mock_stream(), "m"):
+            events.append(event)
+
+        stop_indices = [i for i, e in enumerate(events) if e.type == "content_block_stop"]
+        assert len(stop_indices) >= 1
+        for idx in stop_indices:
+            assert events[idx + 1].type == "ping"
+
+
+# -- Error Stream Events --
+
+
+class TestErrorStreamEvent:
+    async def test_error_event_on_mid_stream_exception(self):
+        async def failing_stream():
+            chunk = MagicMock()
+            chunk.choices = [MagicMock()]
+            chunk.choices[0].delta = MagicMock()
+            chunk.choices[0].delta.content = "partial"
+            chunk.choices[0].delta.tool_calls = None
+            chunk.choices[0].finish_reason = None
+            chunk.usage = None
+            yield chunk
+            raise RuntimeError("connection lost")
+
+        events = []
+        async for event in openai_stream_to_anthropic(failing_stream(), "m"):
+            events.append(event)
+
+        assert events[0].type == "message_start"
+        assert events[-1].type == "error"
+        assert events[-1].error.type == "api_error"
+
+    async def test_error_event_terminates_stream(self):
+        async def failing_stream():
+            raise RuntimeError("immediate failure")
+            yield  # unreachable
+
+        events = []
+        async for event in openai_stream_to_anthropic(failing_stream(), "m"):
+            events.append(event)
+
+        assert events[0].type == "message_start"
+        assert events[1].type == "ping"
+        assert events[2].type == "error"
+        assert len(events) == 3


### PR DESCRIPTION
Extract Anthropic-to-OpenAI translation utilities to shared module under src/ogx/providers/utils/inference/anthropic_translation.py. Add anthropic_messages() and anthropic_count_tokens() methods to the InferenceProvider protocol with a default translation implementation in OpenAIMixin so every OpenAI-compatible provider gains Anthropic support automatically. Ollama and vLLM adapters override with native /v1/messages HTTP passthrough. InferenceRouter dispatches based on the target model. The messages provider is slimmed to a thin delegator that forwards to the inference API, retaining only message batch operations that require local state management.

- Add anthropic_messages() and anthropic_count_tokens() to InferenceProvider protocol
- Add default translation implementation to OpenAIMixin using shared utilities
- Add native passthrough override to OllamaInferenceAdapter and VLLMInferenceAdapter
- Add anthropic_messages() and anthropic_count_tokens() to InferenceRouter
- Slim messages/impl.py to delegate to inference API
- Fix _finalize_batch_error to preserve partial results
- Update error messages to use 'Failed to ...' prefix
- Add missing anthropic methods to SentenceTransformersInferenceImpl
- Update provider registry description to reflect delegation model
- Move translation tests to test_anthropic_translation.py under providers/utils/inference/
- Update test_impl.py to test delegation and batch operations
