### PR TITLE
chore: update ogx-client to ^1.2.4 in UI lockfile

### DIFF
--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -26,7 +26,7 @@
         "next": "15.5.15",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.2.3",
+        "ogx-client": "^1.2.4",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11178,9 +11178,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.2.3.tgz",
-      "integrity": "sha512-Q/zIhf8fib0BczXXVfgJ3YXe2vMuaVh1tmW8heThFRQs0D6kJasE/YDRfS7lAzE3ZQs0Bg3nXRJSAiMFfDTJ8w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.2.4.tgz",
+      "integrity": "sha512-umjKKZWCIEXgg9z45fWAQkgTqxCuRPSVFEKE+9O39wiRhn1jYz2swXq8JCAuuCvlsU0lrkBUyh45yCF19R9ynA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -50,7 +50,7 @@
     "next": "15.5.15",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.2.3",
+    "ogx-client": "^1.2.4",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4389,7 +4389,7 @@ requires-dist = [
     { name = "nltk", marker = "extra == 'starter'", specifier = ">=3.10.0" },
     { name = "numpy", marker = "extra == 'starter'" },
     { name = "ogx-api", editable = "src/ogx_api" },
-    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.2.3" },
+    { name = "ogx-client", marker = "extra == 'client'", specifier = "==1.2.4" },
     { name = "ogx-open-client", marker = "extra == 'openclient'", specifier = ">=1.0.2" },
     { name = "ollama", marker = "extra == 'starter'" },
     { name = "openai", specifier = ">=2.41.0" },
@@ -4625,7 +4625,7 @@ requires-dist = [
 
 [[package]]
 name = "ogx-client"
-version = "1.2.3"
+version = "1.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fire" },
@@ -4635,9 +4635,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/b2/808f2f4c301bc249b83f4b2f979cb93de03988c951ac5ae69898cd520d99/ogx_client-1.2.3.tar.gz", hash = "sha256:03417ab0168e53c750412ce7e94170e28c4717c503c44d1ba5d65fd2f2910dee", size = 642336, upload-time = "2026-08-17T16:31:23.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b2/c8f220db53258147d86a17561bd1e55aa2b960905cef099670b728621d49/ogx_client-1.2.4.tar.gz", hash = "sha256:0ba6633898a474705350619a1feddee9571a0183e9e894b053ff875220180979", size = 642232, upload-time = "2026-08-20T13:59:04.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/fa/b7afdd5e1e80962f5e5c0b954565d5fe82bc1c575b08ca552968d1fbda4a/ogx_client-1.2.3-py3-none-any.whl", hash = "sha256:6ba0e4458c4abfc509d12aeb5c6db45235d16ed1af300983775452ffd6a61b96", size = 1584406, upload-time = "2026-08-17T16:31:21.59Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/b3/1b3b4294362f3cb5a49d31d7b14776a5509c9b62e2f8407776c09d0dfa41/ogx_client-1.2.4-py3-none-any.whl", hash = "sha256:84c96b39b4a7ba0d9867a4fcffc9cbc65d1cc421c9e896bfbfe218fb03dc0d7d", size = 1584402, upload-time = "2026-08-20T13:59:02.792Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automated post-release npm lockfile update after v1.2.4.

Updates ogx-client to ^1.2.4 in the UI package lockfile.

This PR was created automatically by the post-release workflow.