### PR TITLE
feat(inference, messages): add anthropic_count_tokens to OpenAIMixin via translation

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -3801,7 +3801,7 @@ paths:
       tags:
       - Messages
       summary: Count tokens in a message.
-      description: Count the number of tokens in a message request.
+      description: Count the number of tokens in a message request. For some providers, this will cost input tokens and 1 output token.
       operationId: count_message_tokens_v1_messages_count_tokens_post
       requestBody:
         content:

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -3406,7 +3406,7 @@ paths:
       tags:
       - Messages
       summary: Count tokens in a message.
-      description: Count the number of tokens in a message request.
+      description: Count the number of tokens in a message request. For some providers, this will cost input tokens and 1 output token.
       operationId: count_message_tokens_v1_messages_count_tokens_post
       requestBody:
         content:

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -3801,7 +3801,7 @@ paths:
       tags:
       - Messages
       summary: Count tokens in a message.
-      description: Count the number of tokens in a message request.
+      description: Count the number of tokens in a message request. For some providers, this will cost input tokens and 1 output token.
       operationId: count_message_tokens_v1_messages_count_tokens_post
       requestBody:
         content:

--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -650,7 +650,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         self,
         params: AnthropicCountTokensRequest,
     ) -> AnthropicCountTokensResponse:
-        msg_request = AnthropicCreateMessageRequest.model_construct(
+        msg_request = AnthropicCreateMessageRequest(
             model=params.model,
             messages=params.messages,
             max_tokens=1,

--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -661,9 +661,6 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
 
         result = await self.anthropic_messages(msg_request)
 
-        if not isinstance(result, AnthropicMessageResponse):
-            raise RuntimeError("Failed to count tokens: expected non-streaming response, got streaming")
-
         return AnthropicCountTokensResponse(input_tokens=result.usage.input_tokens)
 
     #

--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -650,7 +650,21 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         self,
         params: AnthropicCountTokensRequest,
     ) -> AnthropicCountTokensResponse:
-        raise NotImplementedError("anthropic_count_tokens via translation not yet implemented")
+        msg_request = AnthropicCreateMessageRequest.model_construct(
+            model=params.model,
+            messages=params.messages,
+            max_tokens=1,
+            system=params.system,
+            tools=params.tools,
+            stream=False,
+        )
+
+        result = await self.anthropic_messages(msg_request)
+
+        if not isinstance(result, AnthropicMessageResponse):
+            raise RuntimeError("Failed to count tokens: expected non-streaming response, got streaming")
+
+        return AnthropicCountTokensResponse(input_tokens=result.usage.input_tokens)
 
     #
     # The model_dump implementations are to avoid serializing the extra fields,

--- a/src/ogx_api/messages/fastapi_routes.py
+++ b/src/ogx_api/messages/fastapi_routes.py
@@ -183,7 +183,7 @@ def create_router(impl: Messages) -> APIRouter:
         "/messages/count_tokens",
         response_model=AnthropicCountTokensResponse,
         summary="Count tokens in a message.",
-        description="Count the number of tokens in a message request.",
+        description="Count the number of tokens in a message request. For some providers, this will cost input tokens and 1 output token.",
         responses={
             200: {"description": "Token count for the request."},
         },

--- a/tests/unit/providers/utils/inference/test_openai_mixin_inference.py
+++ b/tests/unit/providers/utils/inference/test_openai_mixin_inference.py
@@ -566,19 +566,3 @@ class TestOpenAIMixinAnthropicCountTokens:
         assert call_args.system is not None
         assert call_args.tools is not None
         mixin.anthropic_messages = original_anthropic_messages
-
-    async def test_count_tokens_raises_on_streaming_response(self, mixin, mock_client_context):
-        """Test that count tokens raises when anthropic_messages returns streaming"""
-
-        async def fake_stream():
-            yield None
-
-        mixin.anthropic_messages = AsyncMock(return_value=fake_stream())
-
-        with pytest.raises(RuntimeError, match="expected non-streaming response"):
-            await mixin.anthropic_count_tokens(
-                AnthropicCountTokensRequest(
-                    model="gpt-4",
-                    messages=[AnthropicMessage(role="user", content="Hello")],
-                )
-            )

--- a/tests/unit/providers/utils/inference/test_openai_mixin_inference.py
+++ b/tests/unit/providers/utils/inference/test_openai_mixin_inference.py
@@ -14,6 +14,14 @@ from ogx_api import (
     OpenAIEmbeddingsRequestWithExtraBody,
     OpenAIUserMessageParam,
 )
+from ogx_api.messages.models import (
+    AnthropicCountTokensRequest,
+    AnthropicCustomToolDef,
+    AnthropicMessage,
+    AnthropicMessageResponse,
+    AnthropicTextBlock,
+    AnthropicUsage,
+)
 
 
 class TestOpenAIMixinAllowedModelsInference:
@@ -502,3 +510,75 @@ class TestOpenAIMixinUserProvidedStreamOptions:
                 assert call_kwargs["stream_options"]["include_usage"] is True
                 # Other options should be preserved
                 assert call_kwargs["stream_options"]["other_option"] is True
+
+
+class TestOpenAIMixinAnthropicCountTokens:
+    """Test cases for anthropic_count_tokens via anthropic_messages translation"""
+
+    async def test_count_tokens_returns_input_tokens(self, mixin, mock_client_context):
+        """Test that count tokens delegates to anthropic_messages with max_tokens=1"""
+        mock_response = AnthropicMessageResponse(
+            id="msg_test",
+            content=[AnthropicTextBlock(text="Hi")],
+            model="gpt-4",
+            stop_reason="max_tokens",
+            usage=AnthropicUsage(input_tokens=42, output_tokens=1),
+        )
+
+        original_anthropic_messages = mixin.anthropic_messages
+        mixin.anthropic_messages = AsyncMock(return_value=mock_response)
+
+        request = AnthropicCountTokensRequest(
+            model="gpt-4",
+            messages=[AnthropicMessage(role="user", content="Hello")],
+        )
+        result = await mixin.anthropic_count_tokens(request)
+
+        assert result.input_tokens == 42
+        mixin.anthropic_messages.assert_awaited_once()
+        call_args = mixin.anthropic_messages.call_args[0][0]
+        assert call_args.max_tokens == 1
+        mixin.anthropic_messages = original_anthropic_messages
+
+    async def test_count_tokens_with_system_and_tools(self, mixin, mock_client_context):
+        """Test that count tokens passes system prompt and tools through"""
+        mock_response = AnthropicMessageResponse(
+            id="msg_test",
+            content=[AnthropicTextBlock(text="Hi")],
+            model="gpt-4",
+            stop_reason="max_tokens",
+            usage=AnthropicUsage(input_tokens=100, output_tokens=1),
+        )
+
+        original_anthropic_messages = mixin.anthropic_messages
+        mixin.anthropic_messages = AsyncMock(return_value=mock_response)
+
+        request = AnthropicCountTokensRequest(
+            model="gpt-4",
+            system=[AnthropicTextBlock(text="You are helpful.")],
+            messages=[AnthropicMessage(role="user", content="Count me")],
+            tools=[AnthropicCustomToolDef(name="calculator", input_schema={"type": "object"})],
+        )
+        result = await mixin.anthropic_count_tokens(request)
+
+        assert result.input_tokens == 100
+        call_args = mixin.anthropic_messages.call_args[0][0]
+        assert call_args.system is not None
+        assert call_args.tools is not None
+        mixin.anthropic_messages = original_anthropic_messages
+
+    async def test_count_tokens_raises_on_streaming_response(self, mixin, mock_client_context):
+        """Test that count tokens raises when anthropic_messages returns streaming"""
+
+        async def fake_stream():
+            yield None
+
+        mixin.anthropic_messages = AsyncMock(return_value=fake_stream())
+
+        with pytest.raises(RuntimeError, match="expected non-streaming response"):
+            await mixin.anthropic_count_tokens(
+                AnthropicCountTokensRequest(
+                    model="gpt-4",
+                    messages=[AnthropicMessage(role="user", content="Hello")],
+                )
+            )


### PR DESCRIPTION
Implement token counting for providers using OpenAIMixin by delegating to anthropic_messages with max_tokens=1 and extracting input_tokens from the response usage.
