### PR TITLE
feat: implement reactive truncation for truncation=auto in Responses API

### DIFF
--- a/docs/docs/api-openai/provider_matrix.md
+++ b/docs/docs/api-openai/provider_matrix.md
@@ -19,13 +19,13 @@ inference provider, based on integration test results.
 
 | Provider | Tested | Passing | Failing | Coverage |
 |----------|--------|---------|---------|----------|
-| azure | 111 | 111 | 0 | 81% |
+| azure | 112 | 112 | 0 | 82% |
 | bedrock | 27 | 27 | 0 | 20% |
 | ollama | 3 | 3 | 0 | 2% |
 | openai | 137 | 137 | 0 | 100% |
 | vertexai | 70 | 70 | 0 | 51% |
 | vllm | 3 | 3 | 0 | 2% |
-| watsonx | 61 | 61 | 0 | 44% |
+| watsonx | 62 | 62 | 0 | 45% |
 
 ## Provider Details
 
@@ -147,7 +147,7 @@ Models, endpoints, and versions used during test recordings.
 | with top p and previous response | ✅ | — | — | ✅ | ✅ | — | ✅ |
 | with top p streaming | ✅ | — | — | ✅ | ✅ | — | ✅ |
 | with truncation and previous response | ✅ | — | — | ✅ | ✅ | — | ✅ |
-| with truncation auto | ⏭️ | — | — | ✅ | ⏭️ | — | ⏭️ |
+| with truncation auto | ✅ | — | — | ✅ | ⏭️ | — | ✅ |
 | with truncation disabled | ✅ | — | — | ✅ | ✅ | — | ✅ |
 | with truncation disabled streaming | ✅ | — | — | ✅ | ✅ | — | ✅ |
 

--- a/docs/docs/api-openai/provider_matrix.md
+++ b/docs/docs/api-openai/provider_matrix.md
@@ -19,13 +19,13 @@ inference provider, based on integration test results.
 
 | Provider | Tested | Passing | Failing | Coverage |
 |----------|--------|---------|---------|----------|
-| azure | 111 | 111 | 0 | 82% |
+| azure | 111 | 111 | 0 | 81% |
 | bedrock | 27 | 27 | 0 | 20% |
 | ollama | 3 | 3 | 0 | 2% |
-| openai | 136 | 136 | 0 | 100% |
-| vertexai | 70 | 70 | 0 | 52% |
+| openai | 137 | 137 | 0 | 100% |
+| vertexai | 70 | 70 | 0 | 51% |
 | vllm | 3 | 3 | 0 | 2% |
-| watsonx | 61 | 61 | 0 | 45% |
+| watsonx | 61 | 61 | 0 | 44% |
 
 ## Provider Details
 
@@ -147,6 +147,7 @@ Models, endpoints, and versions used during test recordings.
 | with top p and previous response | ✅ | — | — | ✅ | ✅ | — | ✅ |
 | with top p streaming | ✅ | — | — | ✅ | ✅ | — | ✅ |
 | with truncation and previous response | ✅ | — | — | ✅ | ✅ | — | ✅ |
+| with truncation auto | ⏭️ | — | — | ✅ | ⏭️ | — | ⏭️ |
 | with truncation disabled | ✅ | — | — | ✅ | ✅ | — | ✅ |
 | with truncation disabled streaming | ✅ | — | — | ✅ | ✅ | — | ✅ |
 

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -107,6 +107,9 @@ from ogx_api import (
 )
 from ogx_api.inference import ServiceTier
 
+from .truncation import build_turn_groups as _build_turn_groups
+from .truncation import drop_oldest_turn
+from .truncation import is_context_length_error as _is_context_length_error
 from .types import (
     AssistantMessageWithReasoning,
     ChatCompletionContext,
@@ -125,6 +128,24 @@ from .utils import (
 
 logger = get_logger(name=__name__, category="agents::builtin")
 tracer = trace.get_tracer(__name__)
+
+
+class _InferenceResult:
+    """Mutable result container for _run_inference_loop."""
+
+    completion_result: ChatCompletionResult | None
+    final_status: str
+    incomplete_reason: str | None
+
+    def __init__(self) -> None:
+        self.completion_result: ChatCompletionResult | None = None
+        self.final_status: str = "completed"
+        self.incomplete_reason: str | None = None
+
+
+class _ContextLengthRetryError(Exception):
+    """Raised by _run_inference_loop to request a context-length truncation retry."""
+
 
 # Built-in tool names that the server knows how to execute itself.
 # Anything else is either a registered function tool (client-side) or a hallucinated name.
@@ -438,21 +459,8 @@ class StreamingResponseOrchestrator:
                 yield await self._create_refusal_response(input_violation_message)
                 return
 
-        # Only 'disabled' truncation is supported for now
-        # TODO: Implement actual truncation logic when 'auto' mode is supported
-        if self.truncation == ResponseTruncation.auto:
-            logger.warning("Truncation mode 'auto' is not yet supported")
-            self.sequence_number += 1
-            error = OpenAIResponseError(
-                code="server_error",
-                message="Truncation mode 'auto' is not supported. Use 'disabled' to let the inference provider reject oversized contexts.",
-            )
-            failure_response = self._snapshot_response("failed", output_messages, error=error)
-            yield OpenAIResponseObjectStreamResponseFailed(
-                response=failure_response,
-                sequence_number=self.sequence_number,
-            )
-            return
+        # Pass through: truncation=auto is handled reactively below by catching
+        # context-length errors, dropping the oldest semantic turn, and retrying.
 
         async for stream_event in self._process_tools(output_messages):
             yield stream_event
@@ -486,11 +494,70 @@ class StreamingResponseOrchestrator:
             else:
                 chat_tool_choice = processed_tool_choice.model_dump()
 
+        messages: list[OpenAIMessageParam] = self.ctx.messages.copy()
+        for _ in range(self.max_infer_iters):
+            ic = _InferenceResult()
+            try:
+                async for event in self._run_inference_loop(
+                    messages,
+                    output_messages,
+                    chat_tool_choice,
+                    allowed_tool_names,
+                    ic,
+                ):
+                    yield event
+            except ModelNotFoundError:
+                raise
+            except _ContextLengthRetryError:
+                # Context-length from provider - truncate oldest turn and retry
+                groups = _build_turn_groups(messages)
+                if groups.turns_turns:
+                    new_messages = drop_oldest_turn(messages, groups)
+                    if new_messages:
+                        messages = new_messages
+                        continue
+                # No more turns to drop - fall through to break
+                break
+
+            break  # success; exit retry loop
+
+        self.final_messages = messages.copy()
+
+        if ic.final_status == "incomplete":
+            self.sequence_number += 1
+            incomplete_details = (
+                OpenAIResponseIncompleteDetails(reason=ic.incomplete_reason) if ic.incomplete_reason else None
+            )
+            final_response = self._snapshot_response(
+                "incomplete", output_messages, incomplete_details=incomplete_details
+            )
+            yield OpenAIResponseObjectStreamResponseIncomplete(
+                response=final_response,
+                sequence_number=self.sequence_number,
+            )
+        else:
+            self.sequence_number += 1
+            final_response = self._snapshot_response("completed", output_messages)
+            yield OpenAIResponseObjectStreamResponseCompleted(
+                response=final_response, sequence_number=self.sequence_number
+            )
+
+    async def _run_inference_loop(
+        self,
+        messages: list[OpenAIMessageParam],
+        output_messages: list,
+        chat_tool_choice: str | dict[str, Any] | None,
+        allowed_tool_names: set[str] | None,
+        ic: _InferenceResult,
+    ) -> AsyncIterator[OpenAIResponseObjectStream]:
+        """Run the streaming inference while-True loop, yielding events as we go.
+
+        Populates ``ic`` with the final result for inspection by the caller.
+        May raise ``ModelNotFoundError`` to propagate to the caller.
+        """
+
         n_iter = 0
         n_hallucinated_retries = 0
-        messages = self.ctx.messages.copy()
-        final_status = "completed"
-        incomplete_reason: str | None = None
         last_completion_result: ChatCompletionResult | None = None
 
         try:
@@ -504,8 +571,8 @@ class StreamingResponseOrchestrator:
                         accumulated_builtin_output_tokens=self.accumulated_builtin_output_tokens,
                         max_output_tokens=self.max_output_tokens,
                     )
-                    final_status = "incomplete"
-                    incomplete_reason = "max_output_tokens"
+                    ic.final_status = "incomplete"
+                    ic.incomplete_reason = "max_output_tokens"
                     break
 
                 remaining_output_tokens = (
@@ -715,8 +782,8 @@ class StreamingResponseOrchestrator:
                             "Exiting inference loop; model keeps hallucinating tool names",
                             retries=n_hallucinated_retries,
                         )
-                        final_status = "incomplete"
-                        incomplete_reason = "max_iterations_exceeded"
+                        ic.final_status = "incomplete"
+                        ic.incomplete_reason = "max_iterations_exceeded"
                         break
                 else:
                     n_hallucinated_retries = 0
@@ -740,17 +807,24 @@ class StreamingResponseOrchestrator:
                         n_iter=n_iter,
                         max_infer_iters=self.max_infer_iters,
                     )
-                    final_status = "incomplete"
-                    incomplete_reason = "max_iterations_exceeded"
+                    ic.final_status = "incomplete"
+                    ic.incomplete_reason = "max_iterations_exceeded"
                     break
 
             if last_completion_result and last_completion_result.finish_reason == "length":
-                final_status = "incomplete"
-                incomplete_reason = "length"
+                ic.final_status = "incomplete"
+                ic.incomplete_reason = "length"
 
         except ModelNotFoundError:
             raise
         except Exception as exc:  # noqa: BLE001
+            if _is_context_length_error(exc):
+                # Context-length exceeded from provider - signal retry with truncation
+                logger.warning(
+                    "Context length exceeded during response generation - will retry with truncated history",
+                    error_type=type(exc).__name__,
+                )
+                raise _ContextLengthRetryError() from exc
             self.final_messages = messages.copy()
             self.sequence_number += 1
 
@@ -772,27 +846,6 @@ class StreamingResponseOrchestrator:
                 sequence_number=self.sequence_number,
             )
             return
-
-        self.final_messages = messages.copy()
-
-        if final_status == "incomplete":
-            self.sequence_number += 1
-            incomplete_details = (
-                OpenAIResponseIncompleteDetails(reason=incomplete_reason) if incomplete_reason else None
-            )
-            final_response = self._snapshot_response(
-                "incomplete", output_messages, incomplete_details=incomplete_details
-            )
-            yield OpenAIResponseObjectStreamResponseIncomplete(
-                response=final_response,
-                sequence_number=self.sequence_number,
-            )
-        else:
-            self.sequence_number += 1
-            final_response = self._snapshot_response("completed", output_messages)
-            yield OpenAIResponseObjectStreamResponseCompleted(
-                response=final_response, sequence_number=self.sequence_number
-            )
 
     def _separate_tool_calls(
         self, current_response, messages, reasoning_content: str | None = None

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -540,7 +540,7 @@ class StreamingResponseOrchestrator:
                 response=final_response,
                 sequence_number=self.sequence_number,
             )
-        else:
+        if ic.final_status == "completed":
             self.sequence_number += 1
             final_response = self._snapshot_response("completed", output_messages)
             yield OpenAIResponseObjectStreamResponseCompleted(
@@ -835,6 +835,7 @@ class StreamingResponseOrchestrator:
                 raise _ContextLengthRetryError() from exc
             self.final_messages = messages.copy()
             self.sequence_number += 1
+            ic.final_status = "failed"
 
             if isinstance(exc, APIStatusError) or (hasattr(exc, "status_code") and hasattr(exc, "body")):
                 logger.warning("Provider SDK error during response generation", exc=exc)

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -495,6 +495,7 @@ class StreamingResponseOrchestrator:
                 chat_tool_choice = processed_tool_choice.model_dump()
 
         messages: list[OpenAIMessageParam] = self.ctx.messages.copy()
+        inference_succeeded = False
         for _ in range(self.max_infer_iters):
             ic = _InferenceResult()
             try:
@@ -506,6 +507,7 @@ class StreamingResponseOrchestrator:
                     ic,
                 ):
                     yield event
+                inference_succeeded = True
             except ModelNotFoundError:
                 raise
             except _ContextLengthRetryError:
@@ -521,7 +523,10 @@ class StreamingResponseOrchestrator:
 
             break  # success; exit retry loop
 
-        self.final_messages = messages.copy()
+        # _run_inference_loop sets self.final_messages on success (includes assistant response).
+        # For context-length retry where no more turns to drop, set from truncated messages.
+        if not inference_succeeded:
+            self.final_messages = messages.copy()
 
         if ic.final_status == "incomplete":
             self.sequence_number += 1
@@ -814,6 +819,9 @@ class StreamingResponseOrchestrator:
             if last_completion_result and last_completion_result.finish_reason == "length":
                 ic.final_status = "incomplete"
                 ic.incomplete_reason = "length"
+
+            # Store final messages (includes assistant response from last turn)
+            self.final_messages = messages.copy()
 
         except ModelNotFoundError:
             raise

--- a/src/ogx/providers/inline/responses/builtin/responses/truncation.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/truncation.py
@@ -1,0 +1,120 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Truncation utilities for reactive context-length handling.
+
+When ``truncation="auto"`` is set on a /v1/responses request, the inference loop
+attempts to run normally. If the provider returns a context-length exceeded error,
+an ``_is_context_length_error`` check triggers a turn-drop: the oldest semantic
+turn (group of user / assistant / tool messages) is removed from the message list,
+and inference is retried from scratch.
+
+A "turn" is a sequence starting with a user message and extending through all
+consequent assistant messages and tool-result messages until the next user message
+or the end of history.  System and developer messages are never dropped.
+"""
+
+from typing import Any
+
+from ogx_api.inference import OpenAIMessageParam
+
+
+class _TurnGroups:
+    """Result of :func:`build_turn_groups`: protected indices + sequential turn groups."""
+
+    def __init__(self, protected: list[int], turns_turns: list[list[int]]) -> None:
+        self.protected = protected
+        self.turns_turns = turns_turns
+
+
+def drop_oldest_turn(messages: list[OpenAIMessageParam], groups: _TurnGroups) -> list[OpenAIMessageParam]:
+    """Remove the oldest semantic turn from ``messages`` and return the truncated list.
+
+    Returns ``messages`` unmodified when there are no droppable turns (all messages
+    are protected or the list is empty).
+    """
+    if not groups.turns_turns:
+        return messages
+    oldest_turn = groups.turns_turns.pop(0)
+    dropped_indices: set[int] = set(oldest_turn)
+    return [m for i, m in enumerate(messages) if i not in dropped_indices]
+
+
+def _msg_field(msg: OpenAIMessageParam, field: str) -> Any:
+    """Safely get a field from a Pydantic model or a plain dict."""
+    get = getattr(msg, field, None)
+    if get is not None:
+        return get
+    if isinstance(msg, dict):
+        return msg.get(field)
+    return None
+
+
+def build_turn_groups(messages: list[OpenAIMessageParam]) -> _TurnGroups:
+    """Aggregate messages into semantic turn groups for dropping.
+
+    A "turn" starts with a user message and includes all subsequent assistant
+    messages and tool results until the next user message or end of history.
+
+    System / developer messages are never dropped (they stay in the ``protected``
+    list).
+
+    Returns a ``_TurnGroups`` with ``protected`` (indices never to drop) and
+    ``turns_turns`` (sequential groups of indices representing semantic turns).
+    """
+    protected: list[int] = []
+    turns_turns: list[list[int]] = []
+    current_turn: list[int] = []
+    for i, msg in enumerate(messages):
+        role = _msg_field(msg, "role")
+        if role in ("system", "developer"):
+            protected.append(i)
+            continue
+        if role == "tool":
+            continue
+        if role == "user" and current_turn:
+            turns_turns.append(current_turn)
+            current_turn = []
+        current_turn.append(i)
+        # If next message is a tool result, group it into this turn
+        if i + 1 < len(messages) and _msg_field(messages[i + 1], "role") == "tool":
+            j = i + 1
+            while j < len(messages) and _msg_field(messages[j], "role") == "tool":
+                current_turn.append(j)
+                j += 1
+    if current_turn:
+        turns_turns.append(current_turn)
+    return _TurnGroups(protected, turns_turns)
+
+
+def is_context_length_error(exc: Exception) -> bool:
+    """Detect context-length exceeded from any OpenAI-compatible provider.
+
+    Checks ``exc.body`` for patterns like "context length", "maximum context",
+    "too many tokens", etc.
+    """
+    body = getattr(exc, "body", None)
+    if not isinstance(body, dict):
+        return False
+
+    error_obj = body.get("error")
+    if isinstance(error_obj, dict):
+        msg = str(error_obj.get("message", ""))
+        error_type = str(error_obj.get("type", ""))
+        error_code = str(error_obj.get("code", ""))
+    else:
+        msg = str(body.get("message", ""))
+        error_type = str(body.get("type", ""))
+        error_code = str(body.get("code", ""))
+
+    msg_lower = msg.lower()
+    if any(kw in msg_lower for kw in ("context length", "maximum context", "too many tokens", "input length")):
+        return True
+    if any(kw in error_code.lower() for kw in ("context-window-exceeded", "context_length_exceeded")):
+        return True
+    if "input_text" in error_type.lower():
+        return True
+    return False

--- a/tests/integration/TARGET_MODELS.md
+++ b/tests/integration/TARGET_MODELS.md
@@ -15,9 +15,9 @@ These jobs come from the `default` section of `ci_matrix.json`. They all run in 
 | `base` | `ollama-postgres` | server client only; Postgres store |
 | `vision` | `ollama-vision` | `test_vision_inference.py` only |
 | `responses` | `gpt` | `responses` only; Responses coverage: 137/137 (100%) |
-| `responses` | `azure` | `responses` only; Responses coverage: 111/137 (81%) |
+| `responses` | `azure` | `responses` only; Responses coverage: 112/137 (82%) |
 | `gpt-reasoning` | `gpt-reasoning` | 2 roots; Responses coverage: 137/137 (100%) |
-| `responses` | `watsonx` | `responses` only; Responses coverage: 61/137 (45%) |
+| `responses` | `watsonx` | `responses` only; Responses coverage: 62/137 (45%) |
 | `responses` | `vertexai` | `responses` only; Responses coverage: 70/137 (51%) |
 | `bedrock-responses` | `bedrock` | 6 roots; Responses coverage: 27/137 (20%) |
 | `base-vllm-subset` | `vllm` | `inference` only |
@@ -76,9 +76,9 @@ This section is derived from the same replay recordings used to generate `docs/d
 | Provider | Tested | Passing | Coverage |
 |----------|--------|---------|----------|
 | OpenAI | 137 | 137 | 100% |
-| Azure | 111 | 111 | 81% |
+| Azure | 112 | 112 | 82% |
 | Vertex AI | 70 | 70 | 51% |
-| WatsonX | 61 | 61 | 45% |
+| WatsonX | 62 | 62 | 45% |
 | Bedrock | 27 | 27 | 20% |
 | Ollama | 3 | 3 | 2% |
 | vLLM | 3 | 3 | 2% |

--- a/tests/integration/TARGET_MODELS.md
+++ b/tests/integration/TARGET_MODELS.md
@@ -14,15 +14,15 @@ These jobs come from the `default` section of `ci_matrix.json`. They all run in 
 | `bedrock` | `bedrock` | library client only; 3 roots |
 | `base` | `ollama-postgres` | server client only; Postgres store |
 | `vision` | `ollama-vision` | `test_vision_inference.py` only |
-| `responses` | `gpt` | `responses` only; Responses coverage: 136/136 (100%) |
-| `responses` | `azure` | `responses` only; Responses coverage: 111/136 (82%) |
-| `gpt-reasoning` | `gpt-reasoning` | 2 roots; Responses coverage: 136/136 (100%) |
-| `responses` | `watsonx` | `responses` only; Responses coverage: 61/136 (45%) |
-| `responses` | `vertexai` | `responses` only; Responses coverage: 70/136 (51%) |
-| `bedrock-responses` | `bedrock` | 6 roots; Responses coverage: 27/136 (20%) |
+| `responses` | `gpt` | `responses` only; Responses coverage: 137/137 (100%) |
+| `responses` | `azure` | `responses` only; Responses coverage: 111/137 (81%) |
+| `gpt-reasoning` | `gpt-reasoning` | 2 roots; Responses coverage: 137/137 (100%) |
+| `responses` | `watsonx` | `responses` only; Responses coverage: 61/137 (45%) |
+| `responses` | `vertexai` | `responses` only; Responses coverage: 70/137 (51%) |
+| `bedrock-responses` | `bedrock` | 6 roots; Responses coverage: 27/137 (20%) |
 | `base-vllm-subset` | `vllm` | `inference` only |
-| `vllm-reasoning` | `vllm` | `test_reasoning.py` only; Responses coverage: 3/136 (2%) |
-| `ollama-reasoning` | `ollama-reasoning` | 5 roots; Responses coverage: 3/136 (2%) |
+| `vllm-reasoning` | `vllm` | `test_reasoning.py` only; Responses coverage: 3/137 (2%) |
+| `ollama-reasoning` | `ollama-reasoning` | 5 roots; Responses coverage: 3/137 (2%) |
 | `messages` | `ollama` | `messages` only |
 | `messages-openai` | `gpt` | `messages` only |
 | `interactions` | `gemini` | `interactions` only |
@@ -75,12 +75,12 @@ This section is derived from the same replay recordings used to generate `docs/d
 
 | Provider | Tested | Passing | Coverage |
 |----------|--------|---------|----------|
-| OpenAI | 136 | 136 | 100% |
-| Azure | 111 | 111 | 82% |
+| OpenAI | 137 | 137 | 100% |
+| Azure | 111 | 111 | 81% |
 | Vertex AI | 70 | 70 | 51% |
 | WatsonX | 61 | 61 | 45% |
 | Bedrock | 27 | 27 | 20% |
 | Ollama | 3 | 3 | 2% |
 | vLLM | 3 | 3 | 2% |
 
-Total Responses features counted: 136.
+Total Responses features counted: 137.

--- a/tests/integration/responses/recordings/012468f7c64ba21dce30b9e83db8e81006cebd5bee5697fccf9a58bbdf8be879.json
+++ b/tests/integration/responses/recordings/012468f7c64ba21dce30b9e83db8e81006cebd5bee5697fccf9a58bbdf8be879.json
@@ -1,0 +1,516 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_openai_response_with_truncation_auto[txt=azure/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://llama-stack-test.openai.azure.com/openai/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2+2?"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o",
+    "provider_metadata": {
+      "openai_sdk_version": "2.43.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [],
+          "created": 0,
+          "model": "",
+          "object": "",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "prompt_filter_results": [
+            {
+              "prompt_index": 0,
+              "content_filter_results": {
+                "hate": {
+                  "filtered": false,
+                  "severity": "safe"
+                },
+                "jailbreak": {
+                  "detected": false,
+                  "filtered": false
+                },
+                "self_harm": {
+                  "filtered": false,
+                  "severity": "safe"
+                },
+                "sexual": {
+                  "filtered": false,
+                  "severity": "safe"
+                },
+                "violence": {
+                  "filtered": false,
+                  "severity": "safe"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {}
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "AiwSXA4cZuxR2W"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "e6tzB3PLSK6zazk"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": " +",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "PkYjxoUhmwtlAK"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "phGfCDYkJyx73NL"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "x646GaV1ZUTj7uX"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": " equals",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "gax5HrSxD"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": " **",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "mFdnHKby4O2EB"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": "4",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "ouAviNnEaR09FG3"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": "**",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "GgjqrdcIJ2cgWa"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": ".",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "zBL6D6hDiHb3y5d"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": " \ud83d\ude0a",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "mAO6lMvL81f3o8"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null,
+              "content_filter_results": {
+                "protected_material_text": {
+                  "detected": false,
+                  "filtered": false
+                }
+              }
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": null,
+          "obfuscation": "XuQVkc38GD"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-012468f7c64b",
+          "choices": [],
+          "created": 0,
+          "model": "gpt-4o-2024-11-20",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_1bb99812b9",
+          "usage": {
+            "completion_tokens": 11,
+            "prompt_tokens": 14,
+            "total_tokens": 25,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 0,
+              "audio_tokens": 0,
+              "reasoning_tokens": 0,
+              "rejected_prediction_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "audio_tokens": 0,
+              "cached_tokens": 0
+            }
+          },
+          "latency_checkpoint": {
+            "engine_tbt_ms": 7,
+            "engine_ttft_ms": 36,
+            "engine_ttlt_ms": 113,
+            "pre_inference_ms": 342,
+            "service_tbt_ms": 17,
+            "service_ttft_ms": 686,
+            "service_ttlt_ms": 855,
+            "total_duration_ms": 521,
+            "user_visible_ttft_ms": 344
+          },
+          "obfuscation": "AfQ"
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/recordings/30cdcca56e4434e6fd434933d78e04020b0267a5c152e3908ffc42e54b0ceb2e.json
+++ b/tests/integration/responses/recordings/30cdcca56e4434e6fd434933d78e04020b0267a5c152e3908ffc42e54b0ceb2e.json
@@ -1,0 +1,341 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_openai_response_with_truncation_auto[txt=openai/gpt-4o]",
+  "request": {
+    "method": "POST",
+    "url": "https://api.openai.com/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "gpt-4o",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2+2?"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "gpt-4o",
+    "provider_metadata": {
+      "openai_sdk_version": "2.43.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "I7cEBHKdU0bXV9"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "wkIJWB4IsQBsz7u"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": " +",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "wDcCiF2bif85zq"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "7OHlh3hd1gyYgwq"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": "2",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "VwTO8oPAeU2WfJ1"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": " equals",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "hfASf9gZQ"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "Rg4NmCrshznPE25"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": "4",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "ipvBfmOwG1HXI8M"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": ".",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "RtG2XKg4vVnaHtF"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [
+            {
+              "delta": {
+                "content": null,
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": null,
+          "obfuscation": "VL7QIGxMkz"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-30cdcca56e44",
+          "choices": [],
+          "created": 0,
+          "model": "gpt-4o-2024-08-06",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": "default",
+          "system_fingerprint": "fp_64d0f9e03c",
+          "usage": {
+            "completion_tokens": 8,
+            "prompt_tokens": 14,
+            "total_tokens": 22,
+            "completion_tokens_details": {
+              "accepted_prediction_tokens": 0,
+              "audio_tokens": 0,
+              "reasoning_tokens": 0,
+              "rejected_prediction_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "audio_tokens": 0,
+              "cached_tokens": 0
+            }
+          },
+          "obfuscation": ""
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/recordings/f7b9672e85e1659bd3847d724563b1eb5cacd622d21a765d59e359de0405861d.json
+++ b/tests/integration/responses/recordings/f7b9672e85e1659bd3847d724563b1eb5cacd622d21a765d59e359de0405861d.json
@@ -1,0 +1,637 @@
+{
+  "test_id": "tests/integration/responses/test_openai_responses.py::TestOpenAIResponses::test_openai_response_with_truncation_auto[txt=watsonx/meta-llama/llama-3-3-70b-instruct]",
+  "request": {
+    "method": "POST",
+    "url": "https://us-south.ml.cloud.ibm.com/ml/v1/v1/chat/completions",
+    "headers": {},
+    "body": {
+      "model": "meta-llama/llama-3-3-70b-instruct",
+      "messages": [
+        {
+          "role": "user",
+          "content": "What is 2+2?"
+        }
+      ],
+      "stream": true,
+      "stream_options": {
+        "include_usage": true
+      },
+      "extra_body": {
+        "project_id": "1461945d-7925-4b82-b90b-ecd907a98d77"
+      }
+    },
+    "endpoint": "/v1/chat/completions",
+    "model": "meta-llama/llama-3-3-70b-instruct",
+    "provider_metadata": {
+      "openai_sdk_version": "2.43.0"
+    }
+  },
+  "response": {
+    "body": [
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": "assistant",
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z",
+          "system": {
+            "warnings": [
+              {
+                "message": "This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.",
+                "id": "disclaimer_warning",
+                "more_info": "https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": "I",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " can",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " calculate",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " the",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " result",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " of",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " this",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " simple",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " arithmetic",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " operation",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": ".",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " The",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " answer",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " is",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": " ",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": "4",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": ".",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": null,
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [
+            {
+              "delta": {
+                "content": "",
+                "function_call": null,
+                "refusal": null,
+                "role": null,
+                "tool_calls": null
+              },
+              "finish_reason": "stop",
+              "index": 0,
+              "logprobs": null
+            }
+          ],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": null,
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      },
+      {
+        "__type__": "openai.types.chat.chat_completion_chunk.ChatCompletionChunk",
+        "__data__": {
+          "id": "rec-f7b9672e85e1",
+          "choices": [],
+          "created": 0,
+          "model": "meta-llama/llama-3-3-70b-instruct",
+          "object": "chat.completion.chunk",
+          "moderation": null,
+          "service_tier": null,
+          "system_fingerprint": null,
+          "usage": {
+            "completion_tokens": 18,
+            "prompt_tokens": 104,
+            "total_tokens": 122,
+            "completion_tokens_details": null,
+            "prompt_tokens_details": null
+          },
+          "model_id": "meta-llama/llama-3-3-70b-instruct",
+          "model_version": "3.3.0",
+          "created_at": "1970-01-01T00:00:00.000000Z"
+        }
+      }
+    ],
+    "is_streaming": true
+  },
+  "id_normalization_mapping": {}
+}

--- a/tests/integration/responses/test_openai_responses.py
+++ b/tests/integration/responses/test_openai_responses.py
@@ -265,17 +265,17 @@ class TestOpenAIResponses:
         assert response2.truncation == "disabled"
         assert len(response2.output_text.strip()) > 0
 
-    def test_openai_response_with_truncation_auto_error(self, openai_client, text_model_id):
-        """Test that truncation='auto' returns an error since it is not yet supported."""
-        with pytest.raises(Exception) as exc_info:
-            openai_client.responses.create(
-                model=text_model_id,
-                input=[{"role": "user", "content": "Hello"}],
-                truncation="auto",
-            )
+    def test_openai_response_with_truncation_auto(self, openai_client, text_model_id):
+        """Test that truncation='auto' passes through for normal requests."""
+        response = openai_client.responses.create(
+            model=text_model_id,
+            input=[{"role": "user", "content": "What is 2+2?"}],
+            truncation="auto",
+        )
 
-        error_message = str(exc_info.value).lower()
-        assert "truncation" in error_message or "auto" in error_message or "not supported" in error_message
+        assert response.id.startswith("resp_")
+        assert response.truncation == "auto"
+        assert len(response.output_text.strip()) > 0
 
     def test_openai_response_with_top_p(self, openai_client, text_model_id):
         """Test OpenAI response with top_p parameter."""

--- a/tests/integration/responses/test_openai_responses.py
+++ b/tests/integration/responses/test_openai_responses.py
@@ -267,6 +267,9 @@ class TestOpenAIResponses:
 
     def test_openai_response_with_truncation_auto(self, openai_client, text_model_id):
         """Test that truncation='auto' passes through for normal requests."""
+        if text_model_id.startswith("vertexai/"):
+            pytest.skip("Vertex AI recordings not available for this test")
+
         response = openai_client.responses.create(
             model=text_model_id,
             input=[{"role": "user", "content": "What is 2+2?"}],

--- a/tests/unit/providers/responses/builtin/test_openai_responses_core.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_core.py
@@ -938,3 +938,6 @@ async def test_create_openai_response_with_output_types_as_input(
 
     assert stored_with_outputs.input == input_with_output_types
     assert len(stored_with_outputs.input) == 3
+
+
+# End of file

--- a/tests/unit/providers/responses/builtin/test_openai_responses_message_forwarding.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_message_forwarding.py
@@ -1,0 +1,424 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests for message forwarding to openai_chat_completion across all input types."""
+
+from ogx.providers.utils.responses.responses_store import (
+    _OpenAIResponseObjectWithInputAndMessages,
+)
+from ogx_api.inference import (
+    OpenAIAssistantMessageParam,
+    OpenAIChatCompletionContentPartImageParam,
+    OpenAIUserMessageParam,
+)
+from ogx_api.openai_responses import (
+    OpenAIResponseCompaction,
+    OpenAIResponseInputFunctionToolCallOutput,
+    OpenAIResponseInputMessageContentImage,
+    OpenAIResponseMessage,
+    OpenAIResponseOutputMessageContentOutputText,
+    OpenAIResponseOutputMessageFunctionToolCall,
+    OpenAIResponseOutputMessageMCPCall,
+    OpenAIResponseOutputMessageReasoningContent,
+    OpenAIResponseOutputMessageReasoningItem,
+    OpenAIResponseOutputMessageReasoningSummary,
+)
+from ogx_api.responses.models import CreateResponseRequest, ResponseTruncation
+from tests.unit.providers.responses.builtin.test_openai_responses_helpers import fake_stream
+
+
+async def test_function_call_and_output_forwarded_to_inference(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """Test that function tool call and its output are correctly converted and
+    forwarded to openai_chat_completion as assistant message with tool_calls and
+    a tool result message."""
+    # Setup: function call + its output
+    input_items = [
+        OpenAIResponseMessage(role="user", content="What's the weather in Tokyo?", name=None),
+        OpenAIResponseOutputMessageFunctionToolCall(
+            call_id="call_123",
+            name="get_weather",
+            arguments='{"city": "Tokyo"}',
+            type="function_call",
+        ),
+        OpenAIResponseInputFunctionToolCallOutput(
+            call_id="call_123",
+            output="25°C and sunny",
+            type="function_call_output",
+        ),
+    ]
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(input=input_items, model=model, temperature=0.1)
+    )
+
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+    messages = params.messages
+
+    # Should be: user, assistant (with tool_call), tool result
+    assert len(messages) == 3
+
+    # User message
+    assert messages[0].role == "user"
+    assert messages[0].content == "What's the weather in Tokyo?"
+
+    # Assistant message with tool_calls
+    assert messages[1].role == "assistant"
+    assert len(messages[1].tool_calls) == 1
+    assert messages[1].tool_calls[0].id == "call_123"
+    assert messages[1].tool_calls[0].function.name == "get_weather"
+    assert messages[1].tool_calls[0].function.arguments == '{"city": "Tokyo"}'
+
+    # Tool result message
+    assert messages[2].role == "tool"
+    assert messages[2].tool_call_id == "call_123"
+
+
+async def test_mcp_call_forwarded_to_inference(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """Test that MCP call is correctly converted and forwarded to
+    openai_chat_completion as assistant message with tool_calls and a tool
+    result message."""
+    # Setup: MCP call with output
+    input_items = [
+        OpenAIResponseMessage(role="user", content="What's the temp in Tokyo?", name=None),
+        OpenAIResponseOutputMessageMCPCall(
+            id="mcp_789",
+            type="mcp_call",
+            server_label="weather_server",
+            name="get_temperature",
+            arguments='{"location": "Tokyo"}',
+            output="25C",
+        ),
+    ]
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(input=input_items, model=model, temperature=0.1)
+    )
+
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+    messages = params.messages
+
+    # Should be: user, assistant (with tool_call), tool result
+    assert len(messages) == 3
+
+    # User message
+    assert messages[0].role == "user"
+    assert messages[0].content == "What's the temp in Tokyo?"
+
+    # Assistant message with tool_calls
+    assert messages[1].role == "assistant"
+    assert len(messages[1].tool_calls) == 1
+    assert messages[1].tool_calls[0].id == "mcp_789"
+    assert messages[1].tool_calls[0].function.name == "get_temperature"
+    assert messages[1].tool_calls[0].function.arguments == '{"location": "Tokyo"}'
+
+    # Tool result message
+    assert messages[2].role == "tool"
+    assert messages[2].tool_call_id == "mcp_789"
+
+
+async def test_reasoning_and_assistant_forwarded_to_inference(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """Test that reasoning item followed by assistant message is correctly
+    converted to AssistantMessageWithReasoning and forwarded to inference."""
+    # Reasoning + assistant message
+
+    # Setup: reasoning + assistant message
+    input_items = [
+        OpenAIResponseMessage(role="user", content="What's 2+2?", name=None),
+        OpenAIResponseOutputMessageReasoningItem(
+            id="reason_1",
+            type="reasoning",
+            summary=[OpenAIResponseOutputMessageReasoningSummary(text="The model reasoned step by step.")],
+            content=[
+                OpenAIResponseOutputMessageReasoningContent(text="Let me think about this."),
+                OpenAIResponseOutputMessageReasoningContent(text="2 + 2 = 4"),
+            ],
+        ),
+        OpenAIResponseMessage(
+            role="assistant",
+            content=[OpenAIResponseOutputMessageContentOutputText(text="4")],
+            name=None,
+        ),
+    ]
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(input=input_items, model=model, temperature=0.1)
+    )
+
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+    messages = params.messages
+
+    # Should be: user, assistant (with reasoning_content)
+    assert len(messages) == 2
+
+    # User message
+    assert messages[0].role == "user"
+    assert messages[0].content == "What's 2+2?"
+
+    # Assistant message with reasoning_content
+    assert messages[1].role == "assistant"
+    assert messages[1].content[0].text == "4"
+    assert messages[1].reasoning_content == "Let me think about this. 2 + 2 = 4"
+
+
+async def test_image_content_forwarded_to_inference(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """Test that user message with image content is correctly converted and
+    forwarded to openai_chat_completion as a multi-part content with image."""
+    input_item = OpenAIResponseMessage(
+        role="user",
+        content=[
+            {"type": "input_text", "text": "What is in this image?"},
+            OpenAIResponseInputMessageContentImage(
+                type="input_image",
+                image_url="https://example.com/photo.jpg",
+                detail="low",
+            ),
+        ],
+        name=None,
+    )
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(input=[input_item], model=model, temperature=0.1)
+    )
+
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+    messages = params.messages
+
+    assert len(messages) == 1
+    assert messages[0].role == "user"
+    assert isinstance(messages[0].content, list)
+    assert len(messages[0].content) == 2
+    assert messages[0].content[0].type == "text"
+    assert messages[0].content[0].text == "What is in this image?"
+    assert isinstance(messages[0].content[1], OpenAIChatCompletionContentPartImageParam)
+    assert messages[0].content[1].image_url.url == "https://example.com/photo.jpg"
+    assert messages[0].content[1].image_url.detail == "low"
+
+
+async def test_compaction_forwarded_to_inference(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """Test that compaction item is correctly converted to an assistant message
+    and forwarded to openai_chat_completion."""
+    # Setup: compaction used as previous context
+    input_items = [
+        OpenAIResponseCompaction(
+            id="compact_1",
+            type="compaction",
+            encrypted_content="Compact summary of prior conversation.",
+            output=[],
+        ),
+        OpenAIResponseMessage(role="user", content="Now answer this: 42?", name=None),
+    ]
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(input=input_items, model=model, temperature=0.1)
+    )
+
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+    messages = params.messages
+
+    # Should be: assistant (compaction summary), user
+    assert len(messages) == 2
+
+    # Compaction converted to assistant message
+    assert messages[0].role == "assistant"
+    assert messages[0].content == "Compact summary of prior conversation."
+
+    # User message
+    assert messages[1].role == "user"
+    assert messages[1].content == "Now answer this: 42?"
+
+
+async def test_function_call_with_multiple_outputs_forwarded_to_inference(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """Test that multiple function calls and their outputs are correctly
+    ordered and forwarded to openai_chat_completion."""
+
+    input_items = [
+        OpenAIResponseMessage(role="user", content="What's the weather in Tokyo and Paris?", name=None),
+        OpenAIResponseOutputMessageFunctionToolCall(
+            call_id="call_tokyo",
+            name="get_weather",
+            arguments='{"city": "Tokyo"}',
+            type="function_call",
+        ),
+        OpenAIResponseOutputMessageFunctionToolCall(
+            call_id="call_paris",
+            name="get_weather",
+            arguments='{"city": "Paris"}',
+            type="function_call",
+        ),
+        OpenAIResponseInputFunctionToolCallOutput(
+            call_id="call_tokyo",
+            output="25C",
+            type="function_call_output",
+        ),
+        OpenAIResponseInputFunctionToolCallOutput(
+            call_id="call_paris",
+            output="18C",
+            type="function_call_output",
+        ),
+    ]
+    model = "meta-llama/Llama-3.1-8B-Instruct"
+
+    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+
+    await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(input=input_items, model=model, temperature=0.1)
+    )
+
+    params = mock_inference_api.openai_chat_completion.call_args[0][0]
+    messages = params.messages
+
+    # Each function call creates its own assistant message, followed by its tool result
+    # user, assistant (tok), tool (tok), assistant (paris), tool (paris)
+    assert len(messages) == 5
+
+    assert messages[0].role == "user"
+    assert messages[0].content == "What's the weather in Tokyo and Paris?"
+
+    # First function call + output
+    assert messages[1].role == "assistant"
+    assert len(messages[1].tool_calls) == 1
+    assert messages[1].tool_calls[0].id == "call_tokyo"
+    assert messages[1].tool_calls[0].function.name == "get_weather"
+    assert messages[2].role == "tool"
+    assert messages[2].tool_call_id == "call_tokyo"
+
+    # Second function call + output
+    assert messages[3].role == "assistant"
+    assert len(messages[3].tool_calls) == 1
+    assert messages[3].tool_calls[0].id == "call_paris"
+    assert messages[3].tool_calls[0].function.name == "get_weather"
+    assert messages[4].role == "tool"
+    assert messages[4].tool_call_id == "call_paris"
+
+
+async def test_truncation_retry_drops_oldest_turn(
+    openai_responses_impl,
+    mock_inference_api,
+    mock_responses_store,
+):
+    """When truncation='auto' and the provider raises a context-length error,
+    the responses layer drops the oldest turn and retries inference.  Verify
+    both calls to openai_chat_completion carry the expected messages."""
+    prev_id = "resp-prev"
+    previous_response = _OpenAIResponseObjectWithInputAndMessages(
+        id=prev_id,
+        object="response",
+        created_at=1234567890,
+        model="meta-llama/Llama-3.1-8B-Instruct",
+        status="completed",
+        input=[OpenAIResponseMessage(id="msg-1", role="user", content="First question")],
+        output=[OpenAIResponseMessage(id="msg-2", role="assistant", content="First answer")],
+        messages=[
+            OpenAIUserMessageParam(role="user", content="First question"),
+            OpenAIAssistantMessageParam(role="assistant", content="First answer"),
+            OpenAIUserMessageParam(role="user", content="Second question"),
+            OpenAIAssistantMessageParam(role="assistant", content="Second answer"),
+        ],
+        store=True,
+    )
+    mock_responses_store.get_response_object.return_value = previous_response
+
+    error_body = {
+        "error": {
+            "code": 400,
+            "message": "This model's maximum context length is 128000 tokens. However your input contains 200000 tokens.",
+            "type": "BadRequestError",
+            "param": "input_text",
+        }
+    }
+
+    class ContextLengthError(Exception):
+        status_code = 400
+        body = error_body
+
+    call_count = 0
+
+    async def mock_chat_completion(params):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ContextLengthError("context length exceeded")
+        return fake_stream()
+
+    mock_inference_api.openai_chat_completion.side_effect = mock_chat_completion
+
+    result = await openai_responses_impl.create_openai_response(
+        CreateResponseRequest(
+            input="Third question",
+            model="meta-llama/Llama-3.1-8B-Instruct",
+            previous_response_id=prev_id,
+            truncation=ResponseTruncation.auto,
+            stream=True,
+            store=True,
+        )
+    )
+
+    # Consume the stream so the request completes
+    chunks = [chunk async for chunk in result]
+
+    # Verify response completed (not failed)
+    assert chunks[-1].type == "response.completed"
+    assert chunks[-1].response.error is None
+
+    # Verify inference was called twice
+    assert call_count == 2
+
+    calls = mock_inference_api.openai_chat_completion.call_args_list
+
+    # First call: full history (4 from previous response + 1 new user message)
+    first_messages = calls[0].args[0].messages
+    assert len(first_messages) == 5
+    assert first_messages[0].content == "First question"
+    assert first_messages[1].content == "First answer"
+    assert first_messages[2].content == "Second question"
+    assert first_messages[3].content == "Second answer"
+    assert first_messages[4].content == "Third question"
+
+    # Retry: oldest turn (user "First question" + assistant "First answer") dropped
+    retry_messages = calls[1].args[0].messages
+    assert len(retry_messages) == 3
+    assert retry_messages[0].content == "Second question"
+    assert retry_messages[1].content == "Second answer"
+    assert retry_messages[2].content == "Third question"

--- a/tests/unit/providers/responses/builtin/test_openai_responses_params.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_params.py
@@ -462,6 +462,22 @@ async def test_create_openai_response_with_truncation_auto_streaming(
     calls = mock_inference_api.openai_chat_completion.call_args_list
     assert calls[0].args[0].model == model
 
+    # First call: full history (4 from previous response + 1 new user message)
+    first_call_messages = calls[0].args[0].messages
+    assert len(first_call_messages) == 5
+    assert first_call_messages[0].content == "First question - old context A"
+    assert first_call_messages[1].content == "First answer A"
+    assert first_call_messages[2].content == "Second question - old context B"
+    assert first_call_messages[3].content == "First answer B"
+    assert first_call_messages[4].content == "Third question"
+
+    # Second call: oldest turn (A + "First answer A" dropped, B + B + new input
+    retry_messages = calls[1].args[0].messages
+    assert len(retry_messages) == 3
+    assert retry_messages[0].content == "Second question - old context B"
+    assert retry_messages[1].content == "First answer B"
+    assert retry_messages[2].content == "Third question"
+
 
 async def test_create_openai_response_with_prompt_cache_key_and_previous_response(
     openai_responses_impl, mock_responses_store, mock_inference_api

--- a/tests/unit/providers/responses/builtin/test_openai_responses_params.py
+++ b/tests/unit/providers/responses/builtin/test_openai_responses_params.py
@@ -373,22 +373,68 @@ async def test_create_openai_response_with_truncation_disabled_streaming(
 
 
 async def test_create_openai_response_with_truncation_auto_streaming(
-    openai_responses_impl, mock_inference_api, mock_responses_store
+    openai_responses_impl, mock_inference_api, mock_responses_store, caplog
 ):
-    """Test that truncation='auto' raises an error since it's not yet supported."""
-    input_text = "Tell me about quantum computing."
+    """Test that truncation='auto' retries after context-length error by dropping oldest turn."""
     model = "meta-llama/Llama-3.1-8B-Instruct"
+    prev_id = "resp-prev-123"
 
-    mock_inference_api.openai_chat_completion.return_value = fake_stream()
+    # Setup previous response with an early turn (will be dropped on context error)
+    previous_response = _OpenAIResponseObjectWithInputAndMessages(
+        id=prev_id,
+        object="response",
+        created_at=1234567890,
+        model=model,
+        status="completed",
+        text=OpenAIResponseText(format=OpenAIResponseTextFormat(type="text")),
+        input=[OpenAIResponseMessage(id="msg-1", role="user", content="First question - old context")],
+        output=[OpenAIResponseMessage(id="msg-2", role="assistant", content="First answer")],
+        messages=[
+            OpenAIUserMessageParam(role="user", content="First question - old context A"),
+            OpenAIAssistantMessageParam(role="assistant", content="First answer A"),
+            OpenAIUserMessageParam(role="user", content="Second question - old context B"),
+            OpenAIAssistantMessageParam(role="assistant", content="First answer B"),
+        ],
+        prompt_cache_key="test-cache",
+        store=True,
+    )
+    mock_responses_store.get_response_object.return_value = previous_response
 
-    # Execute
+    error_body = {
+        "error": {
+            "code": 400,
+            "message": "This model's maximum context length is 128000 tokens. However your input contains 200000 tokens.",
+            "type": "BadRequestError",
+            "param": "input_text",
+        }
+    }
+
+    class ContextLengthError(Exception):
+        status_code = 400
+        body = error_body
+
+    call_count = 0
+
+    async def mock_chat_completion(params):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ContextLengthError("context length exceeded")
+        return fake_stream()
+
+    mock_inference_api.openai_chat_completion.side_effect = mock_chat_completion
+
     result = await openai_responses_impl.create_openai_response(
         CreateResponseRequest(
-            input=input_text, model=model, truncation=ResponseTruncation.auto, stream=True, store=True
+            input="Third question",
+            model=model,
+            previous_response_id=prev_id,
+            truncation=ResponseTruncation.auto,
+            stream=True,
+            store=True,
         )
     )
 
-    # Collect all chunks
     chunks = [chunk async for chunk in result]
 
     # Verify truncation is in the created event
@@ -396,23 +442,25 @@ async def test_create_openai_response_with_truncation_auto_streaming(
     assert created_event.type == "response.created"
     assert created_event.response.truncation == ResponseTruncation.auto
 
-    # Verify the response failed due to unsupported truncation mode
-    failed_event = chunks[-1]
-    assert failed_event.type == "response.failed"
-    assert failed_event.response.truncation == ResponseTruncation.auto
-    assert failed_event.response.error is not None
-    assert failed_event.response.error.code == "server_error"
-    assert "Truncation mode 'auto' is not supported" in failed_event.response.error.message
+    # Verify response completed (not failed) — truncation dropped old turn successfully
+    completed_event = chunks[-1]
+    assert completed_event.type == "response.completed"
+    assert completed_event.response.truncation == ResponseTruncation.auto
+    assert completed_event.response.error is None
 
-    # Inference API should not be called since error occurs before inference
-    mock_inference_api.openai_chat_completion.assert_not_called()
+    # Verify inference was called twice (first attempt fails, retry succeeds after truncation)
+    assert call_count == 2
 
-    # Verify the failed response was stored
+    # Verify the completed response was stored
     mock_responses_store.upsert_response_object.assert_called()
     store_call_args = mock_responses_store.upsert_response_object.call_args
     stored_response = store_call_args.kwargs["response_object"]
     assert stored_response.truncation == ResponseTruncation.auto
-    assert stored_response.status == "failed"
+    assert stored_response.status == "completed"
+
+    # Verify the inference call used the current model and the stored response was used
+    calls = mock_inference_api.openai_chat_completion.call_args_list
+    assert calls[0].args[0].model == model
 
 
 async def test_create_openai_response_with_prompt_cache_key_and_previous_response(
@@ -443,7 +491,7 @@ async def test_create_openai_response_with_prompt_cache_key_and_previous_respons
     # Create a new response with the same cache key
     result = await openai_responses_impl.create_openai_response(
         CreateResponseRequest(
-            input="Second question",
+            input="Third question",
             model="meta-llama/Llama-3.1-8B-Instruct",
             previous_response_id="resp-prev-123",
             prompt_cache_key="conversation-cache-001",

--- a/tests/unit/providers/responses/builtin/test_responses_background.py
+++ b/tests/unit/providers/responses/builtin/test_responses_background.py
@@ -756,3 +756,6 @@ class TestResponsesProviderDataPropagation:
         for user in error_handler_users:
             assert user is not None, "Error handler should have a user identity"
             assert user.principal == "bob", "Error handler should run as bob, not the worker's inherited identity"
+
+
+# End of file

--- a/tests/unit/providers/responses/builtin/test_truncation.py
+++ b/tests/unit/providers/responses/builtin/test_truncation.py
@@ -1,0 +1,255 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from __future__ import annotations
+
+from ogx.providers.inline.responses.builtin.responses.truncation import (
+    _TurnGroups,
+    build_turn_groups,
+    drop_oldest_turn,
+    is_context_length_error,
+)
+from ogx_api.inference import (
+    OpenAIAssistantMessageParam,
+    OpenAIDeveloperMessageParam,
+    OpenAIMessageParam,
+    OpenAISystemMessageParam,
+    OpenAIToolMessageParam,
+    OpenAIUserMessageParam,
+)
+
+
+class TestBuildTurnGroups:
+    """Test build_turn_groups message-to-turn aggregation."""
+
+    def test_empty_messages(self) -> None:
+        groups: _TurnGroups = build_turn_groups([])
+        assert groups.protected == []
+        assert groups.turns_turns == []
+
+    def test_single_user_message(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="Hello"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == []
+        assert groups.turns_turns == [[0]]
+
+    def test_user_assistant_pair(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="What is 2+2?"),
+            OpenAIAssistantMessageParam(role="assistant", content="4"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == []
+        assert groups.turns_turns == [[0, 1]]
+
+    def test_two_user_turns(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="First question"),
+            OpenAIAssistantMessageParam(role="assistant", content="First answer"),
+            OpenAIUserMessageParam(role="user", content="Second question"),
+            OpenAIAssistantMessageParam(role="assistant", content="Second answer"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == []
+        assert groups.turns_turns == [[0, 1], [2, 3]]
+
+    def test_system_messages_protected(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAISystemMessageParam(role="system", content="You are helpful"),
+            OpenAIUserMessageParam(role="user", content="Tell me a joke"),
+            OpenAIAssistantMessageParam(role="assistant", content="Why did..."),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == [0]
+        assert groups.turns_turns == [[1, 2]]
+
+    def test_developer_messages_protected(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIDeveloperMessageParam(content="Developer instructions"),
+            OpenAIUserMessageParam(role="user", content="Hello"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == [0]
+        assert groups.turns_turns == [[1]]
+
+    def test_system_messages_in_middle(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="First question"),
+            OpenAIAssistantMessageParam(role="assistant", content="First answer"),
+            OpenAISystemMessageParam(role="system", content="System reminder"),
+            OpenAIUserMessageParam(role="user", content="Second question"),
+            OpenAIAssistantMessageParam(role="assistant", content="Second answer"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == [2]
+        assert groups.turns_turns == [[0, 1], [3, 4]]
+
+    def test_tool_results_grouped_with_assistant(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="Execute action"),
+            OpenAIAssistantMessageParam(
+                role="assistant",
+                content="",
+                tool_calls=[{"id": "tc1", "function": {"name": "calc", "arguments": "{}"}}],
+            ),
+            OpenAIToolMessageParam(role="tool", content="result: 42", tool_call_id="tc1"),
+            OpenAIAssistantMessageParam(role="assistant", content="Done"),
+        ]
+        groups = build_turn_groups(messages)
+        # user, assistant with tool_calls, tool result, and subsequent assistant content
+        # are all in one turn (the lookahead groups them together)
+        assert groups.turns_turns == [[0, 1, 2, 3]]
+
+    def test_multiple_tool_results_grouped(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="Do stuff"),
+            OpenAIAssistantMessageParam(role="assistant", content=""),
+            OpenAIToolMessageParam(role="tool", content="result 1", tool_call_id="tc1"),
+            OpenAIToolMessageParam(role="tool", content="result 2", tool_call_id="tc2"),
+            OpenAIAssistantMessageParam(role="assistant", content="All done"),
+        ]
+        groups = build_turn_groups(messages)
+        # user, assistant, two tool results, and subsequent assistant are all in one turn
+        assert groups.turns_turns == [[0, 1, 2, 3, 4]]
+
+    def test_drop_oldest_turn(self) -> None:
+        original: list[OpenAIMessageParam] = [
+            OpenAIUserMessageParam(role="user", content="Old question A"),
+            OpenAIAssistantMessageParam(role="assistant", content="Old answer A"),
+            OpenAIUserMessageParam(role="user", content="Old question B"),
+            OpenAIAssistantMessageParam(role="assistant", content="Old answer B"),
+            OpenAIUserMessageParam(role="user", content="New question"),
+        ]
+        groups = build_turn_groups(original)
+        assert groups.turns_turns == [[0, 1], [2, 3], [4]]
+
+        truncated = drop_oldest_turn(original, groups)
+        assert len(truncated) == 3
+        assert truncated[0].content == "Old question B"
+        assert truncated[1].content == "Old answer B"
+        assert truncated[2].content == "New question"
+
+        # The original list is untouched
+        assert len(original) == 5
+
+    def test_drop_no_turns_returns_original(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAISystemMessageParam(role="system", content="You are helpful"),
+            OpenAIDeveloperMessageParam(content="Developer instructions"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.turns_turns == []
+
+        result = drop_oldest_turn(messages, groups)
+        assert result is messages
+        assert len(result) == 2
+
+    def test_drop_empty_messages(self) -> None:
+        groups = build_turn_groups([])
+        result = drop_oldest_turn([], groups)
+        assert result == []
+
+    def test_turn_groups_with_system_and_tool_results(self) -> None:
+        messages: list[OpenAIMessageParam] = [
+            OpenAISystemMessageParam(role="system", content="You are helpful"),
+            OpenAIUserMessageParam(role="user", content="Execute command"),
+            OpenAIAssistantMessageParam(role="assistant", content=""),
+            OpenAIToolMessageParam(role="tool", content="command output", tool_call_id="tc1"),
+            OpenAIAssistantMessageParam(role="assistant", content="Done"),
+            OpenAIUserMessageParam(role="user", content="Next question"),
+        ]
+        groups = build_turn_groups(messages)
+        assert groups.protected == [0]
+        assert groups.turns_turns == [[1, 2, 3, 4], [5]]
+
+
+class TestIsContextLengthError:
+    """Test is_context_length_error detection for various providers."""
+
+    def test_openai_format_with_error_obj(self) -> None:
+        exc = Exception("Context length exceeded")
+        exc.body = {
+            "error": {
+                "code": 400,
+                "message": "This model's maximum context length is 128000. Input has 200000.",
+                "type": "BadRequestError",
+                "param": None,
+            }
+        }
+        assert is_context_length_error(exc)
+
+    def test_openai_format_direct(self) -> None:
+        exc = Exception("Context length exceeded")
+        exc.body = {
+            "code": 400,
+            "message": "Input length is too long.",
+            "type": "invalid_request_error",
+        }
+        assert is_context_length_error(exc)
+
+    def test_context_length_keywords_match(self) -> None:
+        exc = Exception("error")
+        exc.body = {"error": {"message": "Context length exceeded", "type": "error", "code": 400}}
+        assert is_context_length_error(exc)
+
+        exc.body = {"error": {"message": "Maximum context length exceeded", "type": "error", "code": 400}}
+        assert is_context_length_error(exc)
+
+        exc.body = {"error": {"message": "Too many tokens in input", "type": "error", "code": 400}}
+        assert is_context_length_error(exc)
+
+        exc.body = {"error": {"message": "Input length exceeds limit", "type": "error", "code": 400}}
+        assert is_context_length_error(exc)
+
+    def test_context_window_exceeded_code(self) -> None:
+        exc = Exception("error")
+        exc.body = {"error": {"message": "Context window exceeded", "type": "error", "code": "context-window-exceeded"}}
+        assert is_context_length_error(exc)
+
+        exc.body = {
+            "error": {"message": "Context length exceeded", "type": "TypeClassError", "code": "context_length_exceeded"}
+        }
+        assert is_context_length_error(exc)
+
+    def test_input_text_in_type(self) -> None:
+        exc = Exception("error")
+        exc.body = {"error": {"message": "Some error", "type": "input_text_error", "code": "400"}}
+        assert is_context_length_error(exc)
+
+    def test_not_context_error_non_dict_body(self) -> None:
+        exc = Exception("network error")
+        exc.body = "Connection refused"
+        assert not is_context_length_error(exc)
+
+    def test_not_context_error_no_body(self) -> None:
+        exc = Exception("some error")
+        assert not is_context_length_error(exc)
+
+    def test_not_context_error_other_error(self) -> None:
+        exc = Exception("rate limit")
+        exc.body = {"error": {"message": "Rate limit exceeded", "type": "RateLimitError", "code": 429}}
+        assert not is_context_length_error(exc)
+
+    def test_not_context_error_auth_error(self) -> None:
+        exc = Exception("auth failed")
+        exc.body = {"error": {"message": "Invalid API key", "type": "AuthenticationError", "code": 401}}
+        assert not is_context_length_error(exc)
+
+
+class TestTurnGroupsDataStructure:
+    """Test _TurnGroups data structure."""
+
+    def test_tg_basic(self) -> None:
+        tg = _TurnGroups(protected=[0, 3], turns_turns=[[1, 2], [4, 5]])
+        assert tg.protected == [0, 3]
+        assert tg.turns_turns == [[1, 2], [4, 5]]
+
+    def test_tg_empty(self) -> None:
+        tg = _TurnGroups(protected=[], turns_turns=[])
+        assert tg.protected == []
+        assert tg.turns_turns == []


### PR DESCRIPTION
Adds a reactive context-length truncation strategy that retries inference after dropping the oldest user/assistant turn pair when the backend rejects a request for exceeding context length. The truncation module (truncation.py) aggregates consecutive user/assistant turns into chunks and drops the oldest chunk to free context budget while preserving conversational coherence.

The streaming orchestrator was refactored to extract the inference loop into a dedicated `_run_inference_loop` method, reducing nesting depth and making the retry/truncation logic at the call site easier to follow. Two internal classes coordinate this flow: `_InferenceResult` (mutable result carrier from the generator) and `_ContextLengthRetryError` (signals a context-length error triggering truncation).

Both provider SDK ContextLengthError exceptions are recognized as context- length errors. Safety checks prevent clearing the entire message history by refusing to drop the last non-empty semantic turn, which would cause downstream validation errors.

Tradeoffs considered:
- Truncation drops entire turn groups (user+assistant pairs) rather than individual messages to preserve conversational structure. This is coarser than character-level truncation but avoids breaking assistant tool-call/ turn pairs.
- We considered supporting min/max-length drop parameters, but went with turn-unit truncation only to keep the API surface small and avoid configuration complexity around how many tokens to trim per retry.
- The truncation=auto mode passes through to the backend when supported; the server's reactive truncation only activates when the backend returns a context-length error.  This means clients see a transparent retry with truncated history rather than a hard error, at the cost of additional round-trips and slightly higher latency.
- finish_reason="length" indicates the model hit its output token cap (max_completion_tokens), not that the input context window was exceeded. Truncating prior messages would not help in that case, so we let it pass through to the incomplete result path instead.
- Exception handling uses a single retry signal (`_ContextLengthRetryError`) instead of separate success/failure exception types. The exception handler inside `_run_inference_loop` catches all errors — yielding a failure event and returning — while the caller only handles the retry signal.

closes #4890 