### PR TITLE
docs: add OpenAI-compatible gateway example with DaoXE

### DIFF
--- a/docs/docs/distributions/openai_compatible_gateways.mdx
+++ b/docs/docs/distributions/openai_compatible_gateways.mdx
@@ -1,0 +1,114 @@
+---
+title: OpenAI-compatible remote gateways
+description: Point the remote::openai inference provider at any OpenAI-compatible API, including multi-model gateways such as DaoXE.
+sidebar_label: OpenAI-compatible gateways
+sidebar_position: 5
+---
+
+# OpenAI-compatible remote gateways
+
+OGX's [`remote::openai`](/docs/providers/inference/remote_openai) inference provider talks to any endpoint that implements the OpenAI Chat Completions (and related) HTTP surface. You do not need a custom provider package for third-party multi-model gateways: set `base_url` (and an API key) on `remote::openai`.
+
+This is the same mechanism the [starter distribution](/docs/distributions/self_hosted_distro/starter) uses when you export `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`. See also the [OpenAI API compatibility](/docs/api-openai/) overview and the [Open Responses / OpenAI compatibility blog post](/blog/open-responses-openai-compatibility).
+
+## Example: DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model, multi-protocol API gateway. For OGX, use its **OpenAI-compatible** base URL:
+
+```text
+https://daoxe.com/v1
+```
+
+DaoXE also exposes other client protocols (for example Anthropic Messages) for non-OGX clients. Inside OGX you configure only the OpenAI-compatible path above.
+
+:::note Availability
+DaoXE is **not available in mainland China**. Create an account and API key at [daoxe.com](https://daoxe.com). Model IDs are **account-scoped** (availability can differ by plan or group). Always discover exact IDs with authenticated `GET /v1/models` rather than hard-coding a public catalog.
+:::
+
+### Option A — starter distribution + environment variables
+
+```bash
+export OPENAI_API_KEY="your_daoxe_api_key"
+export OPENAI_BASE_URL="https://daoxe.com/v1"
+uvx --from 'ogx[starter]' ogx run starter
+```
+
+With the starter's default `provider_id: openai`, registered model IDs look like `openai/<upstream_model_id>`. List them after the server is up:
+
+```bash
+curl -s http://localhost:8321/v1/models | python -m json.tool
+```
+
+### Option B — explicit `config.yaml` entry
+
+Prefer a dedicated provider ID when you also keep a direct OpenAI key, or when you want clearer model prefixes:
+
+```yaml
+version: 2
+apis:
+  - inference
+  - responses
+providers:
+  inference:
+    - provider_id: daoxe
+      provider_type: remote::openai
+      config:
+        api_key: ${env.DAOXE_API_KEY}
+        base_url: https://daoxe.com/v1
+        # Optional: pin models after discovery
+        # allowed_models:
+        #   - your_exact_model_id
+        refresh_models: true
+```
+
+Start the server with that config (see [Customizing config.yaml](/docs/distributions/customizing_run_yaml) and [Starting the OGX server](/docs/distributions/starting_ogx_server)). Model IDs will be prefixed with the provider ID, for example `daoxe/<your_exact_model_id>`.
+
+### Call OGX with the OpenAI SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8321/v1", api_key="fake")
+
+# Replace with an ID from GET /v1/models for your server
+response = client.chat.completions.create(
+    model="daoxe/your_exact_model_id",
+    messages=[{"role": "user", "content": "Hello from OGX + DaoXE"}],
+    max_tokens=64,
+)
+print(response.choices[0].message.content)
+```
+
+### Call DaoXE directly (without OGX)
+
+If you only need the gateway (no vector stores, Responses orchestration, etc.), point the OpenAI client at DaoXE:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://daoxe.com/v1",
+    api_key="your_daoxe_api_key",
+)
+
+response = client.chat.completions.create(
+    model="your_exact_model_id",  # from DaoXE GET /v1/models
+    messages=[{"role": "user", "content": "Hello"}],
+    max_tokens=64,
+)
+print(response.choices[0].message.content)
+```
+
+Auditable examples and a low-cost smoke benchmark live at [seven7763/DaoXE-AI](https://github.com/seven7763/DaoXE-AI).
+
+## Related providers
+
+| Goal | Provider |
+|------|----------|
+| OpenAI API or any OpenAI-compatible gateway (`base_url` override) | [`remote::openai`](/docs/providers/inference/remote_openai) |
+| Arbitrary OpenAI-compatible endpoint without a fixed default URL | [`remote::passthrough`](/docs/providers/inference/remote_passthrough) |
+| Llama API OpenAI-compat surface | [`remote::llama-openai-compat`](/docs/providers/inference/remote_llama-openai-compat) |
+
+## Disclosure
+
+This page was contributed by a DaoXE maintainer. Configuration uses only stock OGX providers; no DaoXE-specific adapter is required.

--- a/docs/docs/providers/openai.mdx
+++ b/docs/docs/providers/openai.mdx
@@ -206,3 +206,4 @@ Art in hidden form
 - **[OpenAI API Compatibility Guide](/docs/api-openai/)** - Comprehensive overview of OpenAI compatibility features
 - **[OpenAI Responses API Limitations](/docs/providers/openai_responses_limitations)** - Detailed limitations and known issues
 - **[Provider Documentation](/docs/providers/)** - Complete provider ecosystem overview
+- **[OpenAI-compatible remote gateways](/docs/distributions/openai_compatible_gateways)** - Point `remote::openai` at multi-model gateways (for example DaoXE) via `base_url`

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -97,6 +97,7 @@ const sidebars: SidebarsConfig = {
         'distributions/list_of_distributions',
         'distributions/building_distro',
         'distributions/customizing_run_yaml',
+        'distributions/openai_compatible_gateways',
         'distributions/importing_as_library',
         'distributions/configuration',
         'distributions/starting_ogx_server',


### PR DESCRIPTION
# What does this PR do?

Adds a short docs page showing how to use the existing **`remote::openai`** inference provider against a third-party **OpenAI-compatible multi-model gateway**, with [DaoXE](https://daoxe.com) as a concrete example.

DaoXE base URL for OpenAI clients / OGX:

```text
https://daoxe.com/v1
```

The page covers:

- Starter distribution via `OPENAI_API_KEY` + `OPENAI_BASE_URL=https://daoxe.com/v1`
- Explicit `config.yaml` with `provider_type: remote::openai` and `provider_id: daoxe`
- OpenAI SDK calls against a local OGX server and against DaoXE directly
- Account-scoped model IDs (discover via authenticated `GET /v1/models`; no hardcoded catalog)
- Note that DaoXE is multi-protocol (OpenAI + Anthropic Messages, etc.) but OGX uses the OpenAI-compatible path
- Availability note: **not available in mainland China**
- Maintainer disclosure

Also links the page from the Distributions sidebar and from the OpenAI Implementation Guide resources.

Related existing docs:

- [Open Responses / OpenAI compatibility blog](https://github.com/ogx-ai/ogx/blob/main/docs/blog/2026-03-20-open-responses-openai-compatibility.md)
- [`remote::openai` provider](https://github.com/ogx-ai/ogx/blob/main/docs/docs/providers/inference/remote_openai.mdx)
- [OpenAI API compatibility](https://github.com/ogx-ai/ogx/blob/main/docs/docs/api-openai/index.mdx)

Examples: https://github.com/seven7763/DaoXE-AI

Note: `meta-llama/llama-stack` redirects to `ogx-ai/ogx` (project rename). This PR targets the current canonical repo.

## Test Plan

- [ ] Docs page renders at `/docs/distributions/openai_compatible_gateways`
- [ ] Sidebar **Distributions** lists **OpenAI-compatible gateways** after Customizing config.yaml
- [ ] Link from `/docs/providers/openai` Additional Resources resolves
- [ ] Internal links resolve (`remote_openai`, starter, customizing_run_yaml, api-openai, blog slug)
- Docs-only change; no runtime code