### PR TITLE
fix(inference): strip duplicate /v1 prefix in vLLM Anthropic message URLs

### DIFF
--- a/src/ogx/providers/remote/inference/vllm/vllm.py
+++ b/src/ogx/providers/remote/inference/vllm/vllm.py
@@ -233,12 +233,19 @@ class VLLMInferenceAdapter(OpenAIMixin):
 
         return _wrap_chunks()
 
+    def _get_base_url_without_version(self) -> str:
+        """Get the base URL with any trailing /v1 suffix removed."""
+        base_url = str(self.get_base_url()).rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+        return base_url
+
     async def anthropic_messages(
         self,
         params: AnthropicCreateMessageRequest,
     ) -> AnthropicMessageResponse | AsyncIterator[AnthropicStreamEvent]:
         """Handle Anthropic Messages via native /v1/messages endpoint."""
-        url = f"{self.get_base_url()}/v1/messages"
+        url = f"{self._get_base_url_without_version()}/v1/messages"
         body = params.model_dump(exclude_none=True)
         body["model"] = params.model
         headers = {
@@ -268,7 +275,7 @@ class VLLMInferenceAdapter(OpenAIMixin):
         params: AnthropicCountTokensRequest,
     ) -> AnthropicCountTokensResponse:
         """Forward count_tokens to vLLM's /v1/messages/count_tokens endpoint."""
-        url = f"{self.get_base_url()}/v1/messages/count_tokens"
+        url = f"{self._get_base_url_without_version()}/v1/messages/count_tokens"
         body = params.model_dump(exclude_none=True)
         body["model"] = params.model
         headers = {
@@ -353,7 +360,7 @@ class VLLMInferenceAdapter(OpenAIMixin):
         #   "To indicate that the rerank API is not part of the standard OpenAI API,
         #    we have located it at `/rerank`. Please update your client accordingly.
         #    (Note: Conforms to JinaAI rerank API)" - vLLM 0.15.1
-        endpoint = self.get_base_url().replace("/v1", "") + "/rerank"  # TODO: find a better solution
+        endpoint = self._get_base_url_without_version() + "/rerank"
 
         headers: dict[str, str] = {}
         api_key = self._get_api_key_from_config_or_provider_data()

--- a/tests/unit/providers/inference/test_remote_vllm.py
+++ b/tests/unit/providers/inference/test_remote_vllm.py
@@ -625,6 +625,86 @@ class TestRerankTLSAndAuth:
             assert headers.get("Authorization") == "Bearer provider-data-token"
 
 
+class TestBaseUrlVersionStripping:
+    """Regression tests for double /v1/v1/ path bug (issue #6290)."""
+
+    @pytest.mark.parametrize(
+        "base_url, expected",
+        [
+            ("http://localhost:8000/v1", "http://localhost:8000"),
+            ("http://localhost:8000/v1/", "http://localhost:8000"),
+            ("http://localhost:8000", "http://localhost:8000"),
+            ("http://localhost:8000/", "http://localhost:8000"),
+        ],
+    )
+    def test_get_base_url_without_version(self, base_url, expected):
+        config = VLLMInferenceAdapterConfig(base_url=base_url)
+        adapter = VLLMInferenceAdapter(config=config)
+        assert adapter._get_base_url_without_version() == expected
+
+    async def test_anthropic_messages_no_double_v1(self):
+        config = VLLMInferenceAdapterConfig(base_url="http://localhost:8000/v1")
+        adapter = VLLMInferenceAdapter(config=config)
+        await adapter.initialize()
+        adapter.get_request_provider_data = MagicMock(return_value=None)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hello"}],
+                "model": "test-model",
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            }
+            mock_client_instance = MagicMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+            from ogx_api.messages.models import AnthropicCreateMessageRequest
+
+            request = AnthropicCreateMessageRequest(
+                model="test-model",
+                max_tokens=100,
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+            await adapter.anthropic_messages(request)
+
+            url_called = mock_client_instance.post.call_args[0][0]
+            assert url_called == "http://localhost:8000/v1/messages"
+            assert "/v1/v1/" not in url_called
+
+    async def test_anthropic_count_tokens_no_double_v1(self):
+        config = VLLMInferenceAdapterConfig(base_url="http://localhost:8000/v1")
+        adapter = VLLMInferenceAdapter(config=config)
+        await adapter.initialize()
+        adapter.get_request_provider_data = MagicMock(return_value=None)
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = {"input_tokens": 10}
+            mock_client_instance = MagicMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_client_class.return_value.__aenter__.return_value = mock_client_instance
+
+            from ogx_api.messages.models import AnthropicCountTokensRequest
+
+            request = AnthropicCountTokensRequest(
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            await adapter.anthropic_count_tokens(request)
+
+            url_called = mock_client_instance.post.call_args[0][0]
+            assert url_called == "http://localhost:8000/v1/messages/count_tokens"
+            assert "/v1/v1/" not in url_called
+
+
 class TestFairnessHeaderPropagation:
     """Tests for llm-d fairness header injection via _get_extra_request_headers."""
 


### PR DESCRIPTION
## Summary

- Strip trailing `/v1` from the vLLM base URL before constructing Anthropic Messages API paths, fixing a double `/v1/v1/` that caused 404s
- Add `_get_base_url_without_version()` helper matching the existing Ollama adapter pattern, and use it in `anthropic_messages()`, `anthropic_count_tokens()`, and `rerank()`
- Add 6 regression tests covering URL construction with various base URL formats

Closes #6290

## Test plan

- [x] Existing vLLM unit tests pass (33/33)
- [x] New `TestBaseUrlVersionStripping` parametrized tests verify `/v1` stripping for base URLs with/without trailing `/v1` and trailing slash
- [x] New integration-style tests verify `anthropic_messages()` and `anthropic_count_tokens()` construct `http://localhost:8000/v1/messages` (not `/v1/v1/messages`) when `base_url=http://localhost:8000/v1`
- [x] Pre-commit hooks pass (ruff, mypy, all project checks)

```bash
uv run pytest tests/unit/providers/inference/test_remote_vllm.py -v --tb=short
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)