### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ The official `ogx_client` SDK is recommended for most use cases. The `ogx_open_c
 
 We hold regular community calls every Thursday at 09:00 AM PST — see the [Community Event on Discord](https://discord.gg/bUYRqEvK6) for details.
 
-[![Star History Chart](https://star-history.dera.page/svg?repos=ogx-ai/ogx&type=Date)](https://star-history.dera.page/#ogx-ai/ogx&Date)
 
 Thanks to all our amazing contributors!
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The official `ogx_client` SDK is recommended for most use cases. The `ogx_open_c
 
 We hold regular community calls every Thursday at 09:00 AM PST — see the [Community Event on Discord](https://discord.gg/bUYRqEvK6) for details.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ogx-ai/ogx&type=Date)](https://www.star-history.com/#ogx-ai/ogx&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ogx-ai/ogx&type=Date)](https://star-history.dera.page/#ogx-ai/ogx&Date)
 
 Thanks to all our amazing contributors!
 


### PR DESCRIPTION
The star history chart in the README Community section is broken because the previous star-history.com endpoint stopped working due to GitHub stargazer API restrictions. This changes the chart to star-history.dera.page, a maintained fork that works without an API token, restoring the chart for visitors. The wrapping link and the /svg image endpoint are both updated to the new domain.