### PR TITLE
feat(bedrock): auto-discover models via ListFoundationModels and mantle API

### DIFF
--- a/src/ogx/providers/remote/inference/bedrock/bedrock.py
+++ b/src/ogx/providers/remote/inference/bedrock/bedrock.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import asyncio
 from collections.abc import AsyncIterator, Iterable
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -38,6 +39,9 @@ from ogx_api import (
 )
 
 logger = get_logger(name=__name__, category="inference::bedrock")
+
+_BEDROCK_RUNTIME_URL = "https://bedrock-runtime.{region}.amazonaws.com/openai/v1"
+_BEDROCK_MANTLE_URL = "https://bedrock-mantle.{region}.api.aws/v1"
 
 
 class BedrockInferenceAdapter(OpenAIMixin):
@@ -83,8 +87,9 @@ class BedrockInferenceAdapter(OpenAIMixin):
 
     Credentials are automatically refreshed by boto3 when they expire.
 
-    Note: Bedrock's OpenAI-compatible endpoint does not support /v1/models
-    for dynamic model discovery. Models must be pre-registered in the config.
+    When SigV4 auth is active, models are auto-discovered via the
+    ListFoundationModels API. Bearer-token-only deployments must
+    pre-register models in the config.
     """
 
     provider_data_api_key_field: str | None = "aws_bearer_token_bedrock"
@@ -92,6 +97,7 @@ class BedrockInferenceAdapter(OpenAIMixin):
     # built once in initialize() so get_extra_client_params() can stay sync;
     # reusing one client also avoids opening a new socket per request
     _sigv4_http_client: httpx.AsyncClient | None = PrivateAttr(default=None)
+    _bedrock_client: Any = PrivateAttr(default=None)
 
     @property
     def _bedrock_config(self) -> "BedrockConfig":
@@ -102,8 +108,7 @@ class BedrockInferenceAdapter(OpenAIMixin):
         return self.config
 
     def get_base_url(self) -> str:
-        region = self._bedrock_config.region_name or "us-east-2"
-        return f"https://bedrock-runtime.{region}.amazonaws.com/openai/v1"
+        return _BEDROCK_RUNTIME_URL.format(region=self._bedrock_config.region_name or "us-east-2")
 
     def _should_use_sigv4(self) -> bool:
         # checked per-request so a bearer token in provider data can override SigV4 at runtime
@@ -151,6 +156,10 @@ class BedrockInferenceAdapter(OpenAIMixin):
         # per-request bearer token overrides are handled in get_extra_client_params()
         if not self._bedrock_config.has_bearer_token():
             self._sigv4_http_client = self._build_sigv4_http_client()
+            # separate boto3 client for the bedrock control-plane API (ListFoundationModels)
+            from ogx.providers.utils.bedrock.client import create_bedrock_client
+
+            self._bedrock_client = create_bedrock_client(self._bedrock_config, "bedrock")
 
     def get_api_key(self) -> str | None:
         if self._should_use_sigv4():
@@ -166,12 +175,31 @@ class BedrockInferenceAdapter(OpenAIMixin):
         return {}
 
     async def list_provider_model_ids(self) -> Iterable[str]:
-        # bedrock's openai-compatible endpoint doesn't expose /v1/models
-        return []
+        if self._bedrock_client is not None:
+            # SigV4 path: bedrock-runtime doesn't expose /v1/models,
+            # use the control-plane ListFoundationModels API instead
+            try:
+                response = await asyncio.to_thread(
+                    self._bedrock_client.list_foundation_models,
+                    byInferenceType="ON_DEMAND",
+                )
+            except Exception:
+                logger.warning("Failed to list Bedrock foundation models", exc_info=True)
+                return []
+            return [
+                m["modelId"] for m in response.get("modelSummaries", []) if m.get("modelLifecycleStatus") == "ACTIVE"
+            ]
+        # bearer token path: bedrock-runtime doesn't expose /v1/models,
+        # but the mantle endpoint does — query it directly
+        from openai import AsyncOpenAI
 
-    async def check_model_availability(self, model: str) -> bool:
-        # no /v1/models to query — accept whatever is registered in config
-        return True
+        mantle_url = _BEDROCK_MANTLE_URL.format(region=self._bedrock_config.region_name)
+        try:
+            client = AsyncOpenAI(base_url=mantle_url, api_key=self.get_api_key())
+            return [m.id async for m in client.models.list()]
+        except Exception:
+            logger.warning("Failed to list models from Bedrock mantle endpoint", exc_info=True)
+            return []
 
     async def shutdown(self) -> None:
         if self._sigv4_http_client is not None:

--- a/src/ogx/providers/remote/inference/bedrock/bedrock.py
+++ b/src/ogx/providers/remote/inference/bedrock/bedrock.py
@@ -157,9 +157,12 @@ class BedrockInferenceAdapter(OpenAIMixin):
         if not self._bedrock_config.has_bearer_token():
             self._sigv4_http_client = self._build_sigv4_http_client()
             # separate boto3 client for the bedrock control-plane API (ListFoundationModels)
-            from ogx.providers.utils.bedrock.client import create_bedrock_client
+            try:
+                from ogx.providers.utils.bedrock.client import create_bedrock_client
 
-            self._bedrock_client = create_bedrock_client(self._bedrock_config, "bedrock")
+                self._bedrock_client = create_bedrock_client(self._bedrock_config, "bedrock")
+            except Exception:
+                logger.debug("Could not create Bedrock control-plane client, model discovery will be skipped")
 
     def get_api_key(self) -> str | None:
         if self._should_use_sigv4():

--- a/src/ogx/providers/remote/inference/bedrock/bedrock.py
+++ b/src/ogx/providers/remote/inference/bedrock/bedrock.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from ogx.providers.remote.inference.bedrock.config import BedrockConfig
 
 import httpx
-from openai import AuthenticationError, PermissionDeniedError
+from openai import AsyncOpenAI, AuthenticationError, PermissionDeniedError
 from pydantic import PrivateAttr
 
 from ogx.log import get_logger
@@ -40,6 +40,7 @@ from ogx_api import (
 
 logger = get_logger(name=__name__, category="inference::bedrock")
 
+_DEFAULT_REGION = "us-east-2"
 _BEDROCK_RUNTIME_URL = "https://bedrock-runtime.{region}.amazonaws.com/openai/v1"
 _BEDROCK_MANTLE_URL = "https://bedrock-mantle.{region}.api.aws/v1"
 
@@ -87,9 +88,10 @@ class BedrockInferenceAdapter(OpenAIMixin):
 
     Credentials are automatically refreshed by boto3 when they expire.
 
-    When SigV4 auth is active, models are auto-discovered via the
-    ListFoundationModels API. Bearer-token-only deployments must
-    pre-register models in the config.
+    Models are auto-discovered at startup via two paths:
+    - SigV4 auth: uses the ListFoundationModels control-plane API
+    - Bearer token auth: queries the mantle endpoint's /v1/models
+    Pre-registered models in the config are also supported.
     """
 
     provider_data_api_key_field: str | None = "aws_bearer_token_bedrock"
@@ -108,7 +110,7 @@ class BedrockInferenceAdapter(OpenAIMixin):
         return self.config
 
     def get_base_url(self) -> str:
-        return _BEDROCK_RUNTIME_URL.format(region=self._bedrock_config.region_name or "us-east-2")
+        return _BEDROCK_RUNTIME_URL.format(region=self._bedrock_config.region_name or _DEFAULT_REGION)
 
     def _should_use_sigv4(self) -> bool:
         # checked per-request so a bearer token in provider data can override SigV4 at runtime
@@ -178,9 +180,11 @@ class BedrockInferenceAdapter(OpenAIMixin):
         return {}
 
     async def list_provider_model_ids(self) -> Iterable[str]:
-        if self._bedrock_client is not None:
+        if self._should_use_sigv4():
             # SigV4 path: bedrock-runtime doesn't expose /v1/models,
             # use the control-plane ListFoundationModels API instead
+            if self._bedrock_client is None:
+                return []
             try:
                 response = await asyncio.to_thread(
                     self._bedrock_client.list_foundation_models,
@@ -194,15 +198,16 @@ class BedrockInferenceAdapter(OpenAIMixin):
             ]
         # bearer token path: bedrock-runtime doesn't expose /v1/models,
         # but the mantle endpoint does — query it directly
-        from openai import AsyncOpenAI
-
-        mantle_url = _BEDROCK_MANTLE_URL.format(region=self._bedrock_config.region_name)
+        mantle_url = _BEDROCK_MANTLE_URL.format(region=self._bedrock_config.region_name or _DEFAULT_REGION)
         try:
             client = AsyncOpenAI(base_url=mantle_url, api_key=self.get_api_key())
             return [m.id async for m in client.models.list()]
         except Exception:
             logger.warning("Failed to list models from Bedrock mantle endpoint", exc_info=True)
             return []
+
+    async def check_model_availability(self, model: str) -> bool:
+        return True
 
     async def shutdown(self) -> None:
         if self._sigv4_http_client is not None:


### PR DESCRIPTION
## What does this PR do?

The Bedrock provider's `list_provider_model_ids()` currently returns `[]`, requiring users to pre-register every model via `registered_resources` in config.yaml. This adds automatic model discovery for both authentication modes.

### SigV4 path

Uses the `bedrock` control-plane `ListFoundationModels` API via boto3 (reusing the existing `create_bedrock_client()` utility from `ogx/providers/utils/bedrock/client.py`). Results are filtered to `ACTIVE` models with `ON_DEMAND` inference. The boto3 call runs in `asyncio.to_thread()` to avoid blocking the event loop.

### Bearer token path

Queries the Bedrock Mantle endpoint's `/v1/models` route, which returns all available models in the region. Uses a temporary `AsyncOpenAI` client pointed at `bedrock-mantle.{region}.api.aws/v1`.

Both paths fall back to an empty list on failure, so existing deployments with pre-registered models continue to work unchanged.

### Additional changes

- Extracted URL templates as module-level constants (`_BEDROCK_RUNTIME_URL`, `_BEDROCK_MANTLE_URL`)
- Removed the `check_model_availability()` override (no longer needed with discovery)
- Updated docstring to reflect the new behavior

Closes #6312

## Test plan

- [x] **Bearer token path (local)**: Started OGX with a bearer token and no `registered_resources` — `GET /v1/models` returned 49 models auto-discovered from the mantle endpoint
- [ ] **SigV4 path (CI)**: Requires AWS credentials — will validate in downstream CI (opendatahub-io/ogx-distribution)
- [x] **Graceful fallback**: Expired/invalid token logs a warning and returns empty list — server starts normally
- [x] **Existing deployments**: Pre-registered models in `registered_resources` continue to work alongside discovered models