### PR TITLE
fix(vector_io): align FAISS to upsert semantics for repeated chunk IDs

### DIFF
--- a/src/ogx/providers/inline/vector_io/faiss/faiss.py
+++ b/src/ogx/providers/inline/vector_io/faiss/faiss.py
@@ -191,6 +191,15 @@ class FaissIndex(EmbeddingIndex):
         if not embedded_chunks:
             return
 
+        # Upsert semantics: when the same chunk_id appears more than once (within this
+        # batch or already in the index) keep only the last occurrence, so re-ingesting a
+        # chunk replaces its vector instead of silently duplicating it. IndexFlatL2 has no
+        # native upsert, so existing entries are removed before the new ones are appended.
+        deduped: dict[str, EmbeddedChunk] = {}
+        for embedded_chunk in embedded_chunks:
+            deduped[embedded_chunk.chunk_id] = embedded_chunk
+        embedded_chunks = list(deduped.values())
+
         # Extract embeddings and validate dimensions
         np = _get_numpy()
         embeddings = np.array([ec.embedding for ec in embedded_chunks], dtype=np.float32)
@@ -198,55 +207,58 @@ class FaissIndex(EmbeddingIndex):
         if embedding_dim != self.index.d:
             raise ValueError(f"Embedding dimension mismatch. Expected {self.index.d}, got {embedding_dim}")
 
-        # Store chunks by index and update inverted metadata index
-        indexlen = len(self.chunk_by_index)
-        for i, embedded_chunk in enumerate(embedded_chunks):
-            faiss_pos = indexlen + i
-            self.chunk_by_index[faiss_pos] = embedded_chunk
-            for key, val in embedded_chunk.metadata.items():
-                self._meta_index.setdefault(key, {}).setdefault(val, set()).add(faiss_pos)
-
         async with self.chunk_id_lock:
+            for chunk_id in [ec.chunk_id for ec in embedded_chunks if ec.chunk_id in self.chunk_ids]:
+                self._remove_chunk(chunk_id)
+
+            # Store chunks by index and update inverted metadata index
+            indexlen = len(self.chunk_by_index)
+            for i, embedded_chunk in enumerate(embedded_chunks):
+                faiss_pos = indexlen + i
+                self.chunk_by_index[faiss_pos] = embedded_chunk
+                for key, val in embedded_chunk.metadata.items():
+                    self._meta_index.setdefault(key, {}).setdefault(val, set()).add(faiss_pos)
+
             self.index.add(embeddings)
             self.chunk_ids.extend([ec.chunk_id for ec in embedded_chunks])  # EmbeddedChunk inherits from Chunk
 
         # Save updated index
         await self._save_index()
 
+    def _remove_chunk(self, chunk_id: str) -> None:
+        removed_pos = self.chunk_ids.index(chunk_id)
+        self.index.remove_ids(_get_numpy().array([removed_pos]))
+
+        # Remove deleted position from _meta_index
+        for val_map in self._meta_index.values():
+            for positions in val_map.values():
+                positions.discard(removed_pos)
+
+        new_chunk_by_index = {}
+        for idx, chunk in self.chunk_by_index.items():
+            # Shift all chunks after the removed chunk to the left
+            if idx > removed_pos:
+                new_chunk_by_index[idx - 1] = chunk
+            else:
+                new_chunk_by_index[idx] = chunk
+        self.chunk_by_index = new_chunk_by_index
+        self.chunk_ids.pop(removed_pos)
+
+        # Shift all _meta_index positions > removed_pos down by 1
+        for val_map in self._meta_index.values():
+            for val in list(val_map):
+                val_map[val] = {p - 1 if p > removed_pos else p for p in val_map[val]}
+                if not val_map[val]:
+                    del val_map[val]
+
     async def delete_chunks(self, chunks_for_deletion: list[ChunkForDeletion]) -> None:
         chunk_ids = [c.chunk_id for c in chunks_for_deletion]
         if not set(chunk_ids).issubset(self.chunk_ids):
             return
 
-        def remove_chunk(chunk_id: str):
-            removed_pos = self.chunk_ids.index(chunk_id)
-            self.index.remove_ids(_get_numpy().array([removed_pos]))
-
-            # Remove deleted position from _meta_index
-            for val_map in self._meta_index.values():
-                for positions in val_map.values():
-                    positions.discard(removed_pos)
-
-            new_chunk_by_index = {}
-            for idx, chunk in self.chunk_by_index.items():
-                # Shift all chunks after the removed chunk to the left
-                if idx > removed_pos:
-                    new_chunk_by_index[idx - 1] = chunk
-                else:
-                    new_chunk_by_index[idx] = chunk
-            self.chunk_by_index = new_chunk_by_index
-            self.chunk_ids.pop(removed_pos)
-
-            # Shift all _meta_index positions > removed_pos down by 1
-            for val_map in self._meta_index.values():
-                for val in list(val_map):
-                    val_map[val] = {p - 1 if p > removed_pos else p for p in val_map[val]}
-                    if not val_map[val]:
-                        del val_map[val]
-
         async with self.chunk_id_lock:
             for chunk_id in chunk_ids:
-                remove_chunk(chunk_id)
+                self._remove_chunk(chunk_id)
 
         await self._save_index()
 

--- a/tests/unit/providers/vector_io/test_faiss.py
+++ b/tests/unit/providers/vector_io/test_faiss.py
@@ -199,6 +199,67 @@ async def test_meta_index_updated_on_delete_chunks(faiss_index, sample_chunks, s
     assert faiss_index._meta_index["document_id"]["mock-doc-2"] == {0}
 
 
+async def test_add_chunks_replaces_existing_chunk_id(
+    faiss_index, sample_chunks, sample_embeddings, embedding_dimension
+):
+    """Re-adding a chunk with an existing chunk_id should replace it, not duplicate it."""
+    embedded_chunks = [
+        EmbeddedChunk(
+            content=chunk.content,
+            chunk_id=chunk.chunk_id,
+            metadata=chunk.metadata,
+            chunk_metadata=chunk.chunk_metadata,
+            embedding=embedding.tolist(),
+            embedding_model="test-embedding-model",
+            embedding_dimension=embedding_dimension,
+        )
+        for chunk, embedding in zip(sample_chunks, sample_embeddings, strict=False)
+    ]
+    await faiss_index.add_chunks(embedded_chunks)
+    assert faiss_index.index.ntotal == 2
+    assert len(faiss_index.chunk_ids) == 2
+
+    updated = EmbeddedChunk(
+        content="updated content",
+        chunk_id=sample_chunks[0].chunk_id,
+        metadata={"document_id": "mock-doc-1"},
+        chunk_metadata=sample_chunks[0].chunk_metadata,
+        embedding=sample_embeddings[0].tolist(),
+        embedding_model="test-embedding-model",
+        embedding_dimension=embedding_dimension,
+    )
+    await faiss_index.add_chunks([updated])
+
+    # Count is unchanged and the stored chunk reflects the new content.
+    assert faiss_index.index.ntotal == 2
+    assert faiss_index.chunk_ids.count(sample_chunks[0].chunk_id) == 1
+    stored = next(c for c in faiss_index.chunk_by_index.values() if c.chunk_id == sample_chunks[0].chunk_id)
+    assert stored.content == "updated content"
+
+
+async def test_add_chunks_deduplicates_within_batch(faiss_index, sample_chunks, embedding_dimension):
+    """A single add_chunks call with repeated chunk_ids should keep only the last occurrence."""
+    embedding = np.random.rand(embedding_dimension).astype(np.float32).tolist()
+    chunk_id = sample_chunks[0].chunk_id
+    embedded_chunks = [
+        EmbeddedChunk(
+            content=f"content {i}",
+            chunk_id=chunk_id,
+            metadata={"document_id": "mock-doc-1"},
+            chunk_metadata=sample_chunks[0].chunk_metadata,
+            embedding=embedding,
+            embedding_model="test-embedding-model",
+            embedding_dimension=embedding_dimension,
+        )
+        for i in range(3)
+    ]
+    await faiss_index.add_chunks(embedded_chunks)
+
+    assert faiss_index.index.ntotal == 1
+    assert faiss_index.chunk_ids == [chunk_id]
+    assert faiss_index.chunk_by_index[0].content == "content 2"
+
+
 async def test_resolve_filter_positions_eq(faiss_index, sample_chunks, sample_embeddings, embedding_dimension):
     """eq filter should return only positions whose metadata value matches exactly."""
     embedded_chunks = [


### PR DESCRIPTION
# What does this PR do?

Finishes the FAISS part of #6256. PR #6260 aligned Milvus, ChromaDB, and SQLite-vec to upsert semantics and documented the contract on `VectorIO.insert_chunks` and `EmbeddingIndex.add_chunks`, but left FAISS on pure-append semantics.

The FAISS index called `self.index.add(embeddings)` unconditionally, so re-ingesting a chunk with an existing `chunk_id` silently created a duplicate. `add_chunks` now deduplicates within a batch and removes any existing entry that shares an incoming `chunk_id` before appending. The removal reuses the position-shift logic already used by `delete_chunks`, which is extracted into a `_remove_chunk` helper.

Closes #6256

## Test Plan

Added two unit tests: one for replacing a chunk across separate `add_chunks` calls, one for deduplicating repeated `chunk_id`s within a single batch. Both fail on the current code (index count grows to 3) and pass with this change.

```
uv run --group unit --group test pytest tests/unit/providers/vector_io/test_faiss.py -q
```

Output:

```
11 passed in 0.19s
```

Full vector_io unit suite also passes:

```
uv run --group unit --group test pytest tests/unit/providers/vector_io/ -q
277 passed, 19 warnings in 15.18s
```