### PR TITLE
fix(inference): use text_completion type for coalesced usage chunk in completion streams

### DIFF
--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import httpx
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
+from openai.types import Completion
 from openai.types.chat import ChatCompletionChunk
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
@@ -325,7 +326,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             raise ValueError(f"Model {model} has no provider_resource_id")
         return model_obj.provider_resource_id
 
-    async def _postprocess_chunk(self, resp: Any, stream: bool | None) -> Any:
+    async def _postprocess_chunk(self, resp: Any, stream: bool | None, is_chat: bool = True) -> Any:
         if stream:
             new_id = f"cltsd-{uuid.uuid4()}" if self.overwrite_completion_id else None
             fix_usage = self.coalesce_streaming_usage
@@ -346,14 +347,24 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
                         chunk.usage = None
                     yield chunk
                 if fix_usage and last_usage is not None:
-                    yield ChatCompletionChunk(
-                        id=last_id,
-                        choices=[],
-                        created=last_created,
-                        model=last_model,
-                        object="chat.completion.chunk",
-                        usage=last_usage,
-                    )
+                    if is_chat:
+                        yield ChatCompletionChunk(
+                            id=last_id,
+                            choices=[],
+                            created=last_created,
+                            model=last_model,
+                            object="chat.completion.chunk",
+                            usage=last_usage,
+                        )
+                    else:
+                        yield Completion(
+                            id=last_id,
+                            choices=[],
+                            created=last_created,
+                            model=last_model,
+                            object="text_completion",
+                            usage=last_usage,
+                        )
 
             return _gen()
         else:
@@ -402,7 +413,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             completion_kwargs["extra_headers"] = extra_headers
         resp = await self.client.completions.create(**completion_kwargs)
 
-        return await self._postprocess_chunk(resp, params.stream)  # type: ignore[no-any-return]
+        return await self._postprocess_chunk(resp, params.stream, is_chat=False)  # type: ignore[no-any-return]
 
     async def openai_chat_completion(
         self,

--- a/tests/unit/providers/inference/test_openai_mixin_streaming_usage.py
+++ b/tests/unit/providers/inference/test_openai_mixin_streaming_usage.py
@@ -29,9 +29,10 @@ Specific tests:
 from collections.abc import AsyncIterator
 from typing import Any
 
-from openai.types import CompletionUsage
+from openai.types import Completion, CompletionUsage
 from openai.types.chat import ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import Choice, ChoiceDelta
+from openai.types.completion_choice import CompletionChoice
 
 
 def _make_content_chunk(
@@ -298,6 +299,134 @@ class TestFixStreamingUsage:
         final = collected[-1]
         assert final.id == "my-id"
         assert final.model == "gemini-2.5-pro"
+
+
+def _make_text_completion_chunk(
+    text: str,
+    chunk_id: str = "cmpl-1",
+    model: str = "gemini-2.5-flash",
+    finish_reason: str | None = None,
+    usage: CompletionUsage | None = None,
+) -> Completion:
+    # Intermediate stream chunks have finish_reason=None; the SDK parses stream
+    # events leniently (construct), so mirror that here.
+    choice = CompletionChoice.model_construct(text=text, finish_reason=finish_reason, index=0, logprobs=None)
+    return Completion(
+        id=chunk_id,
+        choices=[choice],
+        created=1000,
+        model=model,
+        object="text_completion",
+        usage=usage,
+    )
+
+
+class TestFixStreamingUsageTextCompletion:
+    """coalesce_streaming_usage=True on the legacy /v1/completions stream.
+
+    The final usage-only chunk must be a Completion (object='text_completion'),
+    not a ChatCompletionChunk — OpenAI SDK clients parse every event of a
+    text-completion stream as Completion and fail validation otherwise.
+    """
+
+    def _make_stub(self) -> Any:
+        from ogx.providers.utils.inference.openai_mixin import OpenAIMixin
+
+        class _Stub(OpenAIMixin):
+            config: Any = None
+            coalesce_streaming_usage: bool = True
+            overwrite_completion_id: bool = False
+
+            def get_base_url(self):
+                return "https://example.com"
+
+        stub = _Stub.model_construct()
+        stub.coalesce_streaming_usage = True
+        stub.overwrite_completion_id = False
+        return stub
+
+    async def test_fix_completion_stream_yields_only_text_completion_chunks(self):
+        """Every yielded chunk, including the final usage chunk, is a text_completion."""
+        usage = CompletionUsage(prompt_tokens=9, completion_tokens=5, total_tokens=14)
+        chunks = [
+            _make_text_completion_chunk("hello", usage=usage),
+            _make_text_completion_chunk(" world", finish_reason="stop", usage=usage),
+        ]
+
+        async def _fake_stream():
+            for c in chunks:
+                yield c
+
+        stub = self._make_stub()
+        result = await stub._postprocess_chunk(_fake_stream(), stream=True, is_chat=False)
+        collected = await _collect(result)
+
+        assert len(collected) == 3
+        for chunk in collected:
+            assert isinstance(chunk, Completion), f"got {type(chunk).__name__}"
+            assert chunk.object == "text_completion"
+
+    async def test_fix_completion_stream_final_chunk_carries_usage(self):
+        """Usage is stripped from content chunks and delivered on a final Completion chunk."""
+        usage = CompletionUsage(prompt_tokens=9, completion_tokens=5, total_tokens=14)
+        chunks = [
+            _make_text_completion_chunk("hello", usage=usage),
+            _make_text_completion_chunk(" world", finish_reason="stop", usage=usage),
+        ]
+
+        async def _fake_stream():
+            for c in chunks:
+                yield c
+
+        stub = self._make_stub()
+        result = await stub._postprocess_chunk(_fake_stream(), stream=True, is_chat=False)
+        collected = await _collect(result)
+
+        assert all(c.usage is None for c in collected[:-1])
+        final = collected[-1]
+        assert final.choices == []
+        assert final.id == "cmpl-1"
+        assert final.model == "gemini-2.5-flash"
+        assert final.usage is not None
+        assert final.usage.prompt_tokens == 9
+        assert final.usage.completion_tokens == 5
+        assert final.usage.total_tokens == 14
+
+    async def test_fix_completion_stream_no_usage_no_extra_chunk(self):
+        """No synthetic chunk is appended when no incoming chunk carries usage."""
+        chunks = [
+            _make_text_completion_chunk("hello"),
+            _make_text_completion_chunk(" world", finish_reason="stop"),
+        ]
+
+        async def _fake_stream():
+            for c in chunks:
+                yield c
+
+        stub = self._make_stub()
+        result = await stub._postprocess_chunk(_fake_stream(), stream=True, is_chat=False)
+        collected = await _collect(result)
+
+        assert len(collected) == 2
+        assert all(isinstance(c, Completion) for c in collected)
+
+    async def test_chat_stream_final_chunk_still_chat_completion_chunk(self):
+        """The chat path is unchanged: final usage chunk stays a ChatCompletionChunk."""
+        usage = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        chunks = [_make_stop_chunk(usage=usage)]
+
+        async def _fake_stream():
+            for c in chunks:
+                yield c
+
+        stub = self._make_stub()
+        result = await stub._postprocess_chunk(_fake_stream(), stream=True)
+        collected = await _collect(result)
+
+        final = collected[-1]
+        assert isinstance(final, ChatCompletionChunk)
+        assert final.object == "chat.completion.chunk"
+        assert final.usage.total_tokens == 15
 
 
 class TestGeminiAdapterFlag:


### PR DESCRIPTION
# What does this PR do?

`OpenAIMixin._postprocess_chunk` is shared by both `openai_chat_completion` and the legacy `openai_completion` (`/v1/completions`) paths. When `coalesce_streaming_usage=True` — set for Gemini in `src/ogx/providers/remote/inference/gemini/gemini.py` because its OpenAI-compat endpoint reports (cumulative) usage on every streaming chunk — the wrapper strips usage from each chunk and appends a synthetic final chunk carrying the coalesced usage.

That synthetic final chunk was hardcoded to `ChatCompletionChunk` with `object="chat.completion.chunk"` regardless of the stream's actual type. So a streamed `/v1/completions` call against Gemini ends with a chat-completion-typed SSE event inside a `text_completion` stream:

```
Completion            text_completion
Completion            text_completion
ChatCompletionChunk   chat.completion.chunk   <-- wrong object + schema
```

OpenAI SDK clients parsing the stream as `Completion` fail validation on that last event, and the usage the client asked for via `stream_options={"include_usage": true}` is only delivered in that mistyped event (per-chunk usage having been stripped from all real chunks).

This PR makes `_postprocess_chunk` type-aware via an `is_chat` flag: the completion path (`is_chat=False`) now emits an `openai.types.Completion` final chunk (`object="text_completion"`, empty `choices`, coalesced `usage`), while the chat path is unchanged. Follow-up to #5171, which introduced the coalescing generator; only Gemini currently sets the flag.

## Test Plan

Added `TestFixStreamingUsageTextCompletion` to `tests/unit/providers/inference/test_openai_mixin_streaming_usage.py`, covering:
- every chunk of a coalesced `/v1/completions` stream (including the final usage chunk) is `Completion`/`text_completion`
- usage is stripped from content chunks and delivered on the final `Completion` chunk with the last chunk's id/model
- no synthetic chunk is appended when no incoming chunk carries usage
- the chat path still emits a `ChatCompletionChunk` final usage chunk (regression guard)

```
$ uv run pytest tests/unit/providers/inference/ -q
499 passed in 5.25s
```

Standalone repro script (fails on `main` with `AssertionError: BUG: /v1/completions stream contains non-text_completion chunk(s): [('ChatCompletionChunk', 'chat.completion.chunk')]`; passes with this fix):

```python
import asyncio
from typing import Any

from openai.types import Completion, CompletionUsage
from openai.types.completion_choice import CompletionChoice

from ogx.providers.utils.inference.openai_mixin import OpenAIMixin


def make_chunk(text, finish_reason, usage):
    choice = CompletionChoice.model_construct(text=text, finish_reason=finish_reason, index=0, logprobs=None)
    return Completion(
        id="cmpl-1", choices=[choice], created=1000, model="gemini-2.5-flash", object="text_completion", usage=usage
    )


async def main():
    class Stub(OpenAIMixin):
        config: Any = None
        coalesce_streaming_usage: bool = True
        overwrite_completion_id: bool = False

        def get_base_url(self):
            return "https://example.com"

    stub = Stub.model_construct()
    stub.coalesce_streaming_usage = True
    stub.overwrite_completion_id = False

    async def fake_stream():
        # Gemini-style: usage on every chunk
        yield make_chunk("hello", None, CompletionUsage(prompt_tokens=9, completion_tokens=3, total_tokens=12))
        yield make_chunk(" world", "stop", CompletionUsage(prompt_tokens=9, completion_tokens=5, total_tokens=14))

    result = await stub._postprocess_chunk(fake_stream(), stream=True, is_chat=False)
    chunks = [c async for c in result]
    for c in chunks:
        print(type(c).__name__, c.object)
    bad = [(type(c).__name__, c.object) for c in chunks if c.object != "text_completion"]
    assert not bad, f"BUG: /v1/completions stream contains non-text_completion chunk(s): {bad}"
    assert chunks[-1].usage is not None and chunks[-1].usage.total_tokens == 14
    print("OK: all chunks text_completion, final carries usage")


asyncio.run(main())
```

Output (with this fix):

```
Completion text_completion
Completion text_completion
Completion text_completion
OK: all chunks text_completion, final carries usage
```
