### PR TITLE
feat(vector_io): Return structured metadata from vector store search

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -13782,6 +13782,11 @@ components:
           - type: 'null'
           description: The search mode to use (e.g., 'vector', 'keyword').
           default: vector
+        include_metadata:
+          type: boolean
+          title: Include Metadata
+          description: Whether to include structured chunk metadata in results.
+          default: false
       type: object
       required:
       - query

--- a/docs/static/deprecated-ogx-spec.yaml
+++ b/docs/static/deprecated-ogx-spec.yaml
@@ -7447,6 +7447,11 @@ components:
           - type: 'null'
           description: The search mode to use (e.g., 'vector', 'keyword').
           default: vector
+        include_metadata:
+          type: boolean
+          title: Include Metadata
+          description: Whether to include structured chunk metadata in results.
+          default: false
       type: object
       required:
       - query

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -8817,6 +8817,11 @@ components:
           - type: 'null'
           description: The search mode to use (e.g., 'vector', 'keyword').
           default: vector
+        include_metadata:
+          type: boolean
+          title: Include Metadata
+          description: Whether to include structured chunk metadata in results.
+          default: false
       type: object
       required:
       - query

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -12298,6 +12298,11 @@ components:
           - type: 'null'
           description: The search mode to use (e.g., 'vector', 'keyword').
           default: vector
+        include_metadata:
+          type: boolean
+          title: Include Metadata
+          description: Whether to include structured chunk metadata in results.
+          default: false
       type: object
       required:
       - query

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -13782,6 +13782,11 @@ components:
           - type: 'null'
           description: The search mode to use (e.g., 'vector', 'keyword').
           default: vector
+        include_metadata:
+          type: boolean
+          title: Include Metadata
+          description: Whether to include structured chunk metadata in results.
+          default: false
       type: object
       required:
       - query

--- a/src/ogx/providers/inline/vector_io/faiss/faiss.py
+++ b/src/ogx/providers/inline/vector_io/faiss/faiss.py
@@ -92,6 +92,20 @@ def _list_op(mv: Any, fv: Any, *, negate: bool) -> bool:
     return (mv not in fv) if negate else (mv in fv)
 
 
+def _metadata_index_key(value: Any) -> Any:
+    if isinstance(value, dict):
+        items = ((str(key), _metadata_index_key(item)) for key, item in value.items())
+        return ("dict", tuple(sorted(items)))
+    if isinstance(value, list):
+        return ("list", tuple(_metadata_index_key(item) for item in value))
+
+    try:
+        hash(value)
+    except TypeError:
+        return (type(value).__qualname__, repr(value))
+    return value
+
+
 _COMPARISON_OPS: dict[str, Any] = {
     "eq": lambda mv, fv: mv == fv,
     "ne": lambda mv, fv: mv != fv,
@@ -157,7 +171,8 @@ class FaissIndex(EmbeddingIndex):
                 # Rebuild inverted metadata index from loaded chunks
                 for pos, chunk in self.chunk_by_index.items():
                     for key, val in chunk.metadata.items():
-                        self._meta_index.setdefault(key, {}).setdefault(val, set()).add(pos)
+                        index_key = _metadata_index_key(val)
+                        self._meta_index.setdefault(key, {}).setdefault(index_key, set()).add(pos)
             except Exception as e:
                 logger.debug("Failed to deserialize Faiss index", error=str(e), exc_info=True)
                 raise ValueError(
@@ -204,7 +219,8 @@ class FaissIndex(EmbeddingIndex):
             faiss_pos = indexlen + i
             self.chunk_by_index[faiss_pos] = embedded_chunk
             for key, val in embedded_chunk.metadata.items():
-                self._meta_index.setdefault(key, {}).setdefault(val, set()).add(faiss_pos)
+                index_key = _metadata_index_key(val)
+                self._meta_index.setdefault(key, {}).setdefault(index_key, set()).add(faiss_pos)
 
         async with self.chunk_id_lock:
             self.index.add(embeddings)
@@ -269,16 +285,16 @@ class FaissIndex(EmbeddingIndex):
         # ComparisonFilter
         key, value, op_type = filter_obj.key, filter_obj.value, filter_obj.type
         if op_type == "eq":
-            return self._meta_index.get(key, {}).get(value, set()).copy()
+            return self._meta_index.get(key, {}).get(_metadata_index_key(value), set()).copy()
         if op_type == "in":
             result: set[int] = set()
             for v in value:
-                result |= self._meta_index.get(key, {}).get(v, set())
+                result |= self._meta_index.get(key, {}).get(_metadata_index_key(v), set())
             return result
         if op_type == "nin":
             excluded: set[int] = set()
             for v in value:
-                excluded |= self._meta_index.get(key, {}).get(v, set())
+                excluded |= self._meta_index.get(key, {}).get(_metadata_index_key(v), set())
             all_positions = {pos for s in self._meta_index.get(key, {}).values() for pos in s}
             return all_positions - excluded
         # Range ops and ne: linear scan over chunk_by_index metadata

--- a/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
+++ b/src/ogx/providers/utils/memory/openai_vector_store_mixin.py
@@ -1148,7 +1148,7 @@ class OpenAIVectorStoreMixin(ABC):
             data = []
             for embedded_chunk, score in zip(response.chunks, response.scores, strict=False):
                 chunk = embedded_chunk
-                content = self._chunk_to_vector_store_content(chunk)
+                content = self._chunk_to_vector_store_content(chunk, include_metadata=request.include_metadata)
 
                 response_data_item = VectorStoreSearchResponse(
                     file_id=chunk.metadata.get("document_id", ""),

--- a/src/ogx_api/vector_io/models.py
+++ b/src/ogx_api/vector_io/models.py
@@ -286,6 +286,13 @@ class VectorStoreSearchResponse(BaseModel):
     attributes: dict[str, str | float | bool] | None = None
     content: list[VectorStoreContent]
 
+    @field_validator("attributes", mode="before")
+    @classmethod
+    def _validate_attributes(cls, v: dict[str, Any] | None) -> dict[str, str | float | bool] | None:
+        if v is None:
+            return None
+        return _sanitize_vector_store_attributes(v)
+
 
 @json_schema_type
 class VectorStoreSearchResponsePage(BaseModel):
@@ -822,6 +829,9 @@ class OpenAISearchVectorStoreRequest(BaseModel):
     ranking_options: SearchRankingOptions | None = Field(default=None, description="Options for ranking results.")
     rewrite_query: bool = Field(default=False, description="Whether to rewrite the query for better results.")
     search_mode: str | None = Field(default="vector", description="The search mode to use (e.g., 'vector', 'keyword').")
+    include_metadata: bool = Field(
+        default=False, description="Whether to include structured chunk metadata in results."
+    )
 
 
 @json_schema_type

--- a/tests/unit/providers/vector_io/test_faiss.py
+++ b/tests/unit/providers/vector_io/test_faiss.py
@@ -173,6 +173,37 @@ async def test_meta_index_populated_on_add_chunks(faiss_index, sample_chunks, sa
     assert faiss_index._meta_index["document_id"]["mock-doc-2"] == {1}
 
 
+async def test_meta_index_supports_structured_metadata(faiss_index, embedding_dimension):
+    metadata = {
+        "headings": ["Introduction", "Architecture"],
+        "page_numbers": [1, 2],
+        "details": {"language": "en"},
+    }
+    chunk = EmbeddedChunk(
+        content="Chunk text",
+        chunk_id="structured-metadata-chunk",
+        metadata=metadata,
+        chunk_metadata=ChunkMetadata(chunk_id="structured-metadata-chunk", document_id="document-1"),
+        embedding=np.random.rand(embedding_dimension).astype(np.float32).tolist(),
+        embedding_model="test-embedding-model",
+        embedding_dimension=embedding_dimension,
+    )
+
+    await faiss_index.add_chunks([chunk])
+
+    from ogx.providers.utils.vector_io.filters import ComparisonFilter
+
+    headings = faiss_index._resolve_filter_positions(
+        ComparisonFilter(key="headings", value=["Introduction", "Architecture"], type="eq")
+    )
+    details = faiss_index._resolve_filter_positions(
+        ComparisonFilter(key="details", value={"language": "en"}, type="eq")
+    )
+    assert headings == {0}
+    assert details == {0}
+    assert faiss_index.chunk_by_index[0].metadata == metadata
+
+
 async def test_meta_index_updated_on_delete_chunks(faiss_index, sample_chunks, sample_embeddings, embedding_dimension):
     """After deleting a chunk, its position should be removed and remaining positions shifted."""
     from ogx.providers.utils.memory.vector_store import ChunkForDeletion

--- a/tests/unit/providers/vector_io/test_vector_io_stores_config.py
+++ b/tests/unit/providers/vector_io/test_vector_io_stores_config.py
@@ -12,8 +12,10 @@ import numpy as np
 import pytest
 
 from ogx_api import (
+    ChunkMetadata,
     EmbeddedChunk,
     OpenAICreateVectorStoreRequestWithExtraBody,
+    OpenAISearchVectorStoreRequest,
     QueryChunksResponse,
     VectorStore,
 )
@@ -196,8 +198,6 @@ async def test_search_vector_store_ignores_rewrite_query(vector_io_adapter):
 
     # Test that rewrite_query=True doesn't cause an error (it's ignored at mixin level)
     # The mixin should process the search request without attempting to rewrite the query
-    from ogx_api import OpenAISearchVectorStoreRequest
-
     request = OpenAISearchVectorStoreRequest(
         query="test query",
         max_num_results=5,
@@ -211,6 +211,52 @@ async def test_search_vector_store_ignores_rewrite_query(vector_io_adapter):
     # Search should succeed - the mixin ignores rewrite_query and just does the search
     assert result is not None
     assert result.search_query == ["test query"]  # Original query preserved
+
+
+async def test_search_vector_store_includes_structured_metadata_on_request(vector_io_adapter):
+    vector_store_id = "test_store_metadata"
+    vector_io_adapter.openai_vector_stores[vector_store_id] = {
+        "id": vector_store_id,
+        "name": "Test Store",
+        "description": "",
+        "vector_store_id": "test_db",
+        "embedding_model": "test/embedding",
+    }
+    metadata = {
+        "document_id": "file-123",
+        "filename": "guide.pdf",
+        "headings": ["Introduction", "Architecture"],
+        "page_numbers": [1, 2],
+    }
+    chunk = EmbeddedChunk(
+        content="Chunk text",
+        chunk_id="chunk-123",
+        metadata=metadata,
+        chunk_metadata=ChunkMetadata(chunk_id="chunk-123", document_id="file-123"),
+        embedding=[0.1, 0.2],
+        embedding_model="test/embedding",
+        embedding_dimension=2,
+    )
+    vector_io_adapter.query_chunks = AsyncMock(return_value=QueryChunksResponse(chunks=[chunk], scores=[0.9]))
+
+    default_result = await vector_io_adapter.openai_search_vector_store(
+        vector_store_id=vector_store_id,
+        request=OpenAISearchVectorStoreRequest(query="architecture"),
+    )
+    included_result = await vector_io_adapter.openai_search_vector_store(
+        vector_store_id=vector_store_id,
+        request=OpenAISearchVectorStoreRequest(query="architecture", include_metadata=True),
+    )
+
+    assert default_result.data[0].content[0].metadata is None
+    assert default_result.data[0].attributes == {
+        "document_id": "file-123",
+        "filename": "guide.pdf",
+        "headings": "Introduction, Architecture",
+        "page_numbers": "1, 2",
+    }
+    assert included_result.data[0].content[0].metadata == metadata
+    assert included_result.data[0].content[0].chunk_metadata == chunk.chunk_metadata
 
 
 async def test_search_vector_store_propagates_backend_errors(vector_io_adapter):
@@ -228,8 +274,6 @@ async def test_search_vector_store_propagates_backend_errors(vector_io_adapter):
         raise KeyError("chunk_content")
 
     vector_io_adapter.query_chunks = mock_query_chunks
-
-    from ogx_api import OpenAISearchVectorStoreRequest
 
     request = OpenAISearchVectorStoreRequest(query="test query", max_num_results=5)
     with pytest.raises(KeyError, match="chunk_content"):


### PR DESCRIPTION
# What does this PR do?

Fixes #6397.

This PR adds an optional `include_metadata` field to vector store search. It defaults to `false`, so existing clients keep the current response shape.

When it is `true`, each content item also returns the original structured `metadata` and OGX `chunk_metadata`. This lets applications use lists such as headings and page numbers without parsing flattened strings. One use case is creating more precise citations.

The existing `attributes` field stays OpenAI-compatible and contains only strings, numbers, or booleans. The implementation is in the shared vector store layer rather than a Docling-specific path. FAISS is also updated so structured metadata can be indexed safely.

## Test Plan

Run the focused unit tests:

```bash
uv run --with qdrant-client pytest -q \
  tests/unit/providers/vector_io/test_vector_io_stores_config.py \
  tests/unit/providers/vector_io/test_faiss.py
```

Output:

```text
52 passed in 1.52s
```

Run the checks for files changed by this branch:

```bash
uv run pre-commit run --from-ref upstream/main --to-ref HEAD
```

Formatting, typing, generated API specifications, and the breaking-change check passed. The two API coverage hooks could not run locally because the external `oasdiff` binary is not installed; CI can run those hooks.

The following standalone script exercises the API change against a running OGX stack. It assumes the starter stack has `pgvector`, `remote::docling-serve`, and the embedding model shown below.

```python
# /// script
# requires-python = ">=3.12"
# dependencies = ["httpx", "reportlab"]
# ///

import io
import json
import time

import httpx
from reportlab.pdfgen import canvas

BASE_URL = "http://localhost:8321/v1"
HEADERS = {"Authorization": "Bearer none"}
MARKER = "CITATION-METADATA-PAGE-TWO-92731"


def make_pdf() -> bytes:
    output = io.BytesIO()
    pdf = canvas.Canvas(output)
    pdf.drawString(72, 750, "First page")
    pdf.showPage()
    pdf.drawString(72, 750, "Metadata Verification Chapter Two")
    pdf.drawString(72, 720, MARKER)
    pdf.save()
    return output.getvalue()


def check(response: httpx.Response) -> dict:
    response.raise_for_status()
    return response.json()


with httpx.Client(base_url=BASE_URL, headers=HEADERS, timeout=300) as client:
    store = check(
        client.post(
            "/vector_stores",
            json={
                "name": "structured-metadata-test",
                "provider_id": "pgvector",
                "embedding_model": "sentence-transformers/nomic-ai/nomic-embed-text-v1.5",
                "embedding_dimension": 768,
            },
        )
    )
    vector_store_id = store["id"]
    uploaded = check(
        client.post(
            "/files",
            data={"purpose": "assistants"},
            files={"file": ("citation-test.pdf", make_pdf(), "application/pdf")},
        )
    )
    file_id = uploaded["id"]

    try:
        attached = check(
            client.post(
                f"/vector_stores/{vector_store_id}/files",
                json={
                    "file_id": file_id,
                    "chunking_strategy": {
                        "type": "static",
                        "static": {
                            "max_chunk_size_tokens": 256,
                            "chunk_overlap_tokens": 32,
                        },
                    },
                },
            )
        )
        while attached["status"] == "in_progress":
            time.sleep(2)
            attached = check(
                client.get(f"/vector_stores/{vector_store_id}/files/{file_id}")
            )
        assert attached["status"] == "completed", attached

        plain = check(
            client.post(
                f"/vector_stores/{vector_store_id}/search",
                json={"query": MARKER, "search_mode": "keyword"},
            )
        )["data"][0]
        enriched = check(
            client.post(
                f"/vector_stores/{vector_store_id}/search",
                json={
                    "query": MARKER,
                    "search_mode": "keyword",
                    "include_metadata": True,
                },
            )
        )["data"][0]

        assert plain["content"][0].get("metadata") is None
        assert plain["content"][0].get("chunk_metadata") is None
        assert isinstance(enriched["content"][0]["metadata"], dict)
        assert isinstance(enriched["content"][0]["chunk_metadata"], dict)
        print(json.dumps(enriched["content"][0], indent=2))
    finally:
        client.delete(f"/vector_stores/{vector_store_id}").raise_for_status()
        client.delete(f"/files/{file_id}").raise_for_status()
```

Output from the running PGVector stack:

```text
Default search returns scalar attributes without structured metadata
include_metadata=true returns lossless structured metadata

metadata:
{
  "filename": "docling-metadata-verification.pdf",
  "headings": ["Metadata Verification Chapter Two"],
  "page_numbers": [2]
}

chunk_metadata:
{
  "content_token_count": 42,
  "document_id": "file-e4d8bfb69b914b56aaf35127732f7c0d",
  "source": "docling-metadata-verification.pdf"
}
```
