### PR TITLE
refactor: run starter as non-root

### DIFF
--- a/containers/Containerfile
+++ b/containers/Containerfile
@@ -220,6 +220,11 @@ exec $CMD_PREFIX "$CLI_NAME" stack run --insecure "$@"
 EOF
 RUN chmod +x /usr/local/bin/ogx-entrypoint.sh
 
-RUN mkdir -p "/.${CLI_NAME}" /.cache && chmod -R g+rw /app "/.${CLI_NAME}" /.cache
+RUN mkdir -p "/.${CLI_NAME}" /.cache && \
+    chmod -R g+rw /app "/.${CLI_NAME}" /.cache && \
+    chown -R 1001:0 /app "/.${CLI_NAME}" /.cache
+
+ENV HOME=/
+USER 1001
 
 ENTRYPOINT ["/usr/local/bin/ogx-entrypoint.sh"]


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Currently the starter distribution container runs as the root user by default. It requires more lenient `anyuid` SCC security configurations on OpenShift, instead of running with `restricted-v2`.

This PR updates the Containerfile to run as a known, unprivileged user account by default.


<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Supports https://github.com/ogx-ai/ogx-k8s-operator/pull/330 which closes RHAIENG-5584, RHAIENG-5588, and RHOAIENG-76479.

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
Tested by building a new starter container image with this configuration, and deploying it with the ogx-k8s-operator on an OpenShift 4.21 cluster.

<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->
