### PR TITLE
fix(starter): default trust_remote_code to false for sentence-transformers

### DIFF
--- a/src/ogx/distributions/starter/config.yaml
+++ b/src/ogx/distributions/starter/config.yaml
@@ -98,7 +98,7 @@ providers:
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config:
-      trust_remote_code: true
+      trust_remote_code: false
   vector_io:
   - provider_id: faiss
     provider_type: inline::faiss

--- a/src/ogx/distributions/starter/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/starter/run-with-postgres-store.yaml
@@ -98,7 +98,7 @@ providers:
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config:
-      trust_remote_code: true
+      trust_remote_code: false
   vector_io:
   - provider_id: faiss
     provider_type: inline::faiss

--- a/src/ogx/distributions/starter/starter.py
+++ b/src/ogx/distributions/starter/starter.py
@@ -171,7 +171,7 @@ def get_distribution_template(name: str = "starter") -> DistributionTemplate:
     embedding_provider = Provider(
         provider_id="sentence-transformers",
         provider_type="inline::sentence-transformers",
-        config=SentenceTransformersInferenceConfig(trust_remote_code=True).model_dump(),
+        config=SentenceTransformersInferenceConfig(trust_remote_code=False).model_dump(),
     )
     responses_provider = Provider(
         provider_id="builtin",


### PR DESCRIPTION
The starter distribution configured the sentence-transformers embedding provider with `trust_remote_code: true` (in `starter.py` and the two generated run configs). With that flag, loading any model from the HuggingFace Hub executes code bundled with the model repository, so a compromised or malicious model could run arbitrary code on the OGX server.

The config class documents `trust_remote_code` as defaulting to `false` for exactly this reason, and the starter distribution is the template most new deployments copy from. This restores `trust_remote_code: false` in `starter.py` and regenerates `config.yaml` and `run-with-postgres-store.yaml` via `scripts/distro_codegen.py`. Deployments that need remote code for a specific model (e.g. `nomic-ai/nomic-embed-text-v1.5`) can still opt in on that provider, as the ci-tests distribution already does.

Closes #6311.

Test plan: `uv run ./scripts/distro_codegen.py` regenerates the two starter run configs to `trust_remote_code: false`, matching the source. `ruff check`/`ruff format --check` pass, and the template still loads: `python -c "from ogx.distributions.starter.starter import get_distribution_template; get_distribution_template()"`.