### PR TITLE
fix(providers): stop counting cached tokens twice in the Anthropic-compat usage

### DIFF
--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -44,6 +44,7 @@ GRANDFATHERED_FILES = {
     "tests/unit/server/test_auth.py",  # 1000+ lines after auth middleware refactor
     "tests/unit/providers/responses/builtin/test_openai_responses_tools.py",  # sometimes 1000+ depending on ruff
     "src/ogx/core/stack.py",  # 1000+ lines after type fixes
+    "tests/unit/providers/utils/inference/test_anthropic_translation.py",  # 1009 lines
 }
 
 

--- a/src/ogx/providers/utils/inference/anthropic_translation.py
+++ b/src/ogx/providers/utils/inference/anthropic_translation.py
@@ -303,8 +303,11 @@ def openai_response_to_anthropic(response: OpenAIChatCompletion, request_model: 
         if response.usage.prompt_tokens_details and hasattr(response.usage.prompt_tokens_details, "cached_tokens"):
             cache_read = response.usage.prompt_tokens_details.cached_tokens
 
+        # OpenAI's prompt_tokens includes cached tokens; Anthropic's input_tokens
+        # excludes them (total input = input_tokens + cache_read + cache_creation),
+        # so the cached portion must be subtracted or consumers count it twice.
         usage = AnthropicUsage(
-            input_tokens=response.usage.prompt_tokens or 0,
+            input_tokens=max((response.usage.prompt_tokens or 0) - (cache_read or 0), 0),
             output_tokens=response.usage.completion_tokens or 0,
             cache_read_input_tokens=cache_read,
         )
@@ -430,7 +433,9 @@ async def openai_stream_to_anthropic(
     yield MessageDeltaEvent(
         delta=_MessageDelta(stop_reason=stop_reason),
         usage=AnthropicUsage(
-            input_tokens=input_tokens,
+            # Same convention translation as the non-streaming path: Anthropic's
+            # input_tokens excludes the cached portion of OpenAI's prompt_tokens.
+            input_tokens=max(input_tokens - (cache_read_tokens or 0), 0),
             output_tokens=output_tokens,
             cache_read_input_tokens=cache_read_tokens,
         ),

--- a/tests/unit/providers/utils/inference/test_anthropic_translation.py
+++ b/tests/unit/providers/utils/inference/test_anthropic_translation.py
@@ -546,6 +546,7 @@ class TestResponseTranslation:
         openai_resp.choices[0].finish_reason = "stop"
         openai_resp.usage = MagicMock()
         openai_resp.usage.prompt_tokens = 10
+        openai_resp.usage.prompt_tokens_details = None
         openai_resp.usage.completion_tokens = 5
 
         result = openai_response_to_anthropic(openai_resp, "claude-sonnet-4-20250514")
@@ -575,6 +576,7 @@ class TestResponseTranslation:
         openai_resp.choices[0].finish_reason = "tool_calls"
         openai_resp.usage = MagicMock()
         openai_resp.usage.prompt_tokens = 20
+        openai_resp.usage.prompt_tokens_details = None
         openai_resp.usage.completion_tokens = 10
 
         result = openai_response_to_anthropic(openai_resp, "m")
@@ -594,6 +596,7 @@ class TestResponseTranslation:
         openai_resp.choices[0].finish_reason = "length"
         openai_resp.usage = MagicMock()
         openai_resp.usage.prompt_tokens = 5
+        openai_resp.usage.prompt_tokens_details = None
         openai_resp.usage.completion_tokens = 100
 
         result = openai_response_to_anthropic(openai_resp, "m")
@@ -613,10 +616,31 @@ class TestResponseTranslation:
         openai_resp.usage.prompt_tokens_details.cached_tokens = 75
 
         result = openai_response_to_anthropic(openai_resp, "m")
-        assert result.usage.input_tokens == 100
+        # Anthropic's input_tokens excludes cached tokens; OpenAI's prompt_tokens
+        # includes them. 100 prompt tokens with 75 cached translate to 25, and the
+        # Anthropic-side total (input + cache_read) recovers the original 100.
+        assert result.usage.input_tokens == 25
         assert result.usage.output_tokens == 50
         assert result.usage.cache_read_input_tokens == 75
         assert result.usage.cache_creation_input_tokens is None
+        assert result.usage.input_tokens + result.usage.cache_read_input_tokens == 100
+
+    def test_fully_cached_prompt_translates_to_zero_input_tokens(self):
+        openai_resp = MagicMock()
+        openai_resp.choices = [MagicMock()]
+        openai_resp.choices[0].message = MagicMock()
+        openai_resp.choices[0].message.content = "response"
+        openai_resp.choices[0].message.tool_calls = None
+        openai_resp.choices[0].finish_reason = "stop"
+        openai_resp.usage = MagicMock()
+        openai_resp.usage.prompt_tokens = 80
+        openai_resp.usage.completion_tokens = 10
+        openai_resp.usage.prompt_tokens_details = MagicMock()
+        openai_resp.usage.prompt_tokens_details.cached_tokens = 80
+
+        result = openai_response_to_anthropic(openai_resp, "m")
+        assert result.usage.input_tokens == 0
+        assert result.usage.cache_read_input_tokens == 80
 
     def test_cache_metrics_missing(self):
         openai_resp = MagicMock()
@@ -641,6 +665,35 @@ class TestResponseTranslation:
 
 
 class TestStreamingTranslation:
+    async def test_streaming_usage_excludes_cached_tokens_from_input(self):
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta = MagicMock()
+        chunk.choices[0].delta.content = "hi"
+        chunk.choices[0].delta.tool_calls = None
+        chunk.choices[0].finish_reason = "stop"
+        chunk.usage = MagicMock()
+        chunk.usage.prompt_tokens = 100
+        chunk.usage.completion_tokens = 7
+        chunk.usage.prompt_tokens_details = MagicMock()
+        chunk.usage.prompt_tokens_details.cached_tokens = 75
+
+        async def mock_stream():
+            yield chunk
+
+        events = []
+        async for event in openai_stream_to_anthropic(mock_stream(), "m"):
+            events.append(event)
+
+        delta_events = [e for e in events if e.type == "message_delta"]
+        assert len(delta_events) == 1
+        usage = delta_events[0].usage
+        # Same convention as the non-streaming path: 100 prompt tokens with 75
+        # cached translate to 25 input tokens, and the sum recovers the total.
+        assert usage.input_tokens == 25
+        assert usage.cache_read_input_tokens == 75
+        assert usage.input_tokens + usage.cache_read_input_tokens == 100
+
     async def test_text_streaming(self):
         chunks = []
 


### PR DESCRIPTION
## What the bug looks like

Call the Anthropic-compat endpoint with a prompt of 100 tokens where 75 are cached, and the usage block comes back as `input_tokens: 100, cache_read_input_tokens: 75`. Anthropic's own docs define the total as the sum of the three fields, so a consumer following them bills or logs 175 input tokens for a 100 token request. The bigger the cache hit, the bigger the overcount, and nothing raises.

## Why this is the wrong translation

The two APIs use different conventions for the same fields. OpenAI's `prompt_tokens` includes the cached portion, with `prompt_tokens_details.cached_tokens` as a breakdown of it. Anthropic's is exclusive. From their prompt caching docs:

> `input_tokens`: Number of input tokens which were not read from or used to create a cache (that is, tokens after the last cache breakpoint).

and:

> total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens

So a faithful translation has to subtract the cached tokens before filling `input_tokens`. Both the response path and the streaming path now do that, clamped at zero in case a provider ever reports more cached than prompt tokens.

## About the existing test

`test_cache_metrics_mapping` asserted `input_tokens == 100` with 75 cached, which pins the inclusive convention onto the exclusive field, so I changed it rather than worked around it. The corrected assertion is 25, plus a sum check that the Anthropic-side fields recover the original 100. There is also a new fully-cached case (input_tokens 0) and a streaming case, and all three fail on current main.

Two unrelated tests in the file built their usage mocks without setting `prompt_tokens_details`, which leaked a MagicMock into the cache field once the subtraction existed. They now pin it to `None`; no behaviour change intended there.

## What is not changed

`cache_creation_input_tokens` stays `None`: OpenAI's usage details carry no cache-write counter, so there is nothing truthful to put there. The token counts themselves are passed through untouched apart from the subtraction.
