### PR TITLE
fix(vector_io): prevent duplicate libomp crash when importing faiss on macOS

### DIFF
--- a/src/ogx/providers/inline/vector_io/faiss/faiss.py
+++ b/src/ogx/providers/inline/vector_io/faiss/faiss.py
@@ -8,6 +8,8 @@ import asyncio
 import base64
 import io
 import json
+import os
+import sys
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +27,12 @@ def _get_faiss() -> Any:
     with _faiss_lock:
         if _faiss is not None:
             return _faiss
+        # faiss links against OpenMP; on macOS another dependency (e.g. torch,
+        # scipy) may already have loaded libomp, causing a fatal duplicate-
+        # runtime crash (OMP Error #15: "found libomp already initialized").
+        if sys.platform == "darwin":
+            os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+            logger.debug("Set KMP_DUPLICATE_LIB_OK=TRUE to avoid duplicate libomp crash")
         import faiss  # type: ignore[import-untyped]
 
         _faiss = faiss


### PR DESCRIPTION
# What does this PR do?

Fixes a fatal server crash (OMP Error #15) that occurs on macOS when faiss and another dependency (e.g. torch, scipy) each load their own copy of `libomp.dylib`. The fix sets `KMP_DUPLICATE_LIB_OK=TRUE` before importing faiss, scoped to macOS only via `sys.platform == "darwin"`, with a debug log for visibility.

## Test Plan

1. Run the server on macOS with faiss and another OpenMP-linked library installed
2. Trigger a vector store operation (e.g. `POST /v1/vector_stores`) that causes faiss to be loaded
3. Verify the server no longer crashes with `OMP: Error #15: Initializing libomp.dylib, but found libomp.dylib already initialized`
4. Check debug logs for `Set KMP_DUPLICATE_LIB_OK=TRUE to avoid duplicate libomp crash`

Pre-commit checks all pass:
```
uv run pre-commit run --all-files  # all passed
```