### PR TITLE
fix(core): filter persisted registry objects by active providers

### DIFF
--- a/src/ogx/core/routing_tables/common.py
+++ b/src/ogx/core/routing_tables/common.py
@@ -163,33 +163,10 @@ class CommonRoutingTableImpl(RoutingTable):
 
         raise ValueError(f"Provider not found for `{routing_key}`")
 
-    def _is_provider_active_for_type(self, obj_type: str, provider_id: str) -> bool:
-        from .models import ModelsRoutingTable
-        from .toolgroups import ToolGroupsRoutingTable
-        from .vector_stores import VectorStoresRoutingTable
-
-        if isinstance(self, ModelsRoutingTable) and obj_type == ResourceType.model.value:
-            return provider_id in self.impls_by_provider_id
-        elif isinstance(self, VectorStoresRoutingTable) and obj_type == ResourceType.vector_store.value:
-            return provider_id in self.impls_by_provider_id
-        elif isinstance(self, ToolGroupsRoutingTable) and obj_type == ResourceType.tool_group.value:
-            return provider_id in self.impls_by_provider_id
-        return True
-
     async def get_object_by_identifier(self, type: str, identifier: str) -> RoutableObjectWithProvider | None:
         # Get from disk registry
         obj = await self.dist_registry.get(type, identifier)
         if not obj:
-            return None
-
-        # Check if provider is available in this routing table (for managed types)
-        if not self._is_provider_active_for_type(obj.type, obj.provider_id):
-            logger.debug(
-                "Provider not available for object",
-                resource_type=type,
-                identifier=identifier,
-                provider_id=obj.provider_id,
-            )
             return None
 
         # Check if user has permission to access this object
@@ -262,9 +239,7 @@ class CommonRoutingTableImpl(RoutingTable):
 
     async def get_all_with_type(self, type: str) -> list[RoutableObjectWithProvider]:
         objs = await self.dist_registry.get_all()
-        filtered_objs = [
-            obj for obj in objs if obj.type == type and self._is_provider_active_for_type(obj.type, obj.provider_id)
-        ]
+        filtered_objs = [obj for obj in objs if obj.type == type]
 
         # Apply attribute-based access control filtering
         if filtered_objs:

--- a/src/ogx/core/routing_tables/common.py
+++ b/src/ogx/core/routing_tables/common.py
@@ -146,12 +146,14 @@ class CommonRoutingTableImpl(RoutingTable):
 
         # Get objects from disk registry
         obj = self.dist_registry.get_cached(objtype, routing_key)
-        if not obj:
+        if not obj or obj.provider_id not in self.impls_by_provider_id:
             provider_ids = list(self.impls_by_provider_id.keys())
             if len(provider_ids) > 1:
                 provider_ids_str = f"any of the providers: {', '.join(provider_ids)}"
-            else:
+            elif len(provider_ids) == 1:
                 provider_ids_str = f"provider: `{provider_ids[0]}`"
+            else:
+                provider_ids_str = "any active provider"
             raise ValueError(
                 f"{objtype.capitalize()} `{routing_key}` not served by {provider_ids_str}. Make sure there is an {apiname} provider serving this {objtype}."
             )
@@ -161,10 +163,33 @@ class CommonRoutingTableImpl(RoutingTable):
 
         raise ValueError(f"Provider not found for `{routing_key}`")
 
+    def _is_provider_active_for_type(self, obj_type: str, provider_id: str) -> bool:
+        from .models import ModelsRoutingTable
+        from .toolgroups import ToolGroupsRoutingTable
+        from .vector_stores import VectorStoresRoutingTable
+
+        if isinstance(self, ModelsRoutingTable) and obj_type == ResourceType.model.value:
+            return provider_id in self.impls_by_provider_id
+        elif isinstance(self, VectorStoresRoutingTable) and obj_type == ResourceType.vector_store.value:
+            return provider_id in self.impls_by_provider_id
+        elif isinstance(self, ToolGroupsRoutingTable) and obj_type == ResourceType.tool_group.value:
+            return provider_id in self.impls_by_provider_id
+        return True
+
     async def get_object_by_identifier(self, type: str, identifier: str) -> RoutableObjectWithProvider | None:
         # Get from disk registry
         obj = await self.dist_registry.get(type, identifier)
         if not obj:
+            return None
+
+        # Check if provider is available in this routing table (for managed types)
+        if not self._is_provider_active_for_type(obj.type, obj.provider_id):
+            logger.debug(
+                "Provider not available for object",
+                resource_type=type,
+                identifier=identifier,
+                provider_id=obj.provider_id,
+            )
             return None
 
         # Check if user has permission to access this object
@@ -179,7 +204,8 @@ class CommonRoutingTableImpl(RoutingTable):
         if not is_action_allowed(self.policy, "delete", obj, user):
             raise AccessDeniedError("delete", obj, user)
         await self.dist_registry.delete(obj.type, obj.identifier)
-        await unregister_object_from_provider(obj, self.impls_by_provider_id[obj.provider_id])
+        if obj.provider_id in self.impls_by_provider_id:
+            await unregister_object_from_provider(obj, self.impls_by_provider_id[obj.provider_id])
 
     async def register_object(self, obj: RoutableObjectWithProvider) -> RoutableObjectWithProvider:
         # if provider_id is not specified, pick an arbitrary one from existing entries
@@ -236,7 +262,9 @@ class CommonRoutingTableImpl(RoutingTable):
 
     async def get_all_with_type(self, type: str) -> list[RoutableObjectWithProvider]:
         objs = await self.dist_registry.get_all()
-        filtered_objs = [obj for obj in objs if obj.type == type]
+        filtered_objs = [
+            obj for obj in objs if obj.type == type and self._is_provider_active_for_type(obj.type, obj.provider_id)
+        ]
 
         # Apply attribute-based access control filtering
         if filtered_objs:

--- a/src/ogx/core/routing_tables/models.py
+++ b/src/ogx/core/routing_tables/models.py
@@ -41,7 +41,14 @@ logger = get_logger(name=__name__, category="core::routing_tables")
 class ModelsRoutingTable(CommonRoutingTableImpl, Models):
     """Routing table for managing model registrations, provider lookups, and dynamic model discovery."""
 
-    listed_providers: set[str] = set()
+    def __init__(
+        self,
+        impls_by_provider_id: dict[str, Any],
+        dist_registry: Any,
+        policy: list[Any],
+    ) -> None:
+        super().__init__(impls_by_provider_id, dist_registry, policy)
+        self.listed_providers: set[str] = set()
 
     async def _resolve_auto_model(self, provider_id: str, model_type: ModelType) -> str:
         """Resolve provider_model_id="auto" to an actual model from the provider.
@@ -88,6 +95,21 @@ class ModelsRoutingTable(CommonRoutingTableImpl, Models):
         return selected_model.provider_resource_id
 
     async def refresh(self) -> None:
+        # Delete listed_from_provider entries for inactive/disabled providers
+        existing_models = await self.get_all_with_type("model")
+        for model in existing_models:
+            if (
+                model.source == RegistryEntrySource.listed_from_provider
+                and model.provider_id not in self.impls_by_provider_id
+            ):
+                logger.debug(
+                    "Pruning model from disabled provider",
+                    model=model.identifier,
+                    provider_id=model.provider_id,
+                )
+                await self.unregister_object(model)
+                self.listed_providers.discard(model.provider_id)
+
         for provider_id, provider in self.impls_by_provider_id.items():
             refresh = await provider.should_refresh_models()
             refresh = refresh or provider_id not in self.listed_providers

--- a/tests/unit/distribution/routers/test_routing_tables.py
+++ b/tests/unit/distribution/routers/test_routing_tables.py
@@ -582,38 +582,39 @@ async def test_tool_groups_routing_table_exception_handling(cached_disk_dist_reg
 
 
 async def test_disabled_provider_models_persistence(cached_disk_dist_registry):
-    """Test that models from disabled providers are excluded from listing and lookups, but restored when provider is re-enabled."""
-    # Step 1: Start with provider_a enabled
+    """Test that provider-listed models from disabled providers are pruned during refresh, but re-discovered when provider is re-enabled."""
+    # Step 1: Start with provider_a enabled and discover provider_a models
     provider_a_impl = InferenceImpl()
     table1 = ModelsRoutingTable({"provider_a": provider_a_impl}, cached_disk_dist_registry, {})
     await table1.initialize()
-
-    await table1.register_model(model_id="model_a1", provider_id="provider_a")
+    await table1.refresh()
 
     models1 = await table1.list_models()
-    assert any(m.identifier == "provider_a/model_a1" for m in models1.data)
-    assert await table1.has_model("provider_a/model_a1") is True
+    assert any(m.identifier == "provider_a/provider-model-1" for m in models1.data)
+    assert await table1.has_model("provider_a/provider-model-1") is True
 
     # Step 2: Restart server with provider_a disabled (provider_b enabled instead)
     provider_b_impl = InferenceImpl()
     table2 = ModelsRoutingTable({"provider_b": provider_b_impl}, cached_disk_dist_registry, {})
     await table2.initialize()
+    await table2.refresh()
 
     models2 = await table2.list_models()
-    # provider_a models persisted in registry DB must NOT be listed
+    # provider_a listed models persisted in registry DB must be pruned during refresh
     assert not any(m.identifier.startswith("provider_a/") for m in models2.data)
-    assert await table2.has_model("provider_a/model_a1") is False
+    assert await table2.has_model("provider_a/provider-model-1") is False
 
     with pytest.raises(ModelNotFoundError):
-        await table2.get_model("provider_a/model_a1")
+        await table2.get_model("provider_a/provider-model-1")
 
     # Step 3: Restart server with provider_a re-enabled
     table3 = ModelsRoutingTable({"provider_a": provider_a_impl}, cached_disk_dist_registry, {})
     await table3.initialize()
+    await table3.refresh()
 
     models3 = await table3.list_models()
-    assert any(m.identifier == "provider_a/model_a1" for m in models3.data)
-    assert await table3.has_model("provider_a/model_a1") is True
+    assert any(m.identifier == "provider_a/provider-model-1" for m in models3.data)
+    assert await table3.has_model("provider_a/provider-model-1") is True
 
     await table1.shutdown()
     await table2.shutdown()

--- a/tests/unit/distribution/routers/test_routing_tables.py
+++ b/tests/unit/distribution/routers/test_routing_tables.py
@@ -579,3 +579,42 @@ async def test_tool_groups_routing_table_exception_handling(cached_disk_dist_reg
     tools = await table.list_tools(ListToolsRequest(toolgroup_id="test-toolgroup-exceptions"))
 
     assert len(tools.data) == 0
+
+
+async def test_disabled_provider_models_persistence(cached_disk_dist_registry):
+    """Test that models from disabled providers are excluded from listing and lookups, but restored when provider is re-enabled."""
+    # Step 1: Start with provider_a enabled
+    provider_a_impl = InferenceImpl()
+    table1 = ModelsRoutingTable({"provider_a": provider_a_impl}, cached_disk_dist_registry, {})
+    await table1.initialize()
+
+    await table1.register_model(model_id="model_a1", provider_id="provider_a")
+
+    models1 = await table1.list_models()
+    assert any(m.identifier == "provider_a/model_a1" for m in models1.data)
+    assert await table1.has_model("provider_a/model_a1") is True
+
+    # Step 2: Restart server with provider_a disabled (provider_b enabled instead)
+    provider_b_impl = InferenceImpl()
+    table2 = ModelsRoutingTable({"provider_b": provider_b_impl}, cached_disk_dist_registry, {})
+    await table2.initialize()
+
+    models2 = await table2.list_models()
+    # provider_a models persisted in registry DB must NOT be listed
+    assert not any(m.identifier.startswith("provider_a/") for m in models2.data)
+    assert await table2.has_model("provider_a/model_a1") is False
+
+    with pytest.raises(ModelNotFoundError):
+        await table2.get_model("provider_a/model_a1")
+
+    # Step 3: Restart server with provider_a re-enabled
+    table3 = ModelsRoutingTable({"provider_a": provider_a_impl}, cached_disk_dist_registry, {})
+    await table3.initialize()
+
+    models3 = await table3.list_models()
+    assert any(m.identifier == "provider_a/model_a1" for m in models3.data)
+    assert await table3.has_model("provider_a/model_a1") is True
+
+    await table1.shutdown()
+    await table2.shutdown()
+    await table3.shutdown()


### PR DESCRIPTION
### Summary
When OGX starts with a provider enabled and a persistent registry store active (such as PostgreSQL), auto-discovered models (`listed_from_provider`) are saved to the persistent `registry` namespace. On server restart with that provider disabled or unconfigured, stale models from the inactive provider remained visible in `/v1/models` because `refresh()` only iterated over active providers in `impls_by_provider_id`.

This PR updates `ModelsRoutingTable.refresh()` to add a write-time startup cleanup pass that prunes `listed_from_provider` entries for inactive or disabled providers, while leaving user-configured (`via_register_api`) entries intact.

### Key Changes
- Added a startup cleanup pass at the top of `ModelsRoutingTable.refresh()` to unregister `listed_from_provider` models whose `provider_id` is not present in `impls_by_provider_id`.
- Preserves `via_register_api` (user-configured) models across server restarts regardless of provider presence.
- Avoids fragile read-time filtering across lookup/list methods.
- Re-enabling a provider automatically re-discovers its models during the per-provider refresh loop.
- Added unit tests covering model persistence, startup pruning of disabled provider models, and re-discovery upon re-enabling.

Closes #5786 

### How to Test
1. **Start PostgreSQL database:**
   ```bash
   docker run -d --name postgres-local -p 5432:5432 -e POSTGRES_PASSWORD=mysecretpassword postgres:17-alpine
   ```

2. **Step 1: Start OGX with a provider enabled (e.g., OpenAI)**
   ```bash
   OPENAI_API_KEY="sk-dummy-key" \
   POSTGRES_USER=postgres POSTGRES_PASSWORD=mysecretpassword POSTGRES_DB=postgres \
   ogx run --insecure src/ogx/distributions/starter/run-with-postgres-store.yaml
   ```
   Query models:
   ```bash
   curl -s http://localhost:8321/v1/models | jq .
   ```
   *Expected:* Provider models (e.g., `openai/...`) are listed.

3. **Step 2: Stop OGX and restart with the provider disabled**
   Unset the API key / disable the provider while connecting to the same PostgreSQL store:
   ```bash
   OPENAI_API_KEY="" \
   POSTGRES_USER=postgres POSTGRES_PASSWORD=mysecretpassword POSTGRES_DB=postgres \
   ogx run --insecure src/ogx/distributions/starter/run-with-postgres-store.yaml
   ```
   Query models:
   ```bash
   curl -s http://localhost:8321/v1/models | jq .
   ```
   *Expected:* Stale provider-listed models from the disabled provider are pruned on startup and no longer returned in `/v1/models`.

4. **Step 3: Re-enable the provider**
   Restart OGX with `OPENAI_API_KEY="sk-dummy-key"` set again.
   *Expected:* Provider models are re-discovered and reappear in `/v1/models`.