### PR TITLE
fix(inference): validate MCP tool server_url to block SSRF to private addresses

### DIFF
--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -14,6 +14,7 @@ from openai.types.chat import ChatCompletionToolParam
 from opentelemetry import trace
 
 from ogx.log import get_logger
+from ogx.providers.utils.common.url_validation import validate_url_not_private
 from ogx.providers.utils.inference.openai_compat import convert_tooldef_to_openai_tool
 from ogx.providers.utils.inference.prompt_adapter import interleaved_content_as_str
 from ogx.providers.utils.tools.mcp import list_mcp_tools
@@ -1731,6 +1732,11 @@ class StreamingResponseOrchestrator:
                 raise ValueError(
                     f"Failed to list MCP tools for server '{mcp_tool.server_label}': server_url is not set"
                 )
+
+            # Security: reject MCP server URLs that resolve to private/loopback addresses to
+            # prevent the server from being used as an SSRF proxy against internal services
+            # or cloud metadata endpoints (see #6287).
+            validate_url_not_private(mcp_tool.server_url)
 
             attributes = {
                 "server_label": mcp_tool.server_label,

--- a/tests/unit/providers/inline/responses/builtin/responses/test_mcp_ssrf_guard.py
+++ b/tests/unit/providers/inline/responses/builtin/responses/test_mcp_ssrf_guard.py
@@ -1,0 +1,95 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Regression tests for the MCP tool ``server_url`` SSRF guard.
+
+An unauthenticated caller could point an MCP tool's ``server_url`` at an internal
+address (loopback, RFC1918, link-local, or cloud metadata) and have the server
+connect to it and forward attacker-supplied headers/tokens. The server must reject
+such URLs before opening a connection.
+
+See: https://github.com/ogx-ai/ogx/issues/6287
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ogx.providers.inline.responses.builtin.responses import streaming
+from ogx.providers.inline.responses.builtin.responses.streaming import StreamingResponseOrchestrator
+from ogx.providers.inline.responses.builtin.responses.types import ChatCompletionContext, ToolContext
+from ogx_api import OpenAIResponseInputToolMCP
+
+
+def _make_mcp_server(**kwargs) -> OpenAIResponseInputToolMCP:
+    defaults = {"server_label": "test-server", "server_url": "http://localhost:9999/mcp"}
+    defaults.update(kwargs)
+    return OpenAIResponseInputToolMCP(**defaults)
+
+
+def _build_orchestrator() -> StreamingResponseOrchestrator:
+    mock_ctx = MagicMock(spec=ChatCompletionContext)
+    mock_ctx.tool_context = MagicMock(spec=ToolContext)
+    mock_ctx.tool_context.previous_tools = {}
+    mock_ctx.model = "test-model"
+    mock_ctx.messages = []
+    mock_ctx.temperature = None
+    mock_ctx.top_p = None
+    mock_ctx.frequency_penalty = None
+    mock_ctx.response_format = MagicMock()
+    mock_ctx.tool_choice = None
+    mock_ctx.response_tools = []
+    mock_ctx.approval_response = MagicMock(return_value=None)
+
+    return StreamingResponseOrchestrator(
+        inference_api=AsyncMock(),
+        ctx=mock_ctx,
+        response_id="resp_test",
+        created_at=0,
+        text=MagicMock(),
+        max_infer_iters=1,
+        tool_executor=MagicMock(),
+        instructions=None,
+        moderation_endpoint=None,
+    )
+
+
+class TestMcpServerUrlSsrfGuard:
+    """MCP tool ``server_url`` must be validated to prevent SSRF (issue #6287)."""
+
+    async def test_private_server_url_rejected_before_connection(self):
+        orch = _build_orchestrator()
+        mcp_tool = _make_mcp_server(server_url="http://169.254.169.254/latest/meta-data/")
+
+        with patch.object(streaming, "list_mcp_tools", new_callable=AsyncMock) as mock_list:
+            with pytest.raises(ValueError, match="private"):
+                async for _ in orch._process_mcp_tool(mcp_tool, ["seed"]):
+                    pass
+
+        # The connection must never be opened for a blocked URL.
+        mock_list.assert_not_called()
+
+    async def test_loopback_server_url_rejected(self):
+        orch = _build_orchestrator()
+        mcp_tool = _make_mcp_server(server_url="http://127.0.0.1:19877/mcp")
+
+        with patch.object(streaming, "list_mcp_tools", new_callable=AsyncMock) as mock_list:
+            with pytest.raises(ValueError, match="private"):
+                async for _ in orch._process_mcp_tool(mcp_tool, ["seed"]):
+                    pass
+
+        mock_list.assert_not_called()
+
+    async def test_public_server_url_still_allowed(self):
+        orch = _build_orchestrator()
+        mcp_tool = _make_mcp_server(server_url="http://8.8.8.8/mcp")
+
+        with patch.object(streaming, "list_mcp_tools", new_callable=AsyncMock) as mock_list:
+            async for _ in orch._process_mcp_tool(mcp_tool, ["seed"]):
+                pass
+
+        mock_list.assert_awaited_once()
+        assert mock_list.await_args.kwargs["endpoint"] == "http://8.8.8.8/mcp"


### PR DESCRIPTION
## Problem

`POST /v1/responses` accepts MCP tool definitions whose `server_url` is fetched server-side with no destination validation (GHSA-63qr-vf6v-v7r5). On the default starter configuration the server runs with no `auth:` block, so an unauthenticated remote caller can make the server open connections to arbitrary internal addresses (loopback, RFC1918, link-local, and cloud metadata such as `http://169.254.169.254/`) and relay attacker-chosen `headers`/`authorization` bearer tokens to that destination — turning the server into an SSRF proxy.

## Root cause

`_process_mcp_tool` in `src/ogx/providers/inline/responses/builtin/responses/streaming.py` forwards the caller-controlled `mcp_tool.server_url` straight to `list_mcp_tools(...)` with no host/IP check. The codebase already ships `validate_url_not_private()` and applies it to sibling user-supplied URL inputs (inference content URLs in `prompt_adapter.py`, file-search URLs in `file_search.py`), but it is never applied to the MCP `server_url` — a missing-guard asymmetry.

## Fix

Call `validate_url_not_private(mcp_tool.server_url)` inside `_process_mcp_tool`, after the existing `server_url is not set` check (which also covers connector-id resolution, since `resolve_mcp_connector_id` runs at the top of the method) and before `list_mcp_tools` opens any connection. This reuses the existing guard, mirroring `prompt_adapter.py` and `file_search.py`. Because the validated `mcp_tool` is stored in `mcp_tool_to_server`, the later tool-invocation path (`invoke_mcp_tool` in `tool_executor.py`) also uses the validated URL.

## Test

New unit test file `tests/unit/providers/inline/responses/builtin/responses/test_mcp_ssrf_guard.py`:
- `http://169.254.169.254/latest/meta-data/` (link-local) and `http://127.0.0.1:19877/mcp` (loopback) `server_url`s raise `ValueError` and never reach `list_mcp_tools`;
- a public URL (`http://8.8.8.8/mcp`) is still allowed and reaches `list_mcp_tools`.

Run with:
```sh
uv run --python 3.12 --with-editable . --group unit python -m pytest -q tests/unit/providers/inline/responses/builtin/responses/test_mcp_ssrf_guard.py
```

Fixes #6287