### PR TITLE
fix(ci): publish ogx-client-typescript on release-1.2.x (backport #6301)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -244,11 +244,7 @@ jobs:
           PACKAGE="${{ matrix.package }}"
           TYPE="${{ matrix.type }}"
 
-          # TEMPORARY: skip ogx-client-typescript until external repo has release branch
-          if [ "$PACKAGE" == "ogx-client-typescript" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping $PACKAGE (temporarily disabled)"
-          elif [ "$PACKAGES" == "all" ]; then
+          if [ "$PACKAGES" == "all" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "$PACKAGES" == "ogx-only" ] && { [ "$TYPE" == "local" ] || [ "$TYPE" == "openapi-sdk" ]; }; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -767,10 +763,9 @@ jobs:
       matrix:
         include:
           # Order matters! Dependencies are published first
-          # TEMPORARY: ogx-client-typescript disabled until external repo has release-1.2.x branch
-          # - package: ogx-client-typescript
-          #   registry: npm
-          #   type: external
+          - package: ogx-client-typescript
+            registry: npm
+            type: external
           - package: ogx-client
             registry: pypi
             type: openapi-sdk
@@ -790,11 +785,7 @@ jobs:
           PACKAGE="${{ matrix.package }}"
           TYPE="${{ matrix.type }}"
 
-          # TEMPORARY: skip ogx-client-typescript until external repo has release branch
-          if [ "$PACKAGE" == "ogx-client-typescript" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping publish for $PACKAGE (temporarily disabled)"
-          elif [ "$PACKAGES" == "all" ]; then
+          if [ "$PACKAGES" == "all" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "$PACKAGES" == "ogx-only" ] && { [ "$TYPE" == "local" ] || [ "$TYPE" == "openapi-sdk" ]; }; then
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Backport of #6301 to `release-1.2.x`, enabling the TypeScript client in the release publish pipeline now that `ogx-ai/ogx-client-typescript` has a matching `release-1.2.x` branch.

`release-1.2.x` needed **three** edits (one more than #6301 on main, whose publish-matrix entry was already live):

1. Remove the build `should-build` TEMPORARY skip for `ogx-client-typescript`.
2. **Restore the `ogx-client-typescript` entry in the publish matrix** — it was still commented out here; #6300 only restored the *build* matrix entry (to fix actionlint).
3. Remove the publish `should-publish` TEMPORARY skip.

## Effect

With this on `release-1.2.x`, a `packages: all` (default) or `clients-only` release run builds **and** publishes `ogx-client-typescript` to npm, alongside the Python packages. A 1.2.1 cut will then include the TS client.

## Test plan

- `actionlint` pre-commit hook passes on the edited `pypi.yml`.
- The npm build/publish path is exercised on the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)