### PR TITLE
feat: redact sensitive data from structured logs

### DIFF
--- a/src/ogx/core/routers/inference.py
+++ b/src/ogx/core/routers/inference.py
@@ -108,14 +108,6 @@ class InferenceRouter(Inference):
         metadata: dict[str, Any] | None = None,
         model_type: ModelType | None = None,
     ) -> None:
-        logger.debug(
-            "InferenceRouter.register_model",
-            model_id=model_id,
-            provider_model_id=provider_model_id,
-            provider_id=provider_id,
-            metadata=metadata,
-            model_type=model_type,
-        )
         request = RegisterModelRequest(
             model_id=model_id,
             provider_model_id=provider_model_id,
@@ -164,11 +156,6 @@ class InferenceRouter(Inference):
         # Perform RBAC check
         user = get_authenticated_user()
         if not is_action_allowed(self.routing_table.policy, "read", temp_model, user):
-            logger.debug(
-                "Access denied to model via fallback path for user",
-                model_id=model_id,
-                user=user.principal if user else "anonymous",
-            )
             raise ModelNotFoundError(model_id)
 
         return self.routing_table.impls_by_provider_id[provider_id], provider_resource_id
@@ -189,12 +176,6 @@ class InferenceRouter(Inference):
         self,
         params: Annotated[OpenAICompletionRequestWithExtraBody, Body(...)],
     ) -> OpenAICompletion | AsyncIterator[OpenAICompletion]:
-        logger.debug(
-            "InferenceRouter.openai_completion: model=, stream=, prompt",
-            model=params.model,
-            stream=params.stream,
-            prompt=params.prompt,
-        )
         request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
         inference_model_type_used_total.add(
@@ -230,12 +211,6 @@ class InferenceRouter(Inference):
         self,
         params: Annotated[OpenAIChatCompletionRequestWithExtraBody, Body(...)],
     ) -> OpenAIChatCompletion | AsyncIterator[OpenAIChatCompletionChunk]:
-        logger.debug(
-            "InferenceRouter.openai_chat_completion: model=, stream=, messages",
-            model=params.model,
-            stream=params.stream,
-            messages=params.messages,
-        )
         request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.llm)
         inference_model_type_used_total.add(
@@ -337,13 +312,6 @@ class InferenceRouter(Inference):
         self,
         params: Annotated[OpenAIEmbeddingsRequestWithExtraBody, Body(...)],
     ) -> OpenAIEmbeddingsResponse:
-        logger.debug(
-            "InferenceRouter.openai_embeddings: model=, input_type=, encoding_format=, dimensions",
-            model=params.model,
-            type_params_input=type(params.input),
-            encoding_format=params.encoding_format,
-            dimensions=params.dimensions,
-        )
         request_model_id = params.model
         provider, provider_resource_id = await self._get_model_provider(params.model, ModelType.embedding)
         inference_model_type_used_total.add(
@@ -617,6 +585,5 @@ class InferenceRouter(Inference):
                     model=fully_qualified_model_id,
                     object="chat.completion",
                 )
-                logger.debug("InferenceRouter.completion_response", final_response=final_response)
                 task = asyncio.create_task(self.store.store_chat_completion(final_response, messages))
                 task.add_done_callback(_log_background_task_error)

--- a/src/ogx/log.py
+++ b/src/ogx/log.py
@@ -19,6 +19,61 @@ from rich.logging import RichHandler
 # Default log level
 DEFAULT_LOG_LEVEL = logging.INFO
 
+# Keys whose values must be redacted from log output to prevent leaking
+# user input, model output, or model selection into logs.
+SENSITIVE_LOG_KEYS: frozenset[str] = frozenset(
+    [
+        "prompt",
+        "messages",
+        "message",
+        "input_messages",
+        "output_messages",
+        "content",
+        "text",
+        "tool_calls",
+        "tool_call",
+        "input_items",
+        "output_items",
+        "reasoning_content",
+        "final_response",
+        "final_chat_completion",
+        "response",
+        "body",
+        "exc",
+        # User choices / selections — model name reveals intent
+        "model",
+        "model_id",
+        "provider_model_id",
+        "provider_resource_id",
+        # Session identifiers tied to user context
+        "conversation",
+        "conversation_id",
+        "batch_id",
+        "request_id",
+        "completion_id",
+        "stream_id",
+        # User-supplied URLs or identifiers in provider data
+        "url",
+        # Tool/connector identifiers from user requests
+        "vector_store_id",
+        "file_id",
+        "tool_name",
+        "tool_call_id",
+    ]
+)
+
+
+def _redact_sensitive_keys(logger, method_name, event_dict):
+    """Remove sensitive key-value pairs from log events.
+
+    This runs as a structlog processor on every log call to prevent
+    user input, model output, and user choices from leaking into logs.
+    """
+    for key in SENSITIVE_LOG_KEYS:
+        if key in event_dict:
+            event_dict[key] = "<REDACTED>"
+    return event_dict
+
 
 class LoggingConfig(BaseModel):
     """Configuration model for category-based logging levels."""
@@ -276,6 +331,7 @@ def _configure_structlog(json_output: bool = False) -> None:
     # Shared processors applied to all structlog-originated log entries
     # before they are passed to the stdlib logging infrastructure.
     shared_processors: list[structlog.types.Processor] = [
+        _redact_sensitive_keys,
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,

--- a/src/ogx/log.py
+++ b/src/ogx/log.py
@@ -330,12 +330,17 @@ def _configure_structlog(json_output: bool = False) -> None:
 
     # Shared processors applied to all structlog-originated log entries
     # before they are passed to the stdlib logging infrastructure.
+    #
+    # Order matters: merge_contextvars and ExtraAdder inject additional
+    # data (context variables, stdlib extra=) into the event dict.
+    # _redact_sensitive_keys must run AFTER so that nothing sensitive
+    # injected by those steps escapes redaction.
     shared_processors: list[structlog.types.Processor] = [
-        _redact_sensitive_keys,
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.ExtraAdder(),
+        _redact_sensitive_keys,
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.UnicodeDecoder(),

--- a/src/ogx/log.py
+++ b/src/ogx/log.py
@@ -40,7 +40,6 @@ SENSITIVE_LOG_KEYS: frozenset[str] = frozenset(
         "response",
         "body",
         "exc",
-        "error",
         # User choices / selections — model name reveals intent
         "model",
         "model_id",

--- a/src/ogx/log.py
+++ b/src/ogx/log.py
@@ -40,6 +40,7 @@ SENSITIVE_LOG_KEYS: frozenset[str] = frozenset(
         "response",
         "body",
         "exc",
+        "error",
         # User choices / selections — model name reveals intent
         "model",
         "model_id",
@@ -54,6 +55,7 @@ SENSITIVE_LOG_KEYS: frozenset[str] = frozenset(
         "stream_id",
         # User-supplied URLs or identifiers in provider data
         "url",
+        "server_url",
         # Tool/connector identifiers from user requests
         "vector_store_id",
         "file_id",

--- a/src/ogx/providers/inline/responses/builtin/responses/streaming.py
+++ b/src/ogx/providers/inline/responses/builtin/responses/streaming.py
@@ -455,7 +455,6 @@ class StreamingResponseOrchestrator:
                 headers=self.moderation_headers,
             )
             if input_violation_message:
-                logger.debug("Input guardrail violation", input_violation_message=input_violation_message)
                 yield await self._create_refusal_response(input_violation_message)
                 return
 
@@ -598,7 +597,6 @@ class StreamingResponseOrchestrator:
                         for tool in self.ctx.chat_tools
                         if tool.get("function", {}).get("name") in allowed_tool_names
                     ]
-                logger.debug("calling openai_chat_completion with tools", effective_tools=effective_tools)
 
                 logprobs = (
                     True
@@ -887,8 +885,6 @@ class StreamingResponseOrchestrator:
                     reasoning_content=reasoning_content,
                 )
             next_turn_messages.append(message)
-            logger.debug("Choice message content", content=choice.message.content)
-            logger.debug("Choice message tool_calls", tool_calls=choice.message.tool_calls)
 
             if choice.message.tool_calls and self.ctx.response_tools:
                 executed_tool_calls: list = []
@@ -1385,7 +1381,6 @@ class StreamingResponseOrchestrator:
                     headers=self.moderation_headers,
                 )
                 if violation_message:
-                    logger.debug("Output guardrail violation", violation_message=violation_message)
                     pending_guardrail_events.clear()
                     yield await self._create_refusal_response(violation_message)
                     self.violation_detected = True
@@ -1404,7 +1399,6 @@ class StreamingResponseOrchestrator:
                 headers=self.moderation_headers,
             )
             if violation_message:
-                logger.debug("Output guardrail violation", violation_message=violation_message)
                 pending_guardrail_events.clear()
                 yield await self._create_refusal_response(violation_message)
                 self.violation_detected = True

--- a/tests/unit/core/test_log_redaction.py
+++ b/tests/unit/core/test_log_redaction.py
@@ -31,12 +31,14 @@ _SENSITIVE_TEST_KEYS = frozenset(
         # User input
         "prompt",
         "messages",
+        "message",
         "input_messages",
         "input_items",
         # Model output
         "content",
         "text",
         "final_response",
+        "final_chat_completion",
         "output_messages",
         "output_items",
         "reasoning_content",
@@ -44,6 +46,7 @@ _SENSITIVE_TEST_KEYS = frozenset(
         "model",
         "model_id",
         "provider_model_id",
+        "provider_resource_id",
         # Session identifiers
         "conversation",
         "conversation_id",
@@ -251,3 +254,29 @@ class TestSensitiveDataRedactedFromLogOutput:
             logger.handlers = old_handlers
             logger.level = old_level
             logger.propagate = True
+
+    def test_test_keys_match_production_keys(self):
+        """Both lists must be in sync.
+
+        If a key is added to SENSITIVE_LOG_KEYS in production, this test fails
+        until the corresponding entry is added to _SENSITIVE_TEST_KEYS.
+
+        If a key is removed from SENSITIVE_LOG_KEYS, the parametrized
+        test_sensitive_key_is_redacted for that key will fail because the
+        value appears in log output instead of '<REDACTED>'.
+        """
+        from ogx.log import SENSITIVE_LOG_KEYS
+
+        prod_only = SENSITIVE_LOG_KEYS - _SENSITIVE_TEST_KEYS
+        test_only = _SENSITIVE_TEST_KEYS - SENSITIVE_LOG_KEYS
+
+        if prod_only:
+            pytest.fail(
+                f"Production has {len(prod_only)} key(s) not in the test list: "
+                f"{sorted(prod_only)}. Add them to _SENSITIVE_TEST_KEYS."
+            )
+        if test_only:
+            pytest.fail(
+                f"Test list has {len(test_only)} key(s) not in production: "
+                f"{sorted(test_only)}. Remove them from _SENSITIVE_TEST_KEYS."
+            )

--- a/tests/unit/core/test_log_redaction.py
+++ b/tests/unit/core/test_log_redaction.py
@@ -1,0 +1,155 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""
+Regression test: verify that sensitive values are redacted from structured log
+output via the _redact_sensitive_keys structlog processor.
+
+The keys below are hardcoded — they are NOT derived from SENSITIVE_LOG_KEYS.
+If a developer removes a key from SENSITIVE_LOG_KEYS without updating the test,
+the test will fail and catch the omission.  Do NOT tie this list to the
+production constant.
+"""
+
+import logging  # allow-direct-logging
+
+import pytest
+
+from ogx.log import _reset_logging_state, get_logger
+
+# Keys that must always be redacted in log output.
+# Keep in sync with SENSITIVE_LOG_KEYS — adding/removing here requires
+# the same change in the production constant.
+_SENSITIVE_TEST_KEYS = frozenset(
+    [
+        # User input
+        "prompt",
+        "messages",
+        "input_messages",
+        "input_items",
+        # Model output
+        "content",
+        "text",
+        "final_response",
+        "output_messages",
+        "output_items",
+        "reasoning_content",
+        # Model IDs (user choices)
+        "model",
+        "model_id",
+        "provider_model_id",
+        # Session identifiers
+        "conversation",
+        "conversation_id",
+        "batch_id",
+        "request_id",
+        "completion_id",
+        "stream_id",
+        # Tool data
+        "tool_calls",
+        "tool_call",
+        "tool_name",
+        "tool_call_id",
+        # User data
+        "url",
+        "vector_store_id",
+        "file_id",
+        # Response / body
+        "response",
+        "body",
+        "exc",
+    ]
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_logging_state():
+    _reset_logging_state()
+    yield
+    _reset_logging_state()
+
+
+class TestSensitiveDataRedactedFromLogOutput:
+    """Verify that sensitive values are replaced with '<REDACTED>' in log output."""
+
+    @pytest.mark.parametrize("key", sorted(_SENSITIVE_TEST_KEYS))
+    def test_sensitive_key_is_redacted(self, key, caplog):
+        """Each hardcoded sensitive key must appear as '<REDACTED>' in log output."""
+        sensitive_value = f"sensitive_{key}"
+        with caplog.at_level(logging.DEBUG):
+            logger = get_logger("test.redaction", category="core")
+            logger.info("test message", **{key: sensitive_value})
+        output = caplog.text
+        assert sensitive_value not in output, (
+            f"Log output leaked the value '{sensitive_value}' for key '{key}'. "
+            f"This key must be redacted. Add '{key}' to SENSITIVE_LOG_KEYS "
+            f"if it is not already there."
+        )
+        # Log output is a dict repr: {'key': '<REDACTED>', ...}
+        assert f"'{key}': '<REDACTED>'" in output, (
+            f"Log output for key '{key}' does not show '<REDACTED>'. Check the _redact_sensitive_keys processor."
+        )
+
+    @pytest.mark.parametrize(
+        "level",
+        [
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+        ],
+    )
+    def test_sensitive_key_redacted_at_all_levels(self, level, caplog):
+        """Sensitive keys must be redacted regardless of log level."""
+        with caplog.at_level(logging.DEBUG):
+            logger = get_logger("test.redaction", category="core")
+            # Ensure the stdlib logger allows through the level we're testing
+            logger.setLevel(logging.DEBUG)
+            logger.log(level, "test message", model="should-be-redacted")
+        output = caplog.text
+        assert "should-be-redacted" not in output, (
+            f"Log output leaked the model name at level {logging.getLevelName(level)}."
+        )
+        assert "'model': '<REDACTED>'" in output
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            None,
+            {"nested": "dict"},
+            ["a", "list"],
+            42,
+        ],
+    )
+    def test_sensitive_key_redacted_for_all_value_types(self, value, caplog):
+        """Sensitive keys must be redacted regardless of value type."""
+        key = "prompt"
+        with caplog.at_level(logging.DEBUG):
+            logger = get_logger("test.redaction", category="core")
+            logger.info("test message", **{key: value})
+        output = caplog.text
+        if isinstance(value, str) and value:
+            assert value not in output
+        assert f"'{key}': '<REDACTED>'" in output
+
+    def test_non_sensitive_keys_are_preserved(self, caplog):
+        """Safe keys must appear with their original values."""
+        with caplog.at_level(logging.DEBUG):
+            logger = get_logger("test.redaction", category="core")
+            logger.info("test message", safe_key="keep_me", another_safe=42)
+        output = caplog.text
+        assert "'safe_key': 'keep_me'" in output
+        assert "'another_safe': 42" in output
+
+    def test_event_message_is_preserved(self, caplog):
+        """The event message string must never be redacted."""
+        with caplog.at_level(logging.DEBUG):
+            logger = get_logger("test.redaction", category="core")
+            logger.info("my event message", model="should-be-redacted")
+        output = caplog.text
+        assert "my event message" in output
+        assert "'model': '<REDACTED>'" in output

--- a/tests/unit/core/test_log_redaction.py
+++ b/tests/unit/core/test_log_redaction.py
@@ -58,12 +58,14 @@ _SENSITIVE_TEST_KEYS = frozenset(
         "tool_call_id",
         # User data
         "url",
+        "server_url",
         "vector_store_id",
         "file_id",
         # Response / body
         "response",
         "body",
         "exc",
+        "error",
     ]
 )
 

--- a/tests/unit/core/test_log_redaction.py
+++ b/tests/unit/core/test_log_redaction.py
@@ -65,7 +65,6 @@ _SENSITIVE_TEST_KEYS = frozenset(
         "response",
         "body",
         "exc",
-        "error",
     ]
 )
 

--- a/tests/unit/core/test_log_redaction.py
+++ b/tests/unit/core/test_log_redaction.py
@@ -14,11 +14,14 @@ the test will fail and catch the omission.  Do NOT tie this list to the
 production constant.
 """
 
+import io
 import logging  # allow-direct-logging
 
 import pytest
+import structlog.contextvars
+import structlog.stdlib
 
-from ogx.log import _reset_logging_state, get_logger
+from ogx.log import _configure_structlog, _reset_logging_state, get_logger
 
 # Keys that must always be redacted in log output.
 # Keep in sync with SENSITIVE_LOG_KEYS — adding/removing here requires
@@ -153,3 +156,97 @@ class TestSensitiveDataRedactedFromLogOutput:
         output = caplog.text
         assert "my event message" in output
         assert "'model': '<REDACTED>'" in output
+
+    def test_contextvars_sensitive_key_is_redacted(self, caplog):
+        """Sensitive values injected via structlog contextvars must be redacted.
+
+        Regression: merge_contextvars runs before _redact_sensitive_keys, so
+        context variables with sensitive keys cannot bypass redaction.
+        """
+        with caplog.at_level(logging.DEBUG):
+            structlog.contextvars.bind_contextvars(model="context-leak-test")
+            logger = get_logger("test.redaction", category="core")
+            logger.info("test contextvars")
+            output = caplog.text
+            structlog.contextvars.clear_contextvars()
+        assert "context-leak-test" not in output, (
+            "Sensitive value injected via merge_contextvars leaked. "
+            "_redact_sensitive_keys must run AFTER merge_contextvars."
+        )
+        assert "'model': '<REDACTED>'" in output
+
+    def test_contextvars_sensitive_data_redacted_end_to_end(self, caplog):
+        """End-to-end regression: sensitive data injected via merge_contextvars is redacted.
+
+        Binds a sensitive context variable, logs through the structlog BoundLogger,
+        and asserts the actual log output contains no leaked values.  Exercises
+        the processor chain from contextvar binding through final rendering.
+        """
+        with caplog.at_level(logging.DEBUG):
+            structlog.contextvars.bind_contextvars(model="contextvars-leak-test")
+            logger = get_logger("test.redaction.cvx", category="core")
+            logger.info("contextvars message", safe_key="keep_me")
+            output = caplog.text
+            structlog.contextvars.clear_contextvars()
+
+        assert "contextvars-leak-test" not in output, (
+            "Sensitive value injected via merge_contextvars leaked. "
+            "_redact_sensitive_keys must run AFTER merge_contextvars in the chain."
+        )
+        assert "'model': '<REDACTED>'" in output
+        assert "'safe_key': 'keep_me'" in output
+
+    def test_stdlib_extra_sensitive_data_redacted_end_to_end(self, monkeypatch):
+        """End-to-end regression: sensitive data injected via ExtraAdder is redacted.
+
+        Calls the stdlib logger directly with extra= kwargs, which triggers
+        ExtraAdder to copy those values into the event dict.  Uses a custom
+        handler with the ProcessorFormatter to capture the structlog-processed
+        output (caplog captures at the stdlib level, before the ProcessorFormatter
+        applies foreign_pre_chain).
+
+        Verifies that when ExtraAdder injects data into the event dict,
+        _redact_sensitive_keys (which runs after ExtraAdder in the chain)
+        catches those injected values.
+        """
+        _configure_structlog()
+        shared_processors = _configure_structlog._shared_processors  # type: ignore[attr-defined]
+
+        formatter = structlog.stdlib.ProcessorFormatter(
+            processors=[
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.processors.JSONRenderer(),
+            ],
+            foreign_pre_chain=shared_processors,
+        )
+
+        sink = io.StringIO()
+        handler = logging.StreamHandler(sink)
+        handler.setFormatter(formatter)
+        handler.setLevel(logging.DEBUG)
+
+        logger = logging.getLogger("test.redaction.extra")
+        old_handlers = logger.handlers[:]
+        old_level = logger.level
+        logger.handlers = [handler]
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+
+        try:
+            logger.info(
+                "extra= message",
+                extra=dict(vector_store_id="extra-leak-test", safe_key="keep_me"),
+            )
+            processed = sink.getvalue()
+
+            for leaked in ("extra-leak-test",):
+                assert leaked not in processed, (
+                    "Sensitive value injected via ExtraAdder leaked. "
+                    "_redact_sensitive_keys must run AFTER ExtraAdder in the chain."
+                )
+            assert '"vector_store_id": "<REDACTED>"' in processed
+            assert '"safe_key": "keep_me"' in processed
+        finally:
+            logger.handlers = old_handlers
+            logger.level = old_level
+            logger.propagate = True

--- a/tests/unit/providers/inference/test_remote_openai.py
+++ b/tests/unit/providers/inference/test_remote_openai.py
@@ -331,7 +331,7 @@ class TestOpenAIMaxOutputTokensWarning:
 
         assert result1 is None
         assert result2 is None
-        warning_count = sum(1 for r in caplog.records if "brand-new-model" in r.message)
+        warning_count = sum(1 for r in caplog.records if "Unknown max_output_tokens for model" in r.message)
         assert warning_count == 1
 
     def test_all_known_models_have_limits(self):


### PR DESCRIPTION
Add a structlog processor that redacts 32 sensitive key-value pairs from all log events before rendering, preventing user input, model output, and model selection from leaking into log files:

- User input: prompt, messages, input_messages, input_items
- Model output: content, text, final_response, response, output_messages, output_items, reasoning_content
- Tool data: tool_calls, tool_call, tool_name, tool_call_id
- Model IDs (user choices): model, model_id, provider_model_id, provider_resource_id
- Session identifiers: conversation, conversation_id, batch_id, request_id, completion_id, stream_id
- User data: url

Remove request-level debug logs from the inference path that logged full prompts, messages, responses, and model IDs directly. Init, shutdown, and state logging remain in place.

Add a hardcoded test list (_SENSITIVE_TEST_KEYS) independent of SENSITIVE_LOG_KEYS so that removing a key from production without updating the test will fail and alert the developer. Covers all four log levels (DEBUG/INFO/WARNING/ERROR) and multiple value types.

Fix test_sensitive_key_is_redacted to check the warning message text instead of the model name, since the model name is now redacted.

progress toward #5851 