### PR TITLE
fix(deps): restore pyasn1>=0.6.4 for CVE-2026-59885

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ fallback_version = "0.4.6"
 [tool.uv]
 required-version = ">=0.7.0"
 constraint-dependencies = [
-    "pyasn1>=0.6.3",  # CVE-2026-30922: DoS via unbounded recursion
+    "pyasn1>=0.6.4",  # CVE-2026-30922, CVE-2026-59885: DoS via unbounded recursion
     "starlette>=1.0.1",                # CVE-2026-48710
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "starlette", specifier = ">=1.0.1" },
 ]
 
@@ -3838,11 +3838,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Restores `pyasn1>=0.6.4` on `release-0.4.x`. The constraint is currently back at `>=0.6.3` with the lockfile pinned to 0.6.3, which reintroduces CVE-2026-59885 (GHSA-8ppf-4f7h-5ppj).

## How the regression happened

#6335 bumped pyasn1 to `>=0.6.4` and merged at 13:30. #6361 (the pillow backport) had been rebuilt from a `release-0.4.x` baseline captured *before* that merge — its `pyproject.toml` and `uv.lock` still carried `0.6.3`. Merging it at 13:43 wrote the stale baseline back over the fix.

Both files were affected:

```
pyproject.toml:  "pyasn1>=0.6.4"  ->  "pyasn1>=0.6.3"
uv.lock:         pyasn1 0.6.4     ->  pyasn1 0.6.3
```

The pillow bump from #6361 is unaffected and stays as-is.

## Test plan

`uv lock` moves pyasn1 and nothing else:

```
$ uv lock
Resolved 336 packages in 2.62s
Updated pyasn1 v0.6.3 -> v0.6.4

$ uv lock --check
Resolved 336 packages in 1ms
```

Diff is `pyproject.toml` (1 line) plus the pyasn1 entry and manifest constraint in `uv.lock`. Lockfile `revision` held at 2 to match the branch.

Needed before tagging v0.4.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNE7UmD7wXQwopAYxtTpmL