### PR TITLE
fix(core): return requested model id in streamed completion chunks

### DIFF
--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -189,7 +189,7 @@ class InferenceRouter(Inference):
     async def openai_completion(
         self,
         params: Annotated[OpenAICompletionRequestWithExtraBody, Body(...)],
-    ) -> OpenAICompletion:
+    ) -> OpenAICompletion | AsyncIterator[OpenAICompletion]:
         logger.debug(
             "InferenceRouter.openai_completion: model=, stream=, prompt",
             model=params.model,
@@ -204,11 +204,25 @@ class InferenceRouter(Inference):
         params.model = provider_resource_id
 
         if params.stream:
-            return await provider.openai_completion(params)
+            response_stream = await provider.openai_completion(params)
+            # Providers respond with their internal model id, so rewrite each
+            # chunk to carry the fully qualified model id the client requested
+            # (mirrors the non-streaming path below and the chat-streaming path).
+            return self._rewrite_completion_stream_model_id(response_stream, request_model_id)
 
         response = await provider.openai_completion(params)
         response.model = request_model_id
         return response
+
+    async def _rewrite_completion_stream_model_id(
+        self,
+        response: AsyncIterator[OpenAICompletion],
+        fully_qualified_model_id: str,
+    ) -> AsyncIterator[OpenAICompletion]:
+        """Yield streamed completion chunks with the requested model id restored."""
+        async for chunk in response:
+            chunk.model = fully_qualified_model_id
+            yield chunk
 
     async def openai_chat_completion(
         self,

--- a/tests/unit/core/routers/test_inference_router.py
+++ b/tests/unit/core/routers/test_inference_router.py
@@ -23,11 +23,14 @@ import pytest
 from ogx.core.routers.inference import InferenceRouter
 from ogx_api import (
     ModelType,
+    OpenAICompletion,
+    OpenAICompletionRequestWithExtraBody,
     RerankData,
     RerankResponse,
     RoutingTable,
 )
 from ogx_api.inference import RerankRequest
+from ogx_api.inference.models import OpenAICompletionChoice
 
 
 @pytest.fixture
@@ -47,6 +50,93 @@ def mock_routing_table():
     routing_table.get_provider_impl = AsyncMock(return_value=mock_provider)
 
     return routing_table, mock_provider
+
+
+@pytest.fixture
+def mock_llm_routing_table():
+    """Create a mock routing table with an LLM model registered under a fully qualified id"""
+    routing_table = MagicMock(spec=RoutingTable)
+
+    mock_model = MagicMock()
+    mock_model.identifier = "test_provider/test-llm-model"
+    mock_model.model_type = ModelType.llm
+    mock_model.provider_resource_id = "test-llm-model"
+
+    mock_provider = MagicMock()
+    mock_provider.__provider_id__ = "test_provider"
+
+    routing_table.get_object_by_identifier = AsyncMock(return_value=mock_model)
+    routing_table.get_provider_impl = AsyncMock(return_value=mock_provider)
+
+    return routing_table, mock_provider
+
+
+def _make_completion_chunk(text: str, model: str) -> OpenAICompletion:
+    return OpenAICompletion(
+        id="cmpl-test",
+        choices=[OpenAICompletionChoice(finish_reason="stop", text=text, index=0)],
+        created=0,
+        model=model,
+        object="text_completion",
+    )
+
+
+async def test_openai_completion_streaming_rewrites_model_id(mock_llm_routing_table):
+    """
+    Test that streamed /v1/completions chunks report the fully qualified model id
+    that the client requested, not the provider-internal resource id.
+
+    This mirrors the non-streaming path in openai_completion (which sets
+    response.model = request_model_id) and the chat streaming path
+    (stream_tokens_and_compute_metrics_openai_chat, which rewrites chunk.model).
+    """
+    routing_table, mock_provider = mock_llm_routing_table
+    router = InferenceRouter(routing_table=routing_table)
+
+    async def provider_stream():
+        # Providers respond with their internal model id
+        yield _make_completion_chunk("Hello", model="test-llm-model")
+        yield _make_completion_chunk(" world", model="test-llm-model")
+
+    mock_provider.openai_completion = AsyncMock(return_value=provider_stream())
+
+    params = OpenAICompletionRequestWithExtraBody(
+        model="test_provider/test-llm-model",
+        prompt="Say hello",
+        stream=True,
+    )
+
+    stream = await router.openai_completion(params)
+    chunks = [chunk async for chunk in stream]
+
+    assert len(chunks) == 2
+    assert [chunk.model for chunk in chunks] == ["test_provider/test-llm-model", "test_provider/test-llm-model"], (
+        "Streamed completion chunks should carry the requested model id, not the provider resource id"
+    )
+    assert [choice.text for chunk in chunks for choice in chunk.choices] == ["Hello", " world"]
+
+    # The provider itself should still be called with its own resource id
+    called_params = mock_provider.openai_completion.call_args.args[0]
+    assert called_params.model == "test-llm-model"
+
+
+async def test_openai_completion_non_streaming_rewrites_model_id(mock_llm_routing_table):
+    """Non-streaming /v1/completions responses report the requested model id (regression guard)."""
+    routing_table, mock_provider = mock_llm_routing_table
+    router = InferenceRouter(routing_table=routing_table)
+
+    mock_provider.openai_completion = AsyncMock(
+        return_value=_make_completion_chunk("Hello world", model="test-llm-model")
+    )
+
+    params = OpenAICompletionRequestWithExtraBody(
+        model="test_provider/test-llm-model",
+        prompt="Say hello",
+    )
+
+    response = await router.openai_completion(params)
+
+    assert response.model == "test_provider/test-llm-model"
 
 
 async def test_rerank_calls_provider_correctly(mock_routing_table):


### PR DESCRIPTION
# What does this PR do?

Fixes an inconsistency in `InferenceRouter.openai_completion`: streamed `/v1/completions` chunks report the provider-internal model id instead of the model id the client requested.

The router rewrites `params.model` to the provider's `provider_resource_id` before calling the provider. For non-streaming requests it then restores the requested fully qualified id (`response.model = request_model_id`), and the chat-completions streaming path does the same per chunk in `stream_tokens_and_compute_metrics_openai_chat` (`chunk.model = fully_qualified_model_id`). But the `stream=True` branch of `openai_completion` returned the provider stream untouched, so every streamed chunk leaked the provider-internal id — e.g. a client requesting `openai/gpt-4o` gets `model="openai/gpt-4o"` when not streaming but `model="gpt-4o"` on every streamed chunk. Clients that correlate responses by the model they requested (or that multiplex providers behind aliases) see different model ids depending solely on whether they streamed.

The fix wraps the provider stream in a small async generator that restores the requested model id on each chunk before yielding, mirroring the existing chat-streaming behavior. The return type annotation is also corrected to `OpenAICompletion | AsyncIterator[OpenAICompletion]`, matching the chat sibling.

## Test Plan

Added two unit tests in `tests/unit/core/routers/test_inference_router.py`:

- `test_openai_completion_streaming_rewrites_model_id` — fails on `main`, passes with this fix
- `test_openai_completion_non_streaming_rewrites_model_id` — regression guard for the already-correct non-streaming path

```
$ uv run pytest tests/unit/core/routers/ -q
83 passed, 1 warning in 4.12s
```

Standalone repro script (run from the repo root; not committed):

```python
import asyncio
from unittest.mock import AsyncMock, MagicMock

from ogx.core.routers.inference import InferenceRouter
from ogx_api import ModelType, OpenAICompletion, OpenAICompletionRequestWithExtraBody, RoutingTable
from ogx_api.inference.models import OpenAICompletionChoice


def make_chunk(text: str, model: str) -> OpenAICompletion:
    return OpenAICompletion(
        id="cmpl-1",
        choices=[OpenAICompletionChoice(finish_reason="stop", text=text, index=0)],
        created=0,
        model=model,
    )


async def main() -> None:
    routing_table = MagicMock(spec=RoutingTable)
    model = MagicMock()
    model.identifier = "openai/gpt-4o"
    model.model_type = ModelType.llm
    model.provider_resource_id = "gpt-4o"
    provider = MagicMock()
    provider.__provider_id__ = "openai"
    routing_table.get_object_by_identifier = AsyncMock(return_value=model)
    routing_table.get_provider_impl = AsyncMock(return_value=provider)
    router = InferenceRouter(routing_table=routing_table)

    # Non-streaming: provider answers with its internal id, router restores it
    provider.openai_completion = AsyncMock(return_value=make_chunk("hi", model="gpt-4o"))
    resp = await router.openai_completion(
        OpenAICompletionRequestWithExtraBody(model="openai/gpt-4o", prompt="hi")
    )
    print("non-stream response.model:", resp.model)

    # Streaming: provider chunks also carry the internal id
    async def provider_stream():
        yield make_chunk("hi", model="gpt-4o")
        yield make_chunk(" there", model="gpt-4o")

    provider.openai_completion = AsyncMock(return_value=provider_stream())
    stream = await router.openai_completion(
        OpenAICompletionRequestWithExtraBody(model="openai/gpt-4o", prompt="hi", stream=True)
    )
    models = [chunk.model async for chunk in stream]
    print("streaming chunk models:", models)
    assert models == ["openai/gpt-4o"] * 2, (
        f"BUG: streaming completion chunks expose provider-internal model id: {models}"
    )
    print("OK")


asyncio.run(main())
```

Output on `main` (before this fix):

```
non-stream response.model: openai/gpt-4o
streaming chunk models: ['gpt-4o', 'gpt-4o']
AssertionError: BUG: streaming completion chunks expose provider-internal model id: ['gpt-4o', 'gpt-4o']
```

Output with this fix:

```
non-stream response.model: openai/gpt-4o
streaming chunk models: ['openai/gpt-4o', 'openai/gpt-4o']
OK
```

`uv run pre-commit run --files src/ogx/core/routers/inference.py tests/unit/core/routers/test_inference_router.py` passes (ruff, ruff format, mypy, logging-style checks).
