### PR TITLE
fix(ui): improve vector store and citation workflows

### DIFF
--- a/src/ogx_ui/README.md
+++ b/src/ogx_ui/README.md
@@ -23,3 +23,17 @@ bun dev
 ```
 
 Open [http://localhost:8322](http://localhost:8322) with your browser to see the result.
+
+## Model filtering
+
+The Chat Playground shows all available LLM models by default. To limit the
+model dropdown, set `NEXT_PUBLIC_OGX_UI_ALLOWED_MODELS` to a comma-separated
+list of model IDs:
+
+```bash
+NEXT_PUBLIC_OGX_UI_ALLOWED_MODELS=openai/gpt-4.1-mini,anthropic/claude-sonnet-4-6
+```
+
+When configured, only matching models are shown in the configured order, and
+the first matching model is selected by default. If the variable is unset, the
+first model in the existing sorted list is selected by default.

--- a/src/ogx_ui/app/chat-playground/page.test.tsx
+++ b/src/ogx_ui/app/chat-playground/page.test.tsx
@@ -114,6 +114,7 @@ describe("ChatPlaygroundPage", () => {
       });
 
       expect(screen.getAllByRole("combobox")).toHaveLength(1);
+      expect(screen.getByRole("combobox")).toHaveTextContent("test-model-1");
     });
 
     test("shows settings panel", async () => {

--- a/src/ogx_ui/app/chat-playground/page.tsx
+++ b/src/ogx_ui/app/chat-playground/page.tsx
@@ -26,6 +26,11 @@ import {
   removeConversation,
   updateConversation,
 } from "@/lib/conversation-history";
+import { filterModels, parseModelAllowlist } from "@/lib/model-filter";
+
+const configuredModelIds = parseModelAllowlist(
+  process.env.NEXT_PUBLIC_OGX_UI_ALLOWED_MODELS
+);
 
 type ModelWithMeta = Model & {
   custom_metadata?: Record<string, unknown>;
@@ -140,7 +145,17 @@ function ChatPlaygroundContent() {
         );
 
         llmModels.sort((a, b) => a.id.localeCompare(b.id));
-        setModels(llmModels);
+        const visibleModels = filterModels(llmModels, configuredModelIds);
+        setModels(visibleModels);
+        setSelectedModel(currentModel => {
+          if (
+            currentModel &&
+            visibleModels.some(model => model.id === currentModel)
+          ) {
+            return currentModel;
+          }
+          return visibleModels[0]?.id ?? "";
+        });
       } catch (err) {
         console.error("Error fetching models:", err);
         setModelsError("Failed to load models");
@@ -713,6 +728,13 @@ function ChatPlaygroundContent() {
                 </Select>
                 {modelsError && (
                   <p className="text-destructive text-xs mt-1">{modelsError}</p>
+                )}
+                {!isModelsLoading && !modelsError && models.length === 0 && (
+                  <p className="text-muted-foreground text-xs mt-1">
+                    {configuredModelIds.length > 0
+                      ? "No models matched the configured allowlist."
+                      : "No models available."}
+                  </p>
                 )}
               </div>
 

--- a/src/ogx_ui/app/logs/vector-stores/page.tsx
+++ b/src/ogx_ui/app/logs/vector-stores/page.tsx
@@ -25,6 +25,7 @@ import {
   VectorStoreEditor,
   VectorStoreFormData,
 } from "@/components/vector-stores/vector-store-editor";
+import { buildVectorStoreParams } from "@/components/vector-stores/vector-store-params";
 
 export default function VectorStoresPage() {
   const router = useRouter();
@@ -41,6 +42,7 @@ export default function VectorStoresPage() {
     hasMore,
     error,
     loadMore,
+    refetch,
   } = usePagination<VectorStore>({
     limit: 20,
     order: "desc",
@@ -130,27 +132,12 @@ export default function VectorStoresPage() {
         return;
       }
 
-      const createParams: Record<string, unknown> = {
-        name: formData.name || undefined,
-      };
-
-      if (formData.provider_id) {
-        createParams.provider_id = formData.provider_id;
-      }
-      if (formData.embedding_model) {
-        createParams.embedding_model = formData.embedding_model;
-      }
-      if (formData.embedding_dimension) {
-        createParams.embedding_dimension = formData.embedding_dimension;
-      }
-
-      await client.vectorStores.create(createParams);
+      await client.vectorStores.create(buildVectorStoreParams(formData));
+      refetch();
 
       // Show success state with close button
       setShowSuccessState(true);
-      setModalError(
-        "✅ Vector store created successfully! You can close this modal and refresh the page to see changes."
-      );
+      setModalError("✅ Vector store created successfully!");
     } catch (err: unknown) {
       console.error("Failed to create vector store:", err);
       const errorMessage =

--- a/src/ogx_ui/components/files/file-detail.test.tsx
+++ b/src/ogx_ui/components/files/file-detail.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { FileDetail } from "./file-detail";
+
+const mockReplace = jest.fn();
+const mockRouter = { replace: mockReplace };
+const mockClient = {
+  files: {
+    retrieve: jest.fn(),
+  },
+  vectorStores: {
+    list: jest.fn(),
+    files: {
+      list: jest.fn(),
+    },
+  },
+};
+
+jest.mock("@/hooks/use-auth-client", () => ({
+  useAuthClient: () => mockClient,
+}));
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ id: "file-orphaned" }),
+  useRouter: () => mockRouter,
+}));
+
+describe("FileDetail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not log a Files API error when vector-store fallback succeeds", async () => {
+    mockClient.files.retrieve.mockRejectedValue(new Error("404"));
+    mockClient.vectorStores.list.mockResolvedValue({
+      data: [{ id: "vs_123" }],
+    });
+    mockClient.vectorStores.files.list.mockResolvedValue({
+      data: [{ id: "file-orphaned" }],
+    });
+    const consoleError = jest.spyOn(console, "error").mockImplementation();
+
+    render(<FileDetail />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/logs/vector-stores/vs_123/files/file-orphaned"
+      );
+    });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/src/ogx_ui/components/files/file-detail.tsx
+++ b/src/ogx_ui/components/files/file-detail.tsx
@@ -57,17 +57,45 @@ export function FileDetail() {
         const response = await client.files.retrieve(fileId);
         setFile(response as FileResource);
       } catch (err) {
-        console.error("Failed to fetch file:", err);
-        setError(
-          err instanceof Error ? err : new Error("Failed to fetch file")
-        );
+        try {
+          const storesResponse = await client.vectorStores.list({
+            limit: 100,
+            order: "desc",
+          });
+          const stores =
+            (storesResponse as { data?: { id?: string }[] }).data ?? [];
+          const matchingStore = await Promise.any(
+            stores
+              .filter((store): store is { id: string } => Boolean(store.id))
+              .map(async store => {
+                const filesResponse = await client.vectorStores.files.list(
+                  store.id
+                );
+                const files =
+                  (filesResponse as { data?: { id?: string }[] }).data ?? [];
+                if (files.some(file => file.id === fileId)) {
+                  return store.id;
+                }
+                throw new Error("File is not in this vector store");
+              })
+          );
+          router.replace(
+            `/logs/vector-stores/${matchingStore}/files/${fileId}`
+          );
+          return;
+        } catch {
+          console.error("Failed to fetch file details:", err);
+          setError(
+            err instanceof Error ? err : new Error("Failed to fetch file")
+          );
+        }
       } finally {
         setLoading(false);
       }
     };
 
     fetchFile();
-  }, [fileId, client]);
+  }, [fileId, client, router]);
 
   // Cleanup blob URL when component unmounts or content changes
   useEffect(() => {

--- a/src/ogx_ui/components/vector-stores/available-files.test.ts
+++ b/src/ogx_ui/components/vector-stores/available-files.test.ts
@@ -1,0 +1,32 @@
+import type { VectorStoreFile } from "ogx-client/resources/vector-stores/files";
+import type { File } from "ogx-client/resources/files";
+import { getAvailableFiles } from "./available-files";
+
+const uploadedFile = (id: string): File =>
+  ({ id, filename: `${id}.txt` }) as File;
+
+const attachedFile = (id: string): VectorStoreFile => ({
+  id,
+  created_at: 0,
+  status: "completed",
+  usage_bytes: 0,
+  vector_store_id: "vs_test",
+  chunking_strategy: { type: "auto" },
+});
+
+describe("getAvailableFiles", () => {
+  test("filters out files already attached to the vector store", () => {
+    expect(
+      getAvailableFiles(
+        [uploadedFile("file_1"), uploadedFile("file_2")],
+        [attachedFile("file_1")]
+      ).map(file => file.id)
+    ).toEqual(["file_2"]);
+  });
+
+  test("returns no files when every uploaded file is attached", () => {
+    expect(
+      getAvailableFiles([uploadedFile("file_1")], [attachedFile("file_1")])
+    ).toEqual([]);
+  });
+});

--- a/src/ogx_ui/components/vector-stores/available-files.ts
+++ b/src/ogx_ui/components/vector-stores/available-files.ts
@@ -1,0 +1,10 @@
+import type { File } from "ogx-client/resources/files";
+import type { VectorStoreFile } from "ogx-client/resources/vector-stores/files";
+
+export function getAvailableFiles(
+  uploadedFiles: File[],
+  attachedFiles: VectorStoreFile[]
+): File[] {
+  const attachedFileIds = new Set(attachedFiles.map(file => file.id));
+  return uploadedFiles.filter(file => !attachedFileIds.has(file.id));
+}

--- a/src/ogx_ui/components/vector-stores/model-list.test.ts
+++ b/src/ogx_ui/components/vector-stores/model-list.test.ts
@@ -1,0 +1,20 @@
+import type { Model } from "ogx-client/resources/models";
+import { normalizeModelList } from "./model-list";
+
+const embeddingModel = { id: "embedding-model" } as Model;
+
+describe("normalizeModelList", () => {
+  test("unwraps the OpenAI-style data response", () => {
+    expect(normalizeModelList({ data: [embeddingModel] })).toEqual([
+      embeddingModel,
+    ]);
+  });
+
+  test("preserves array responses", () => {
+    expect(normalizeModelList([embeddingModel])).toEqual([embeddingModel]);
+  });
+
+  test("returns an empty list for an invalid response", () => {
+    expect(normalizeModelList({ models: [embeddingModel] })).toEqual([]);
+  });
+});

--- a/src/ogx_ui/components/vector-stores/model-list.ts
+++ b/src/ogx_ui/components/vector-stores/model-list.ts
@@ -1,0 +1,14 @@
+import type { Model } from "ogx-client/resources/models";
+
+export function normalizeModelList(result: unknown): Model[] {
+  if (Array.isArray(result)) {
+    return result as Model[];
+  }
+
+  if (result && typeof result === "object" && "data" in result) {
+    const data = (result as { data?: unknown }).data;
+    return Array.isArray(data) ? (data as Model[]) : [];
+  }
+
+  return [];
+}

--- a/src/ogx_ui/components/vector-stores/vector-store-detail.test.tsx
+++ b/src/ogx_ui/components/vector-stores/vector-store-detail.test.tsx
@@ -149,9 +149,35 @@ describe("VectorStoreDetailView", () => {
         provider_vector_db_id: "test_db_id",
       },
     };
+    const mockFiles: VectorStoreFile[] = [
+      {
+        id: "file_1",
+        status: "completed",
+        created_at: 1710000001,
+        usage_bytes: 0,
+      },
+      {
+        id: "file_2",
+        status: "completed",
+        created_at: 1710000002,
+        usage_bytes: 0,
+      },
+      {
+        id: "file_3",
+        status: "completed",
+        created_at: 1710000003,
+        usage_bytes: 0,
+      },
+    ];
 
     test("renders store properties correctly", () => {
-      render(<VectorStoreDetailView {...defaultProps} store={mockStore} />);
+      render(
+        <VectorStoreDetailView
+          {...defaultProps}
+          store={mockStore}
+          files={mockFiles}
+        />
+      );
 
       expect(screen.getByText("Vector Store Details")).toBeInTheDocument();
       expect(screen.getByText("vs_123")).toBeInTheDocument();
@@ -313,9 +339,23 @@ describe("VectorStoreDetailView", () => {
       usage_bytes: 1024,
       metadata: {},
     };
+    const mockFiles: VectorStoreFile[] = [
+      {
+        id: "file_layout",
+        status: "completed",
+        created_at: 1710000001,
+        usage_bytes: 0,
+      },
+    ];
 
     test("renders main content and sidebar in correct layout", () => {
-      render(<VectorStoreDetailView {...defaultProps} store={mockStore} />);
+      render(
+        <VectorStoreDetailView
+          {...defaultProps}
+          store={mockStore}
+          files={mockFiles}
+        />
+      );
 
       expect(screen.getByText("Files")).toBeInTheDocument();
 

--- a/src/ogx_ui/components/vector-stores/vector-store-detail.tsx
+++ b/src/ogx_ui/components/vector-stores/vector-store-detail.tsx
@@ -4,12 +4,20 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import type { VectorStore } from "ogx-client/resources/vector-stores/vector-stores";
 import type { VectorStoreFile } from "ogx-client/resources/vector-stores/files";
+import type { File as UploadedFile } from "ogx-client/resources/files";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { useAuthClient } from "@/hooks/use-auth-client";
 import { Edit2, Plus, Trash2, X } from "lucide-react";
-import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getAvailableFiles } from "./available-files";
 import {
   DetailLoadingView,
   DetailErrorView,
@@ -61,6 +69,41 @@ export function VectorStoreDetailView({
   const [isAttaching, setIsAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
   const [attachSuccess, setAttachSuccess] = useState<string | null>(null);
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+  const [isLoadingUploadedFiles, setIsLoadingUploadedFiles] = useState(true);
+  const [uploadedFilesError, setUploadedFilesError] = useState<string | null>(
+    null
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadUploadedFiles = async () => {
+      try {
+        setIsLoadingUploadedFiles(true);
+        setUploadedFilesError(null);
+        const response = await client.files.list();
+        if (isMounted) {
+          setUploadedFiles(response.data);
+        }
+      } catch (err: unknown) {
+        if (isMounted) {
+          setUploadedFilesError(
+            err instanceof Error ? err.message : "Failed to load uploaded files"
+          );
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoadingUploadedFiles(false);
+        }
+      }
+    };
+
+    loadUploadedFiles();
+    return () => {
+      isMounted = false;
+    };
+  }, [client]);
 
   // Handle ESC key to close modal
   useEffect(() => {
@@ -154,7 +197,17 @@ export function VectorStoreDetailView({
     setAttachSuccess(null);
 
     try {
-      await client.vectorStores.files.create(id, { file_id: trimmedId });
+      const result = (await client.vectorStores.files.create(id, {
+        file_id: trimmedId,
+      })) as unknown as {
+        status?: string;
+        last_error?: { message?: string } | null;
+      };
+      if (result.status === "failed") {
+        throw new Error(
+          result.last_error?.message || `Failed to attach file ${trimmedId}`
+        );
+      }
       setAttachSuccess(`File ${trimmedId} attached successfully.`);
       setAttachFileId("");
       onFilesChanged?.();
@@ -167,6 +220,8 @@ export function VectorStoreDetailView({
       setIsAttaching(false);
     }
   };
+
+  const availableFiles = getAvailableFiles(uploadedFiles, files);
 
   if (errorStore) {
     return (
@@ -197,23 +252,49 @@ export function VectorStoreDetailView({
           <div className="space-y-2">
             <label className="text-sm font-medium">Attach File</label>
             <div className="flex gap-2">
-              <Input
-                placeholder="Enter file ID to attach..."
-                value={attachFileId}
-                onChange={e => {
-                  setAttachFileId(e.target.value);
-                  setAttachError(null);
-                  setAttachSuccess(null);
-                }}
-                disabled={isAttaching}
-                className="flex-1 font-mono text-sm"
-                onKeyDown={e => {
-                  if (e.key === "Enter") handleAttachFile();
-                }}
-              />
+              {isLoadingUploadedFiles ? (
+                <div className="flex-1 text-sm text-muted-foreground p-2">
+                  Loading uploaded files...
+                </div>
+              ) : uploadedFilesError ? (
+                <div className="flex-1 text-destructive text-sm p-2">
+                  Error loading uploaded files: {uploadedFilesError}
+                </div>
+              ) : availableFiles.length === 0 ? (
+                <div className="flex-1 text-sm text-muted-foreground p-2">
+                  No unattached files available.
+                </div>
+              ) : (
+                <Select
+                  value={attachFileId}
+                  onValueChange={value => {
+                    setAttachFileId(value);
+                    setAttachError(null);
+                    setAttachSuccess(null);
+                  }}
+                  disabled={isAttaching}
+                >
+                  <SelectTrigger className="flex-1">
+                    <SelectValue placeholder="Select an uploaded file" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableFiles.map(file => (
+                      <SelectItem key={file.id} value={file.id}>
+                        {file.filename || file.id} ({file.id})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
               <Button
                 onClick={handleAttachFile}
-                disabled={!attachFileId.trim() || isAttaching}
+                disabled={
+                  !attachFileId.trim() ||
+                  isAttaching ||
+                  isLoadingUploadedFiles ||
+                  !!uploadedFilesError ||
+                  availableFiles.length === 0
+                }
                 size="sm"
               >
                 {isAttaching ? (
@@ -348,7 +429,7 @@ export function VectorStoreDetailView({
         value={new Date(store.created_at * 1000).toLocaleString()}
       />
       <PropertyItem label="Status" value={store.status} />
-      <PropertyItem label="Total Files" value={store.file_counts.total} />
+      <PropertyItem label="Total Files" value={files.length} />
       <PropertyItem label="Usage Bytes" value={store.usage_bytes} />
       <PropertyItem
         label="Provider ID"

--- a/src/ogx_ui/components/vector-stores/vector-store-editor.tsx
+++ b/src/ogx_ui/components/vector-stores/vector-store-editor.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/select";
 import { useAuthClient } from "@/hooks/use-auth-client";
 import type { Model } from "ogx-client/resources/models";
+import { normalizeModelList } from "./model-list";
 
 export interface VectorStoreFormData {
   name: string;
@@ -43,8 +44,8 @@ export function VectorStoreEditor({
   const [formData, setFormData] = useState<VectorStoreFormData>(
     initialData || {
       name: "",
-      embedding_model: "",
-      embedding_dimension: 768,
+      embedding_model: undefined,
+      embedding_dimension: undefined,
       provider_id: "",
     }
   );
@@ -62,19 +63,10 @@ export function VectorStoreEditor({
       try {
         setModelsLoading(true);
         setModelsError(null);
-        const modelList = await client.models.list();
+        const modelList: Model[] = normalizeModelList(
+          await client.models.list()
+        );
         setModels(modelList);
-
-        // Set default embedding model if available
-        const embeddingModelsList = modelList.filter(model => {
-          return model.custom_metadata?.model_type === "embedding";
-        });
-        if (embeddingModelsList.length > 0 && !formData.embedding_model) {
-          setFormData(prev => ({
-            ...prev,
-            embedding_model: embeddingModelsList[0].id,
-          }));
-        }
       } catch (err) {
         console.error("Failed to load models:", err);
         setModelsError(
@@ -86,7 +78,7 @@ export function VectorStoreEditor({
     };
 
     fetchModels();
-  }, [client, formData.embedding_model]);
+  }, [client]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -130,7 +122,7 @@ export function VectorStoreEditor({
               </div>
             ) : (
               <Select
-                value={formData.embedding_model}
+                value={formData.embedding_model ?? ""}
                 onValueChange={value =>
                   setFormData({ ...formData, embedding_model: value })
                 }
@@ -170,7 +162,7 @@ export function VectorStoreEditor({
                   embedding_dimension: parseInt(e.target.value) || 768,
                 })
               }
-              placeholder="768"
+              placeholder="Use server default"
             />
           </div>
 

--- a/src/ogx_ui/components/vector-stores/vector-store-params.test.ts
+++ b/src/ogx_ui/components/vector-stores/vector-store-params.test.ts
@@ -1,0 +1,25 @@
+import { buildVectorStoreParams } from "./vector-store-params";
+
+describe("buildVectorStoreParams", () => {
+  it("leaves embedding defaults to the server when the form leaves them empty", () => {
+    expect(
+      buildVectorStoreParams({ name: "Neo4j store", provider_id: "neo4j" })
+    ).toEqual({ name: "Neo4j store", provider_id: "neo4j" });
+  });
+
+  it("includes explicitly selected embedding settings", () => {
+    expect(
+      buildVectorStoreParams({
+        name: "Custom store",
+        provider_id: "neo4j",
+        embedding_model: "sentence-transformers/example",
+        embedding_dimension: 384,
+      })
+    ).toEqual({
+      name: "Custom store",
+      provider_id: "neo4j",
+      embedding_model: "sentence-transformers/example",
+      embedding_dimension: 384,
+    });
+  });
+});

--- a/src/ogx_ui/components/vector-stores/vector-store-params.ts
+++ b/src/ogx_ui/components/vector-stores/vector-store-params.ts
@@ -1,0 +1,18 @@
+import type { VectorStoreFormData } from "./vector-store-editor";
+
+export function buildVectorStoreParams(
+  formData: VectorStoreFormData
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    name: formData.name || undefined,
+  };
+
+  if (formData.provider_id) params.provider_id = formData.provider_id;
+  if (formData.embedding_model)
+    params.embedding_model = formData.embedding_model;
+  if (formData.embedding_dimension) {
+    params.embedding_dimension = formData.embedding_dimension;
+  }
+
+  return params;
+}

--- a/src/ogx_ui/lib/model-filter.test.ts
+++ b/src/ogx_ui/lib/model-filter.test.ts
@@ -1,0 +1,32 @@
+import type { Model } from "ogx-client/resources/models";
+import { filterModels, parseModelAllowlist } from "./model-filter";
+
+const models = [
+  { id: "model-a" },
+  { id: "model-b" },
+  { id: "model-c" },
+] as Model[];
+
+describe("model filtering", () => {
+  test("keeps the API model list unchanged when no allowlist is configured", () => {
+    expect(parseModelAllowlist(undefined)).toEqual([]);
+    expect(filterModels(models, [])).toEqual(models);
+  });
+
+  test("filters models in allowlist order", () => {
+    const allowed = parseModelAllowlist(" model-c, model-a ");
+
+    expect(filterModels(models, allowed).map(model => model.id)).toEqual([
+      "model-c",
+      "model-a",
+    ]);
+  });
+
+  test("omits unknown model IDs", () => {
+    const allowed = parseModelAllowlist("missing, model-b");
+
+    expect(filterModels(models, allowed).map(model => model.id)).toEqual([
+      "model-b",
+    ]);
+  });
+});

--- a/src/ogx_ui/lib/model-filter.ts
+++ b/src/ogx_ui/lib/model-filter.ts
@@ -1,0 +1,30 @@
+import type { Model } from "ogx-client/resources/models";
+
+export function parseModelAllowlist(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map(modelId => modelId.trim())
+    .filter(Boolean);
+}
+
+export function filterModels(
+  models: Model[],
+  allowedModelIds: string[]
+): Model[] {
+  if (allowedModelIds.length === 0) {
+    return models;
+  }
+
+  const modelsById = new Map(models.map(model => [model.id, model]));
+  const seenModelIds = new Set<string>();
+
+  return allowedModelIds.flatMap(modelId => {
+    const model = modelsById.get(modelId);
+    if (!model || seenModelIds.has(modelId)) {
+      return [];
+    }
+
+    seenModelIds.add(modelId);
+    return [model];
+  });
+}


### PR DESCRIPTION
## What changed

- Add an uploaded-file dropdown when attaching files to a vector store, showing only unattached files.
- Refresh the vector-store list after creating a store and improve attach failure handling.
- Add model allowlisting via `NEXT_PUBLIC_OGX_UI_ALLOWED_MODELS`, with the first visible model selected by default.
- Redirect citation links for vector-store-only files to their vector-store file details page.
- Add regression and utility tests for these UI flows.

## Root cause

Citation links can reference files that are present in a vector store but are not present in the global Files API. The generic file details route now falls back to locating the file across vector stores before showing an error.

## Validation

- `npx jest --runInBand app/chat-playground/page.test.tsx components/files/file-detail.test.tsx components/vector-stores/available-files.test.ts components/vector-stores/model-list.test.ts components/vector-stores/vector-store-params.test.ts lib/model-filter.test.ts`
- 6 suites passed, 18 tests passed.
- ESLint and Prettier checks passed for the changed file-detail files.
- Live browser verification completed for the citation redirect.