### PR TITLE
fix: bump starlette and aiohttp for CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ fallback_version = "0.7.3"
 required-version = ">=0.7.0"
 constraint-dependencies = [
     "pyasn1>=0.6.4",  # CVE-2026-30922: DoS via unbounded recursion
-    "starlette>=1.0.1",                # CVE-2026-48710
+    "starlette>=1.3.1",                # CVE-2026-48710, CVE-2026-54283: form() DoS
 ]
 
 [project]
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "PyYAML>=6.0",
-    "aiohttp>=3.14.0",                                  # CVE-2026-34993: CookieJar.load() RCE
+    "aiohttp>=3.14.3",                                  # CVE-2026-34993: RCE; CVE-2026-69244/69243: parser DoS, request smuggling
     "fastapi>=0.115.0,<1.0",                          # server
     "fire",                                           # for MCP in LLS client
     "httpx",

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "pyasn1", specifier = ">=0.6.4" },
-    { name = "starlette", specifier = ">=1.0.1" },
+    { name = "starlette", specifier = ">=1.3.1" },
 ]
 
 [[package]]
@@ -2762,7 +2762,7 @@ unit = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.0" },
+    { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "aiohttp", marker = "extra == 'starter'" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "aiosqlite", marker = "extra == 'starter'" },
@@ -6213,15 +6213,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.2.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Backport of the starlette and aiohttp CVE fixes from `main` to `release-0.7.x`.

- starlette `>=1.0.1` -> `>=1.3.1` (CVE-2026-54283: `form()` DoS; also CVE-2026-48710)
- aiohttp `>=3.14.0` -> `>=3.14.3` (CVE-2026-69244: parser DoS; CVE-2026-69243: request smuggling)

pyasn1 already at `>=0.6.4` on this branch.

`uv.lock` regenerated: starlette 1.6.0, aiohttp 3.14.3.