### PR TITLE
fix(ci): use generated ADC for Vertex recordings

### DIFF
--- a/.github/workflows/record-integration-tests.yml
+++ b/.github/workflows/record-integration-tests.yml
@@ -258,6 +258,12 @@ jobs:
             echo "Skipping provider: $CURRENT"
           fi
 
+      - name: Reject Vertex AI recording for fork PRs
+        if: steps.should_run.outputs.run == 'true' && matrix.provider.setup == 'vertexai' && needs.compute-pr-info.outputs.is_fork_pr == 'true'
+        run: |
+          echo "::error::Failed to record with Vertex AI because Google Cloud authentication is intentionally unavailable for fork PRs. Push the commit to a branch in ogx-ai/ogx and dispatch the workflow from that branch."
+          exit 1
+
       - name: Checkout PR code
         if: steps.should_run.outputs.run == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -267,11 +273,13 @@ jobs:
           fetch-depth: 0
 
       - name: Authenticate to Google Cloud (Vertex AI)
+        id: vertex_auth
         if: steps.should_run.outputs.run == 'true' && matrix.provider.setup == 'vertexai' && needs.compute-pr-info.outputs.is_fork_pr != 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ secrets.VERTEX_AI_PROJECT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          create_credentials_file: true
 
       - name: Setup test environment
         if: steps.should_run.outputs.run == 'true'
@@ -319,7 +327,7 @@ jobs:
           WATSONX_PROJECT_ID: ${{ matrix.provider.setup == 'watsonx' && secrets.WATSONX_PROJECT_ID || '' }}
           VERTEX_AI_PROJECT: ${{ matrix.provider.setup == 'vertexai' && secrets.VERTEX_AI_PROJECT || '' }}
           VERTEX_AI_LOCATION: ${{ matrix.provider.setup == 'vertexai' && 'global' || '' }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ matrix.provider.setup == 'vertexai' && secrets.GOOGLE_APPLICATION_CREDENTIALS || '' }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ matrix.provider.setup == 'vertexai' && steps.vertex_auth.outputs.credentials_file_path || '' }}
           GEMINI_API_KEY: ${{ matrix.provider.setup == 'gemini' && secrets.GEMINI_API_KEY || '' }}
           TAVILY_SEARCH_API_KEY: ${{ contains(fromJSON('["gpt","azure","vertexai"]'), matrix.provider.setup) && secrets.TAVILY_SEARCH_API_KEY || '' }}
           AWS_BEDROCK_BEARER_TOKEN: ${{ matrix.provider.setup == 'bedrock' && secrets.AWS_BEARER_TOKEN_BEDROCK || '' }}


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHAIENG-7102

## Summary

Vertex recording now uses the short-lived ADC file created by `google-github-actions/auth` instead of the unrelated `GOOGLE_APPLICATION_CREDENTIALS` repository secret.

Fork PRs fail the Vertex matrix entry before checkout with a clear message. The workflow still does not authenticate fork code against Google Cloud.


## Testing

- `bash -n scripts/integration-tests.sh`
- `uv run pre-commit run --files .github/workflows/record-integration-tests.yml`

A trusted-branch Vertex recording dispatch is still needed to prove the full credential flow and recordings artifact upload.

## Sensitive CI/auth check

- Contract: trusted runs inherit the auth action's generated ADC file; fork Vertex runs stop before any Google auth.
- CI / merge queue: triggers, permissions, `pull_request` model, and existing fork guard are unchanged.
- Security: no static credential secret was added or logged.
