### PR TITLE
fix(ci): publish ogx-client-typescript now that its release branches exist

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -245,11 +245,7 @@ jobs:
           PACKAGE="${{ matrix.package }}"
           TYPE="${{ matrix.type }}"
 
-          # TEMPORARY: skip ogx-client-typescript until external repo has release branch
-          if [ "$PACKAGE" == "ogx-client-typescript" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping $PACKAGE (temporarily disabled)"
-          elif [ "$PACKAGES" == "all" ]; then
+          if [ "$PACKAGES" == "all" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "$PACKAGES" == "ogx-only" ] && { [ "$TYPE" == "local" ] || [ "$TYPE" == "openapi-sdk" ]; }; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -790,11 +786,7 @@ jobs:
           PACKAGE="${{ matrix.package }}"
           TYPE="${{ matrix.type }}"
 
-          # TEMPORARY: skip ogx-client-typescript until external repo has release branch
-          if [ "$PACKAGE" == "ogx-client-typescript" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping publish for $PACKAGE (temporarily disabled)"
-          elif [ "$PACKAGES" == "all" ]; then
+          if [ "$PACKAGES" == "all" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "$PACKAGES" == "ogx-only" ] && { [ "$TYPE" == "local" ] || [ "$TYPE" == "openapi-sdk" ]; }; then
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Both the build and publish matrices in `pypi.yml` special-cased `ogx-client-typescript` with an unconditional `skip=true`, added while the external `ogx-client-typescript` repo lacked matching release branches:

```bash
# TEMPORARY: skip ogx-client-typescript until external repo has release branch
if [ "$PACKAGE" == "ogx-client-typescript" ]; then
  echo "skip=true" ...
```

Those branches now exist (`main` and `release-1.2.x` in `ogx-ai/ogx-client-typescript`), so the temporary guard is no longer needed. Remove both guards (build `should-build` and publish `should-publish`) so the TypeScript client flows through the normal `packages` selection (`all` / `clients-only`) like every other package.

No matrix changes needed on `main` — both TS entries were already live (they're what keeps actionlint happy on `matrix.repo`). This only removes the runtime skip.

## Effect

- `packages: all` (default) and `packages: clients-only` now build **and** publish `ogx-client-typescript` to npm.
- Python packages unchanged.

## Backport note

The `release-1.2.x` backport needs one extra change beyond this diff: its **publish** matrix entry for `ogx-client-typescript` is still commented out (only the build-matrix entry was restored in #6300), so it must be uncommented there too.

## Test plan

- `actionlint` pre-commit hook passes on the edited `pypi.yml`.
- The npm build/publish path is exercised on the next `clients-only`/`all` release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)