### PR TITLE
fix(deps): bump urllib3 and python-dotenv for CVE-2026-44432, CVE-2026-44431, and CVE-2026-28684

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "llama-stack-api",                                # API and provider specifications (local dev via tool.uv.sources)
     "openai>=2.5.0",
     "prompt-toolkit",
-    "python-dotenv",
+    "python-dotenv>=1.2.2",                           # CVE-2026-28684: arbitrary file overwrite via symlink following
     "pyjwt[crypto]>=2.12.0",                          # Pull crypto to support RS256 for jwt. Requires 2.12.0+ to fix CVE-2026-32597.
     "pydantic>=2.11.9",
     "rich",
@@ -60,7 +60,7 @@ dependencies = [
     "starlette>=0.49.1",
     "psycopg2-binary",
     "tornado>=6.5.3",
-    "urllib3>=2.6.3",
+    "urllib3>=2.7.0",                                 # CVE-2026-44432: DoS via excessive decompression; CVE-2026-44431: cross-origin redirect header leak
     "oracledb>=3.4.1",
     "oci>=2.165.0",
     "numpy>=2.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2805,7 +2805,7 @@ requires-dist = [
     { name = "pymongo", marker = "extra == 'starter'" },
     { name = "pypdf", marker = "extra == 'starter'", specifier = ">=6.7.2" },
     { name = "pythainlp", marker = "extra == 'starter'" },
-    { name = "python-dotenv" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'starter'" },
@@ -2829,7 +2829,7 @@ requires-dist = [
     { name = "tornado", specifier = ">=6.5.3" },
     { name = "tqdm", marker = "extra == 'starter'" },
     { name = "tree-sitter", marker = "extra == 'starter'" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "uvicorn", marker = "extra == 'starter'" },
     { name = "weaviate-client", marker = "extra == 'starter'", specifier = ">=4.16.5" },
@@ -5108,11 +5108,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -6792,11 +6792,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps two dependency constraints on `release-0.7.x` that were never backported to this branch:

| Dependency | Before | After | CVE |
|---|---|---|---|
| `urllib3` | `>=2.6.3` | `>=2.7.0` | CVE-2026-44432 (DoS via excessive decompression), CVE-2026-44431 (cross-origin redirect header leak) |
| `python-dotenv` | unpinned (lock: 1.1.1) | `>=1.2.2` | CVE-2026-28684 (arbitrary file overwrite via symlink following) |

## Why this branch was missed

The 0.4.x backport (#6222) covered both #6183 and #6184, but the 0.7.x backport (#6223) covered only #6183. urllib3 and python-dotenv were in #6184, so they never reached `release-0.7.x`.

The constraint lines and comments here match what `release-0.4.x` already carries (landed via #6303), so the two release branches stay consistent.

## Test plan

`uv lock` resolves cleanly with no collateral upgrades:

```
$ uv lock
Resolved 377 packages in 4.72s
Updated python-dotenv v1.1.1 -> v1.2.2
Updated urllib3 v2.6.3 -> v2.7.0
```

Diff is limited to `pyproject.toml` (2 lines) and `uv.lock` (those two packages plus their manifest constraint entries). Lockfile `revision` is unchanged at 3.

Needed for the upcoming v0.7.3 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNE7UmD7wXQwopAYxtTpmL