### PR TITLE
fix(vertexai): map "default" service_tier to None instead of "standard"

### DIFF
--- a/src/ogx/providers/remote/inference/vertexai/vertexai.py
+++ b/src/ogx/providers/remote/inference/vertexai/vertexai.py
@@ -543,7 +543,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         different vocabulary for the same concept:
 
         - ``"auto"``     → ``None``        (omit; let the API decide)
-        - ``"default"``  → ``"standard"``  (Gemini's default tier)
+        - ``"default"``  → ``None``        (omit; Vertex AI rejects ``"standard"``)
         - ``"flex"``     → ``"flex"``
         - ``"priority"`` → ``"priority"``
 
@@ -554,7 +554,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
 
         _map: dict[str, str | None] = {
             "auto": None,
-            "default": "standard",
+            "default": None,
             "flex": "flex",
             "priority": "priority",
         }

--- a/tests/unit/providers/inference/vertexai/test_adapter_params.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_params.py
@@ -260,7 +260,7 @@ class TestServiceTier:
         [
             pytest.param("flex", "flex", id="flex"),
             pytest.param("priority", "priority", id="priority"),
-            pytest.param("default", "standard", id="default_maps_to_standard"),
+            pytest.param("default", _OMITTED, id="default_omitted"),
             pytest.param("auto", _OMITTED, id="auto_omitted"),
             pytest.param(None, _OMITTED, id="none_omitted"),
         ],


### PR DESCRIPTION
## Summary

Map `"default"` service\_tier to `None` (omit) instead of `"standard"` in the Vertex AI provider. The Vertex AI REST API rejects `"standard"` as an invalid ServiceTier value.

## Bug

In multi-turn Responses API flows, `streaming.py` sets `self.service_tier = "default"` after the first inference call when the provider returns `service_tier=None` (line 616). On the next loop iteration this value is passed back to the inference provider as `ServiceTier("default")` (line 563).

The Vertex AI adapter maps `"default"` → `"standard"` in `_convert_service_tier()`, but the Vertex AI REST API rejects `"standard"`:

```
ClientError: 400 Bad Request. Invalid value at 'service_tier'
  (type.googleapis.com/google.cloud.aiplatform.v1beta1.ServiceTier), "standard"
```

This means every multi-turn response (tool calling, agentic flows) fails on the **second** inference call.

## Fix

Change the mapping from `"default": "standard"` to `"default": None`. This omits the field from the request, letting the API use its own default tier — consistent with how `"auto"` is already handled.

## Test plan

```bash
uv run pytest tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier -x -v
```

Output (all 10 pass):

```
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_service_tier_mapping[flex] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_service_tier_mapping[priority] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_service_tier_mapping[default_omitted] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_service_tier_mapping[auto_omitted] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_service_tier_mapping[none_omitted] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_unknown_service_tier_returns_none PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_supported_values_produce_no_warnings[flex] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_supported_values_produce_no_warnings[priority] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_supported_values_produce_no_warnings[default] PASSED
tests/unit/providers/inference/vertexai/test_adapter_params.py::TestServiceTier::test_supported_values_produce_no_warnings[auto] PASSED
```

Full vertexai suite (275 tests) passes.

Fixes #6418