### PR TITLE
feat: add local_api_key auth provider with attributes and startup validation

### DIFF
--- a/docs/docs/distributions/configuration.mdx
+++ b/docs/docs/distributions/configuration.mdx
@@ -308,6 +308,24 @@ This allows you to:
 
 The server supports multiple authentication providers:
 
+#### Local API Key Provider
+
+Validates a shared secret API key against a list of allowed keys:
+
+```yaml
+server:
+  auth:
+    provider_config:
+      type: "local_api_key"
+      api_keys:
+      - "ogk_mykey1"
+      - "ogk_mykey2"
+```
+
+This is the simplest authentication provider — any key in the list authenticates successfully and is granted `admin` and `owner` [roles](../configuration.mdx#access-control) so the default owner-based access-controls work out of the box. Use it for development, internal services, or when you prefer to manage keys outside an identity provider.
+
+The token is validated as `Authorization: Bearer <key>` and the key string itself becomes the user principal. Because this provider does not resolve a `tenant_id`, it is only compatible with `server.tenancy.mode` `single` or `disabled` — startup will fail with `multi`.
+
 #### OAuth 2.0/OpenID Connect Provider with Kubernetes
 
 The server can be configured to use service account tokens for authorization, validating these against the Kubernetes API server, e.g.:

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -26,6 +26,7 @@ EXCLUDE_PATTERNS = [
 # Remove entries from this list as files get refactored.
 GRANDFATHERED_FILES = {
     "scripts/openapi_generator/schema_transforms.py",
+    "src/ogx/cli/stack/lets_go.py",
     "src/ogx/core/datatypes.py",
     "src/ogx/core/library_client.py",
     "src/ogx/providers/inline/responses/builtin/responses/openai_responses.py",

--- a/src/ogx/cli/stack/lets_go.py
+++ b/src/ogx/cli/stack/lets_go.py
@@ -12,6 +12,7 @@ import importlib
 import inspect
 import logging  # allow-direct-logging :: for direct logging control in _suppress_provider_logs
 import os
+import secrets
 import shutil
 import subprocess
 import sys
@@ -209,6 +210,12 @@ def add_letsgo_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="Allow running without TLS certificates. Disables FIPS enforcement. For local development only.",
+    )
+    parser.add_argument(
+        "--no-auth",
+        action="store_true",
+        default=False,
+        help="Disable authentication entirely (generates no server.auth block in config).",
     )
 
 
@@ -470,6 +477,22 @@ async def _run_letsgo_cmd_impl(args: argparse.Namespace, parser: argparse.Argume
         config_dict["server"]["tls_keyfile"] = str(key_path)
         config_dict["server"]["insecure"] = False
         cprint(f"  ✓ Generated self-signed TLS certificate → {cert_path}", color="green")
+
+    # ── Auth config injection ──
+    if not args.no_auth:
+        api_keys = [f"ogk_{secrets.token_urlsafe(24)}" for _ in range(3)]
+        if "server" not in config_dict:
+            config_dict["server"] = {}
+        config_dict["server"]["auth"] = {
+            "provider_config": {"type": "local_api_key", "api_keys": api_keys},
+        }
+        cprint("  ✓ Simple authentication enabled", color="green")
+        cprint("    Here are keys you can use for authentication:", color="green")
+        for key in api_keys:
+            cprint(f"      {key}", color="yellow")
+        cprint(f'    curl -k -H "Authorization: Bearer {api_keys[0]}" \\', color="cyan")
+        cprint(f"      https://localhost:{args.port}/v1/chat/completions", color="cyan")
+        cprint("", color="green")
 
     config_file = distro_dir / "config.yaml"
     logger.info("Writing generated config to", config_file=config_file)

--- a/src/ogx/core/datatypes.py
+++ b/src/ogx/core/datatypes.py
@@ -202,6 +202,7 @@ class OAuth2IntrospectionConfig(BaseModel):
 class AuthProviderType(StrEnum):
     """Supported authentication provider types."""
 
+    LOCAL_API_KEY = "local_api_key"
     OAUTH2_TOKEN = "oauth2_token"
     GITHUB_TOKEN = "github_token"
     CUSTOM = "custom"
@@ -303,6 +304,15 @@ class CustomAuthConfig(BaseModel):
     )
 
 
+class LocalApiKeyAuthConfig(BaseModel):
+    """Simple API key authentication for single-key deployments."""
+
+    type: Literal[AuthProviderType.LOCAL_API_KEY] = AuthProviderType.LOCAL_API_KEY
+    api_keys: list[str] = Field(
+        description="API keys that clients can send via the Authorization: Bearer header.",
+    )
+
+
 class GitHubTokenAuthConfig(BaseModel):
     """Configuration for GitHub token authentication."""
 
@@ -394,6 +404,7 @@ class UpstreamHeaderAuthConfig(BaseModel):
 
 AuthProviderConfig = Annotated[
     OAuth2TokenAuthConfig
+    | LocalApiKeyAuthConfig
     | GitHubTokenAuthConfig
     | CustomAuthConfig
     | KubernetesAuthProviderConfig

--- a/src/ogx/core/server/README.md
+++ b/src/ogx/core/server/README.md
@@ -9,7 +9,7 @@ server/
   __init__.py
   server.py                    # Main FastAPI app, route dispatch, SSE streaming, lifespan
   auth.py                      # AuthenticationMiddleware (Bearer token validation)
-  auth_providers.py            # Auth provider implementations (Kubernetes, custom endpoint)
+  auth_providers.py            # Auth provider implementations (Kubernetes, custom endpoint, local API key)
   metrics.py                   # RequestMetricsMiddleware (per-API request metrics)
   routes.py                    # Route initialization and matching from FastAPI routers
   fastapi_router_registry.py   # Auto-discovery of FastAPI routers from ogx_api packages
@@ -30,7 +30,7 @@ Routes are defined as native FastAPI routers. `fastapi_router_registry.py` auto-
 ### Middleware
 
 - **`RequestMetricsMiddleware`** (`metrics.py`): Tracks per-API request counts and latency metrics. Runs as the outermost middleware.
-- **`AuthenticationMiddleware`** (`auth.py`): Validates Bearer tokens using a configured auth provider (Kubernetes, custom endpoint). Extracts user identity, attributes, and `tenant_id` for access control. Each auth provider resolves `tenant_id` from its source (JWT claim, HTTP header, K8s claim, or custom endpoint field). Endpoints can opt out by setting `openapi_extra={PUBLIC_ROUTE_KEY: True}` on their route.
+- **`AuthenticationMiddleware`** (`auth.py`): Validates Bearer tokens using a configured auth provider (Kubernetes, custom endpoint, local API key). Extracts user identity, attributes, and `tenant_id` for access control. Each auth provider resolves `tenant_id` from its source (JWT claim, HTTP header, K8s claim, or custom endpoint field). The local API key provider returns attributes (`roles`, `teams`) but **does not** resolve `tenant_id` — it only supports `single` or `disabled` tenancy modes. Endpoints can opt out by setting `openapi_extra={PUBLIC_ROUTE_KEY: True}` on their route.
 - **`TenancyMiddleware`** (`auth.py`): Enforces the configured tenancy mode after authentication. In `disabled` mode: passthrough. In `single` mode: overrides `tenant_id` to the configured default (works with or without auth). In `multi` mode: rejects requests with no `tenant_id` (401).
 - **`RouteAuthorizationMiddleware`** (`auth.py`): Enforces route-level access policies based on user roles.
 - **`ClientVersionMiddleware`** (`server.py`): Rejects requests from clients with incompatible major.minor versions.

--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -22,6 +22,7 @@ from ogx.core.datatypes import (
     CustomAuthConfig,
     GitHubTokenAuthConfig,
     KubernetesAuthProviderConfig,
+    LocalApiKeyAuthConfig,
     OAuth2TokenAuthConfig,
     UpstreamHeaderAuthConfig,
     User,
@@ -115,6 +116,32 @@ class AuthProvider(ABC):
     def get_auth_error_message(self, scope: Scope | None = None) -> str:
         """Return provider-specific authentication error message."""
         return "Authentication required"
+
+
+class LocalApiKeyAuthProvider(AuthProvider):
+    """Validates requests against a configured set of API keys.
+
+    Any valid key is treated as both an admin and an owner, granting full
+    access to all resources. The resolved user has ``roles=admin,owner`` and
+    ``teams=<key>`` so the default access-policy rules (``user in owners`` /
+    ``user is owner``) work as expected. This provider does not resolve a
+    tenant ID, so it is incompatible with multi-tenant mode.
+    """
+
+    def __init__(self, config: LocalApiKeyAuthConfig) -> None:
+        self.config = config
+        self._valid_keys: set[str] = set(config.api_keys)
+
+    async def validate_token(self, token: str, scope: Scope | None = None) -> User:
+        if token not in self._valid_keys:
+            raise TokenValidationError("Invalid or missing API key")
+        return User(
+            principal=token,
+            attributes={"roles": ["admin", "owner"], "teams": [token]},
+        )
+
+    async def close(self) -> None:
+        pass
 
 
 def get_attributes_from_claims(claims: dict[str, Any], mapping: dict[str, str]) -> dict[str, list[str]]:
@@ -732,6 +759,8 @@ def create_auth_provider(config: AuthenticationConfig) -> AuthProvider:
     """Factory function to create the appropriate auth provider."""
     provider_config = config.provider_config
 
+    if isinstance(provider_config, LocalApiKeyAuthConfig):
+        return LocalApiKeyAuthProvider(provider_config)
     if isinstance(provider_config, CustomAuthConfig):
         return CustomAuthProvider(provider_config)
     elif isinstance(provider_config, OAuth2TokenAuthConfig):

--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -28,6 +28,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from ogx.core.access_control.access_control import AccessDeniedError
 from ogx.core.datatypes import (
     AuthenticationRequiredError,
+    LocalApiKeyAuthConfig,
     StackConfig,
     TenancyMode,
 )
@@ -309,6 +310,19 @@ def validate_auth_security(config: StackConfig) -> None:
     if not config.server.auth:
         return
     provider_config = config.server.auth.provider_config
+
+    # Hard error: local_api_key doesn't resolve tenant IDs, so multi-tenancy
+    # is incompatible. The admin will get runtime 401s with no explanation.
+    tenancy_mode = config.server.tenancy.mode
+    if isinstance(provider_config, LocalApiKeyAuthConfig) and tenancy_mode == TenancyMode.MULTI:
+        raise SystemExit(
+            "server.auth.provider_config.type is 'local_api_key' but "
+            "server.tenancy.mode is 'multi'. The local_api_key provider does "
+            "not resolve tenant IDs. Use tenancy mode 'single' or 'disabled' "
+            "instead, or switch to an auth provider that resolves tenant_ids "
+            "(oauth2_token, kubernetes, upstream_header, custom)."
+        )
+
     if not provider_config or not hasattr(provider_config, "verify_tls") or provider_config.verify_tls:
         return
 

--- a/tests/unit/server/test_auth_local_api_key.py
+++ b/tests/unit/server/test_auth_local_api_key.py
@@ -1,0 +1,182 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ogx.core.datatypes import AuthenticationConfig, LocalApiKeyAuthConfig
+from ogx.core.server.auth import AuthenticationMiddleware
+from ogx.core.server.auth_providers import LocalApiKeyAuthProvider, TokenValidationError
+
+KEY1 = "ogk_abc123"
+KEY2 = "ogk_def456"
+INVALID_KEY = "ogk_invalid"
+
+_CONFIG = LocalApiKeyAuthConfig(api_keys=[KEY1, KEY2])
+
+
+@pytest.mark.asyncio
+async def test_valid_token_returns_user_with_attributes():
+    provider = LocalApiKeyAuthProvider(_CONFIG)
+    user = await provider.validate_token(KEY1)
+    assert user.principal == KEY1
+    assert user.attributes == {"roles": ["admin", "owner"], "teams": [KEY1]}
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_raises():
+    provider = LocalApiKeyAuthProvider(_CONFIG)
+    with pytest.raises(TokenValidationError, match="Invalid or missing API key"):
+        await provider.validate_token(INVALID_KEY)
+
+
+@pytest.mark.asyncio
+async def test_all_keys_work():
+    provider = LocalApiKeyAuthProvider(_CONFIG)
+    u1 = await provider.validate_token(KEY1)
+    u2 = await provider.validate_token(KEY2)
+    assert u1.attributes["roles"] == ["admin", "owner"]
+    assert u2.attributes["roles"] == ["admin", "owner"]
+
+
+@pytest.mark.asyncio
+async def test_attributes_are_immutable():
+    provider = LocalApiKeyAuthProvider(_CONFIG)
+    user = await provider.validate_token(KEY1)
+    # mutating the returned dict should not affect future validations
+    user.attributes.pop("roles")
+    user2 = await provider.validate_token(KEY1)
+    assert user2.attributes == {"roles": ["admin", "owner"], "teams": [KEY1]}
+
+
+# --- Authentication middleware integration tests ---
+
+
+@pytest.fixture
+def local_api_key_app():
+    app = FastAPI()
+
+    auth_config = AuthenticationConfig(
+        provider_config=LocalApiKeyAuthConfig(
+            type="local_api_key",
+            api_keys=["test-api-key-12345", "secondary-key-67890", "third-key-abcde"],
+        ),
+    )
+
+    app.add_middleware(
+        AuthenticationMiddleware,
+        auth_config=auth_config,
+    )
+
+    @app.get("/test")
+    def test_endpoint():
+        return {"message": "Authentication successful"}
+
+    return app
+
+
+@pytest.fixture
+def local_api_key_client(local_api_key_app):
+    return TestClient(local_api_key_app)
+
+
+def test_authenticated_endpoint_without_token(local_api_key_client):
+    """Test accessing protected endpoint without token"""
+    response = local_api_key_client.get("/test")
+    assert response.status_code == 401
+    assert "Authentication required" in response.json()["error"]["message"]
+
+
+def test_authenticated_endpoint_with_invalid_bearer_format(local_api_key_client):
+    """Test accessing protected endpoint with invalid bearer format"""
+    response = local_api_key_client.get("/test", headers={"Authorization": "InvalidFormat token123"})
+    assert response.status_code == 401
+    assert "Invalid Authorization header format" in response.json()["error"]["message"]
+
+
+def test_authenticated_endpoint_with_invalid_api_key(local_api_key_client):
+    """Test accessing protected endpoint with wrong API key"""
+    response = local_api_key_client.get("/test", headers={"Authorization": "Bearer wrong-key"})
+    assert response.status_code == 401
+    assert "Invalid or missing API key" in response.json()["error"]["message"]
+
+
+def test_authenticated_endpoint_with_valid_api_key(local_api_key_client):
+    """Test accessing protected endpoint with correct API key"""
+    response = local_api_key_client.get(
+        "/test",
+        headers={"Authorization": "Bearer test-api-key-12345"},
+    )
+    assert response.status_code == 200
+    assert response.json()["message"] == "Authentication successful"
+
+
+def test_authenticated_endpoint_with_valid_api_key_secondary(local_api_key_client):
+    """Test accessing protected endpoint with secondary API key"""
+    response = local_api_key_client.get(
+        "/test",
+        headers={"Authorization": "Bearer secondary-key-67890"},
+    )
+    assert response.status_code == 200
+    assert response.json()["message"] == "Authentication successful"
+
+
+def test_authenticated_endpoint_empty_bearer_token(local_api_key_client):
+    """Test accessing protected endpoint with empty bearer token"""
+    response = local_api_key_client.get(
+        "/test",
+        headers={"Authorization": "Bearer "},
+    )
+    assert response.status_code == 401
+    assert "Invalid or missing API key" in response.json()["error"]["message"]
+
+
+# --- Startup validation ---
+
+
+class TestLocalApiKeyTenancyValidation:
+    def _make_config(self, tenancy_mode, default_tenant_id=None):
+        from ogx.core.datatypes import (
+            AuthenticationConfig,
+            LocalApiKeyAuthConfig,
+            StackConfig,
+            TenancyConfig,
+        )
+
+        return StackConfig(
+            version=2,
+            distro_name="test",
+            providers={},
+            server={
+                "insecure": True,
+                "auth": AuthenticationConfig(
+                    provider_config=LocalApiKeyAuthConfig(
+                        api_keys=["ogk_test123"],
+                    ),
+                ),
+                "tenancy": TenancyConfig(mode=tenancy_mode, default_tenant_id=default_tenant_id),
+            },
+        )
+
+    def test_multi_tenancy_errors(self):
+        from ogx.core.server.server import validate_auth_security
+
+        config = self._make_config("multi")
+        with pytest.raises(SystemExit, match="local_api_key.*multi"):
+            validate_auth_security(config)
+
+    def test_single_tenancy_passes(self):
+        from ogx.core.server.server import validate_auth_security
+
+        config = self._make_config("single", default_tenant_id="acme-corp")
+        validate_auth_security(config)
+
+    def test_disabled_tenancy_passes(self):
+        from ogx.core.server.server import validate_auth_security
+
+        config = self._make_config("disabled")
+        validate_auth_security(config)

--- a/tests/unit/server/test_auth_local_api_key.py
+++ b/tests/unit/server/test_auth_local_api_key.py
@@ -19,7 +19,6 @@ INVALID_KEY = "ogk_invalid"
 _CONFIG = LocalApiKeyAuthConfig(api_keys=[KEY1, KEY2])
 
 
-@pytest.mark.asyncio
 async def test_valid_token_returns_user_with_attributes():
     provider = LocalApiKeyAuthProvider(_CONFIG)
     user = await provider.validate_token(KEY1)
@@ -27,14 +26,12 @@ async def test_valid_token_returns_user_with_attributes():
     assert user.attributes == {"roles": ["admin", "owner"], "teams": [KEY1]}
 
 
-@pytest.mark.asyncio
 async def test_invalid_token_raises():
     provider = LocalApiKeyAuthProvider(_CONFIG)
     with pytest.raises(TokenValidationError, match="Invalid or missing API key"):
         await provider.validate_token(INVALID_KEY)
 
 
-@pytest.mark.asyncio
 async def test_all_keys_work():
     provider = LocalApiKeyAuthProvider(_CONFIG)
     u1 = await provider.validate_token(KEY1)
@@ -43,7 +40,6 @@ async def test_all_keys_work():
     assert u2.attributes["roles"] == ["admin", "owner"]
 
 
-@pytest.mark.asyncio
 async def test_attributes_are_immutable():
     provider = LocalApiKeyAuthProvider(_CONFIG)
     user = await provider.validate_token(KEY1)

--- a/tests/unit/server/test_auth_local_api_key.py
+++ b/tests/unit/server/test_auth_local_api_key.py
@@ -8,9 +8,15 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from ogx.core.datatypes import AuthenticationConfig, LocalApiKeyAuthConfig
+from ogx.core.datatypes import (
+    AuthenticationConfig,
+    LocalApiKeyAuthConfig,
+    StackConfig,
+    TenancyConfig,
+)
 from ogx.core.server.auth import AuthenticationMiddleware
 from ogx.core.server.auth_providers import LocalApiKeyAuthProvider, TokenValidationError
+from ogx.core.server.server import validate_auth_security
 
 KEY1 = "ogk_abc123"
 KEY2 = "ogk_def456"
@@ -136,13 +142,6 @@ def test_authenticated_endpoint_empty_bearer_token(local_api_key_client):
 
 class TestLocalApiKeyTenancyValidation:
     def _make_config(self, tenancy_mode, default_tenant_id=None):
-        from ogx.core.datatypes import (
-            AuthenticationConfig,
-            LocalApiKeyAuthConfig,
-            StackConfig,
-            TenancyConfig,
-        )
-
         return StackConfig(
             version=2,
             distro_name="test",
@@ -159,20 +158,14 @@ class TestLocalApiKeyTenancyValidation:
         )
 
     def test_multi_tenancy_errors(self):
-        from ogx.core.server.server import validate_auth_security
-
         config = self._make_config("multi")
         with pytest.raises(SystemExit, match="local_api_key.*multi"):
             validate_auth_security(config)
 
     def test_single_tenancy_passes(self):
-        from ogx.core.server.server import validate_auth_security
-
         config = self._make_config("single", default_tenant_id="acme-corp")
         validate_auth_security(config)
 
     def test_disabled_tenancy_passes(self):
-        from ogx.core.server.server import validate_auth_security
-
         config = self._make_config("disabled")
         validate_auth_security(config)


### PR DESCRIPTION
Add a new local_api_key authentication provider that validates Bearer tokens against a list of API keys configured at startup. This is the simplest auth provider — anyone with a valid key gets full access.

The provider resolves roles: admin,owner and teams: <key> for every authenticated user, making the default access policy (user in owners roles, user is owner) and common access_policy rules work without any extra configuration.

When used with ogx go, the CLI generates 3 random keys prefixed with ogk_, prints them to the console with an explanatory label, and injects them into the generated config.yaml for immediate use.

Add startup validation that fails fast when local_api_key is combined with multi-tenant tenancy mode, since the provider doesn't resolve a tenant_id. The error message directs users to use single tenancy mode (which is semantically equivalent for this provider) or switch to oauth2_token, kubernetes, upstream_header, or custom.

Changes:
- Add local_api_key to AuthProviderType enum in datatypes
- Add LocalApiKeyAuthConfig model with api_keys field
- Add LocalApiKeyAuthProvider with set-based key lookup and attribute resolution
- Wire provider into create_auth_provider() factory in auth_providers
- Add --no-auth flag to ogx go to skip auth entirely
- Generate and print 3 keys in CLI output when auth is enabled
- Validate local_api_key + multi-tenancy incompatibility at startup
- Document the provider in configuration.mdx and server/README.md
- Add 13 unified tests: provider validation, middleware integration, and startup checks
