### PR TITLE
fix(containers): pass --insecure to entrypoint to restore starter image boot

### DIFF
--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -209,14 +209,14 @@ fi
 CLI_NAME="${CLI_NAME:-ogx}"
 
 if [ -n "$RUN_CONFIG_PATH" ] && [ -f "$RUN_CONFIG_PATH" ]; then
-  exec $CMD_PREFIX "$CLI_NAME" stack run "$RUN_CONFIG_PATH" "$@"
+  exec $CMD_PREFIX "$CLI_NAME" stack run --insecure "$RUN_CONFIG_PATH" "$@"
 fi
 
 if [ -n "$DISTRO_NAME" ]; then
-  exec $CMD_PREFIX "$CLI_NAME" stack run "$DISTRO_NAME" "$@"
+  exec $CMD_PREFIX "$CLI_NAME" stack run --insecure "$DISTRO_NAME" "$@"
 fi
 
-exec $CMD_PREFIX "$CLI_NAME" stack run "$@"
+exec $CMD_PREFIX "$CLI_NAME" stack run --insecure "$@"
 EOF
 RUN chmod +x /usr/local/bin/ogx-entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Since #5603 introduced TLS as a hard requirement, the starter container fails to start without TLS certs
- Add `--insecure` to all `ogx stack run` invocations in the entrypoint script to restore the previous behaviour

## Test plan

```
podman run -it --rm docker.io/ogxai/distribution-starter:latest
```

Before: `TLS required: set tls_certfile/tls_keyfile in server config or pass '--insecure' to disable.`
After: server starts normally