### PR TITLE
fix(inference): remove duplicate per-provider model id resolution

### DIFF
--- a/src/ogx/providers/remote/inference/gemini/gemini.py
+++ b/src/ogx/providers/remote/inference/gemini/gemini.py
@@ -82,7 +82,7 @@ class GeminiInferenceAdapter(OpenAIMixin):
 
         # Build request params conditionally to avoid NotGiven/Omit type mismatch
         request_params: dict[str, Any] = {
-            "model": await self._get_provider_model_id(params.model),
+            "model": params.model,
             "input": params.input,
         }
         if params.encoding_format is not None:

--- a/src/ogx/providers/remote/inference/together/together.py
+++ b/src/ogx/providers/remote/inference/together/together.py
@@ -89,7 +89,7 @@ class TogetherInferenceAdapter(OpenAIMixin, NeedsRequestProviderData):
 
         # Cast encoding_format to match OpenAI SDK's expected Literal type
         response = await self.client.embeddings.create(
-            model=await self._get_provider_model_id(params.model),
+            model=params.model,
             input=params.input,
             encoding_format=cast(Any, params.encoding_format),
         )

--- a/src/ogx/providers/remote/inference/vertexai/vertexai.py
+++ b/src/ogx/providers/remote/inference/vertexai/vertexai.py
@@ -364,16 +364,6 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 ) from None
         return self._default_client
 
-    async def _get_provider_model_id(self, model: str) -> str:
-        # model_store is injected at runtime by the routing infra
-        if hasattr(self, "model_store") and self.model_store and await self.model_store.has_model(model):  # type: ignore[attr-defined]
-            model_obj: Model = await self.model_store.get_model(model)  # type: ignore[attr-defined]
-            if model_obj.provider_resource_id is None:
-                raise ValueError(f"Model {model} has no provider_resource_id")
-            return model_obj.provider_resource_id
-
-        return model
-
     async def list_provider_model_ids(self) -> list[str]:
         """List model IDs available from the configured Vertex AI project.
 
@@ -759,7 +749,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         self,
         params: OpenAIChatCompletionRequestWithExtraBody,
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
-        provider_model_id = await self._get_provider_model_id(params.model)
+        provider_model_id = params.model
         self._validate_model_allowed(provider_model_id)
         client = self._get_client()
 
@@ -843,7 +833,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         prompts = self._validate_completion_prompt(params.prompt)
         self._warn_unsupported_completion_params(params)
 
-        provider_model_id = await self._get_provider_model_id(params.model)
+        provider_model_id = params.model
         self._validate_model_allowed(provider_model_id)
         client = self._get_client()
         config = self._build_completion_config(params)
@@ -934,7 +924,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
                 ignored_keys=list(params.model_extra.keys()),
             )
 
-        provider_model_id = await self._get_provider_model_id(params.model)
+        provider_model_id = params.model
         self._validate_model_allowed(provider_model_id)
         client = self._get_client()
 

--- a/src/ogx/providers/utils/inference/openai_mixin.py
+++ b/src/ogx/providers/utils/inference/openai_mixin.py
@@ -76,8 +76,10 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
 
     Expected Dependencies:
     - self.model_store: Injected by the OGX distribution system at runtime.
-      This provides model registry functionality for looking up registered models.
-      The model_store is set in routing_tables/common.py during provider initialization.
+      Used by check_model_availability() to check pre-registered models. Model name ->
+      provider model id resolution is NOT done here: InferenceRouter resolves params.model
+      to the provider_resource_id before calling any provider method, so provider code can
+      assume params.model is already the provider-specific id.
     """
 
     # Allow extra fields so the routing infra can inject model_store, __provider_id__, etc.
@@ -309,29 +311,6 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
                 f"Allowed models: {self.config.allowed_models}"
             )
 
-    async def _get_provider_model_id(self, model: str) -> str:
-        """
-        Get the provider-specific model ID from the model store.
-
-        This is a utility method that looks up the registered model and returns
-        the provider_resource_id that should be used for actual API calls.
-
-        :param model: The registered model name/identifier
-        :return: The provider-specific model ID (e.g., "gpt-4")
-        """
-        # self.model_store is injected by the distribution system at runtime
-        assert self.model_store is not None
-
-        if not await self.model_store.has_model(model):
-            return model
-
-        # Look up the registered model to get the provider-specific model ID
-        model_obj: Model = await self.model_store.get_model(model)
-        # provider_resource_id is str | None, but we expect it to be str for OpenAI calls
-        if model_obj.provider_resource_id is None:
-            raise ValueError(f"Model {model} has no provider_resource_id")
-        return model_obj.provider_resource_id
-
     async def _postprocess_chunk(self, resp: Any, stream: bool | None) -> Any:
         if stream:
             new_id = f"cltsd-{uuid.uuid4()}" if self.overwrite_completion_id else None
@@ -380,7 +359,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             params.stream_options, params.stream or False, self.supports_stream_options
         )
 
-        provider_model_id = await self._get_provider_model_id(params.model)
+        provider_model_id = params.model
         self._validate_model_allowed(provider_model_id)
 
         completion_kwargs = await prepare_openai_completion_params(
@@ -423,7 +402,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
             params.stream_options, params.stream or False, self.supports_stream_options
         )
 
-        provider_model_id = await self._get_provider_model_id(params.model)
+        provider_model_id = params.model
         self._validate_model_allowed(provider_model_id)
 
         messages = params.messages
@@ -494,7 +473,7 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         if not self.supports_tokenized_embeddings_input:
             validate_embeddings_input_is_text(params)
 
-        provider_model_id = await self._get_provider_model_id(params.model)
+        provider_model_id = params.model
         self._validate_model_allowed(provider_model_id)
 
         # Build request params conditionally to avoid NotGiven/Omit type mismatch
@@ -643,7 +622,6 @@ class OpenAIMixin(NeedsRequestProviderData, ABC, BaseModel):
         )
 
         openai_params = anthropic_request_to_openai(params)
-        openai_params.model = await self._get_provider_model_id(openai_params.model)
         self._validate_model_allowed(openai_params.model)
 
         result = await self.openai_chat_completion(openai_params)

--- a/tests/unit/providers/inference/test_ollama_adapter.py
+++ b/tests/unit/providers/inference/test_ollama_adapter.py
@@ -11,7 +11,6 @@ from ogx.providers.remote.inference.ollama.config import OllamaImplConfig
 from ogx.providers.remote.inference.ollama.ollama import OllamaInferenceAdapter
 from ogx.providers.utils.inference.openai_compat import prepare_openai_completion_params
 from ogx_api import (
-    Model,
     OpenAIAssistantMessageParam,
     OpenAIChatCompletionRequestWithExtraBody,
     OpenAIUserMessageParam,
@@ -27,12 +26,6 @@ async def test_openai_chat_completions_with_reasoning_keeps_messages_typed():
     """Ollama should remap reasoning fields without widening messages to raw dicts."""
     adapter = OllamaInferenceAdapter(config=OllamaImplConfig(base_url="http://localhost:11434/v1"))
     adapter.__provider_id__ = "ollama"
-    adapter.model_store = AsyncMock()
-    adapter.model_store.get_model.return_value = Model(
-        identifier="test-model",
-        provider_id="ollama",
-        provider_resource_id="test-model",
-    )
 
     mock_client = MagicMock()
     mock_client.chat.completions.create = AsyncMock(return_value=_empty_stream())

--- a/tests/unit/providers/inference/test_remote_vllm.py
+++ b/tests/unit/providers/inference/test_remote_vllm.py
@@ -142,7 +142,6 @@ async def test_openai_chat_completion_converts_developer_messages_for_vllm(vllm_
             ],
         )
     )
-    vllm_inference_adapter.model_store.has_model.return_value = False
 
     params = OpenAIChatCompletionRequestWithExtraBody(
         model="mock-model",
@@ -180,7 +179,6 @@ async def test_openai_chat_completion_converts_typed_developer_messages_for_vllm
             ],
         )
     )
-    vllm_inference_adapter.model_store.has_model.return_value = False
 
     params = OpenAIChatCompletionRequestWithExtraBody(
         model="mock-model",

--- a/tests/unit/providers/inference/vertexai/conftest.py
+++ b/tests/unit/providers/inference/vertexai/conftest.py
@@ -161,11 +161,6 @@ def patch_chat_completion_dependencies(monkeypatch):
         )
         captured: dict[str, Any] = {"fake_completion": fake_completion}
 
-        async def _provider_model_id(_: str) -> str:
-            """Return a fixed provider model identifier."""
-            return "gemini-2.5-flash"
-
-        monkeypatch.setattr(adapter, "_get_provider_model_id", _provider_model_id)
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
 

--- a/tests/unit/providers/inference/vertexai/test_adapter_completion.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_completion.py
@@ -52,7 +52,6 @@ def make_completion_adapter(monkeypatch):
         a = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
         fake_client = MagicMock()
         fake_client.aio.models.generate_content = AsyncMock(return_value=fake_response)
-        monkeypatch.setattr(a, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(a, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(a, "_get_client", lambda: fake_client)
         return a, fake_client
@@ -97,7 +96,6 @@ class TestOpenAICompletion:
         fake_chunk = _make_fake_streaming_chunk("hi")
         fake_client = MagicMock()
         fake_client.aio.models.generate_content_stream = AsyncMock(return_value=_async_pager([fake_chunk]))
-        monkeypatch.setattr(adapter, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
         params = OpenAICompletionRequestWithExtraBody(model="google/gemini-2.5-flash", prompt=["a", "b"], stream=True)
@@ -195,7 +193,6 @@ class TestOpenAICompletion:
         fake_client = SimpleNamespace(
             aio=SimpleNamespace(models=SimpleNamespace(generate_content_stream=AsyncMock(return_value=fake_stream())))
         )
-        monkeypatch.setattr(adapter, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
 
@@ -220,7 +217,6 @@ class TestOpenAICompletion:
         fake_client = SimpleNamespace(
             aio=SimpleNamespace(models=SimpleNamespace(generate_content_stream=AsyncMock(return_value=fake_stream())))
         )
-        monkeypatch.setattr(adapter, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
 
@@ -240,7 +236,6 @@ class TestOpenAICompletion:
         fake_chunk = _make_fake_streaming_chunk("hi")
         fake_client = MagicMock()
         fake_client.aio.models.generate_content_stream = AsyncMock(return_value=_async_pager([fake_chunk]))
-        monkeypatch.setattr(adapter, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
         params = OpenAICompletionRequestWithExtraBody(model="google/gemini-2.5-flash", prompt=["hello"], stream=True)
@@ -249,7 +244,6 @@ class TestOpenAICompletion:
 
     def _patch_streaming_dependencies(self, monkeypatch, adapter, fake_client):
         """Patch streaming dependencies for completion tests."""
-        monkeypatch.setattr(adapter, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
 
@@ -392,7 +386,6 @@ class TestCompletionModelExtra:
         fake_client = SimpleNamespace(
             aio=SimpleNamespace(models=SimpleNamespace(generate_content_stream=AsyncMock(return_value=fake_stream())))
         )
-        monkeypatch.setattr(adapter, "_get_provider_model_id", AsyncMock(return_value="gemini-2.5-flash"))
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
 
@@ -433,16 +426,11 @@ class TestCompletionStreamOptions:
         )
         stream_call_args: dict[str, Any] = {}
 
-        async def _provider_model_id(_: str) -> str:
-            """Return a fixed provider model identifier."""
-            return "gemini-2.5-flash"
-
         async def _stream_completion(client, model_id, contents, config, model, stream_options=None):
             """Handle stream completion."""
             stream_call_args["stream_options"] = stream_options
             return _async_pager([])
 
-        monkeypatch.setattr(adapter, "_get_provider_model_id", _provider_model_id)
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
         monkeypatch.setattr(

--- a/tests/unit/providers/inference/vertexai/test_adapter_params.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_params.py
@@ -316,16 +316,11 @@ class TestTelemetryStreamOptions:
         )
         stream_call_args: dict[str, Any] = {}
 
-        async def _provider_model_id(_: str) -> str:
-            """Return a fixed provider model identifier."""
-            return "gemini-2.5-flash"
-
         async def _stream_chat_completion(client, model_id, contents, config, model, stream_options=None):
             """Handle stream chat completion."""
             stream_call_args["stream_options"] = stream_options
             return _async_pager([])
 
-        monkeypatch.setattr(adapter, "_get_provider_model_id", _provider_model_id)
         monkeypatch.setattr(adapter, "_validate_model_allowed", lambda _: None)
         monkeypatch.setattr(adapter, "_get_client", lambda: fake_client)
         monkeypatch.setattr(adapter, "_build_generation_config", lambda *_args, **_kwargs: object())

--- a/tests/unit/providers/responses/builtin/test_openai_responses_params.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_params.py
@@ -257,10 +257,6 @@ async def test_params_passed_through_full_chain_to_backend_service(
     openai_adapter = OpenAIInferenceAdapter(config=config)
     openai_adapter.provider_data_api_key_field = None
 
-    mock_model_store = AsyncMock()
-    mock_model_store.has_model = AsyncMock(return_value=False)
-    openai_adapter.model_store = mock_model_store
-
     openai_responses_impl = OpenAIResponsesImpl(
         inference_api=openai_adapter,
         tool_groups_api=AsyncMock(),

--- a/tests/unit/providers/utils/inference/openai_mixin_helpers.py
+++ b/tests/unit/providers/utils/inference/openai_mixin_helpers.py
@@ -91,11 +91,10 @@ def mixin():
     config = RemoteInferenceProviderConfig()
     mixin_instance = OpenAIMixinImpl(config=config)
 
-    # Mock model_store with async methods
+    # Mock model_store, used by check_model_availability() to look up pre-registered models.
+    # Model name -> provider model id resolution no longer goes through model_store; the router
+    # resolves params.model to the provider_resource_id before calling the mixin.
     mock_model_store = AsyncMock()
-    mock_model = MagicMock()
-    mock_model.provider_resource_id = "test-provider-resource-id"
-    mock_model_store.get_model = AsyncMock(return_value=mock_model)
     mock_model_store.has_model = AsyncMock(return_value=False)  # Default to False, tests can override
     mixin_instance.model_store = mock_model_store
 


### PR DESCRIPTION
OpenAIMixin and VertexAIInferenceAdapter each had a _get_provider_model_id() method that looked up the registered model in model_store and returned its provider_resource_id before making API calls. This was redundant because the InferenceRouter already resolves params.model to the provider_resource_id before invoking a provider; the router sets response.provider_id so the resolved model can be traced back.

Remove _get_provider_model_id from OpenAIMixin and VertexAIInferenceAdapter and replace all call sites with direct use of params.model. Also inline the call in GeminiInferenceAdapter and TogetherInferenceAdapter embedding methods.

Update test fixtures to drop model_store mocking for removed method. Update OpenAIMixin docstring to document the new resolution boundary: the router handles name-to-provider-id resolution, and providers can assume params.model is already the provider-specific id.
