### PR TITLE
fix(server): warn at startup when authentication is not configured

### DIFF
--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -486,6 +486,13 @@ def create_app() -> StackApp:
 
     validate_auth_security(config)
 
+    if not (config.server.auth and config.server.auth.provider_config):
+        logger.warning(
+            "Authentication is not configured. All API endpoints are accessible without credentials. "
+            "See https://ogx-ai.github.io/distributions/configuration#authentication-configuration"
+            " to configure authentication.",
+        )
+
     if config.server.auth:
         # Add route authorization middleware if route_policy is configured
         # This can work independently of authentication

--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -489,7 +489,7 @@ def create_app() -> StackApp:
     if not (config.server.auth and config.server.auth.provider_config):
         logger.warning(
             "Authentication is not configured. All API endpoints are accessible without credentials. "
-            "See https://ogx-ai.github.io/distributions/configuration#authentication-configuration"
+            "See https://ogx-ai.github.io/docs/distributions/configuration#authentication-configuration"
             " to configure authentication.",
         )
 


### PR DESCRIPTION
## Summary
- Adds a server-level warning log at startup when no authentication provider is configured, making the unauthenticated state explicit in server logs
- Checks the actual `provider_config` on the auth configuration object, not environment variables, so it correctly reflects the server's auth state regardless of how config is provided
- No behavior change — the server continues to start and function exactly as before

This benefits all OGX deployments rather than requiring each distribution to add its own entrypoint checks (see opendatahub-io/ogx-distribution#502 for context).

## Test plan
- [x] Unit tests pass (`tests/unit/server/test_server.py` — 17/17)
- [x] Pre-commit hooks pass
- [ ] Verify warning appears in server logs when no auth provider is configured
- [ ] Verify warning does not appear when an auth provider is configured
- [ ] Verify server starts and functions normally in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)