### PR TITLE
docs: add eyeWalker external tool_runtime provider (accessibility research)

### DIFF
--- a/docs/docs/providers/external/external-providers-list.mdx
+++ b/docs/docs/providers/external/external-providers-list.mdx
@@ -9,3 +9,4 @@ Here's a list of known external providers that you can use with OGX:
 | RamaLama | Inference models with RamaLama | Inference | Remote | [ramalama-stack](https://github.com/containers/ramalama-stack) |
 | TrustyAI LM-Eval | Evaluate models with TrustyAI LM-Eval | Eval | Remote | [llama-stack-provider-lmeval](https://github.com/trustyai-explainability/llama-stack-provider-lmeval) |
 | MongoDB | VectorIO with MongoDB | Vector_IO | Remote | [mongodb-llama-stack](https://github.com/mongodb-partners/mongodb-llama-stack) |
+| eyeWalker | Assistive navigation research tools for vision impairment (not a medical device) | Tool Runtime | Remote | [ogx-provider-eyewalker](https://github.com/aeyemovment/ogx-provider-eyewalker) |


### PR DESCRIPTION
## Summary

Adds **eyeWalker** to the [Known External Providers](https://ogx-ai.github.io/docs/providers/external/external-providers-list) list.

| Field | Value |
|-------|--------|
| Name | eyeWalker |
| API | Tool Runtime |
| Type | Remote |
| Package / repo | https://github.com/aeyemovment/ogx-provider-eyewalker |
| Application source | https://github.com/aeyemovment/eyeWalker |

### What it is

External `remote::eyewalker` **tool_runtime** provider exposing research-prototype tools for assistive navigation cues (guidance text / mock-capable path). Built by **NeuroAgent AI** for people with rare neurologic diseases affecting vision and other neurologic/ophthalmologic causes of visual impairment.

### Safety (required)

> This is assistive, not replacement for cane/guide dog. Always keep traditional mobility aid. This is alpha. It is a research prototype for users and developers to improve upon. **Not a medical device. Not for clinical diagnosis or treatment.**

### Demos

- PWA: https://aeyemovment.github.io/eyeWalker/pwa.html
- HF Space (static): https://huggingface.co/spaces/NeuroAgentAI/eyeWalker

### Note on Llama Stack rename

`meta-llama/llama-stack` redirects to **OGX** (`ogx-ai/ogx`). This PR follows the **out-of-tree external provider** contribution path rather than embedding a tool inside the monorepo.

### Test plan

- [x] Provider package public and installable via git URL
- [x] Docs-only change to `external-providers-list.mdx`
- [x] Maintainer confirm table rendering on docs site