### PR TITLE
fix(auth): recurse into sub-routers when building route auth table

### DIFF
--- a/src/ogx/core/server/routes.py
+++ b/src/ogx/core/server/routes.py
@@ -105,6 +105,20 @@ def find_matching_route(method: str, path: str, route_impls: RouteImpls) -> Rout
     raise ValueError(f"No endpoint found for {path}")
 
 
+def _collect_api_routes(routes: list[Any]) -> list[APIRoute]:
+    """Collect all APIRoute objects, recursing into included routers."""
+    api_routes: list[APIRoute] = []
+    for route in routes:
+        if isinstance(route, APIRoute):
+            api_routes.append(route)
+        elif hasattr(route, "original_router"):
+            # FastAPI >= 0.137 wraps include_router() results in _IncludedRouter
+            api_routes.extend(_collect_api_routes(route.original_router.routes))
+        elif hasattr(route, "routes"):
+            api_routes.extend(_collect_api_routes(route.routes))
+    return api_routes
+
+
 def build_route_impls_from_routes(routes: list[Any]) -> RouteImpls:
     """Build RouteImpls from mounted FastAPI routes.
 
@@ -119,9 +133,7 @@ def build_route_impls_from_routes(routes: list[Any]) -> RouteImpls:
         RouteImpls mapping method -> path regex -> (endpoint, path, RouteAuthInfo)
     """
     route_impls: RouteImpls = {}
-    for route in routes:
-        if not isinstance(route, APIRoute):
-            continue
+    for route in _collect_api_routes(routes):
         methods = [m for m in (route.methods or []) if m != "HEAD"]
         if not methods:
             continue


### PR DESCRIPTION
Closes #6265

## Summary

- FastAPI 0.137 changed `include_router()` to wrap routes in `_IncludedRouter` instead of flattening them as `APIRoute` objects
- `build_route_impls_from_routes()` only checked for `APIRoute`, so public routes like `/v1/health` were invisible to the auth middleware
- Adds `_collect_api_routes()` that recurses into `original_router.routes` and `.routes` to find all `APIRoute` objects regardless of FastAPI version

## Test plan

- [x] Verified fix works with both flat `APIRoute` lists (pre-0.137) and `_IncludedRouter` tree (0.137+)
- [x] `uv run pytest tests/unit/server/ -x` passes (269 tests)
- [x] Manually tested `curl /v1/health` returns 200 with auth configured on FastAPI 0.137