### PR TITLE
refactor: Harden upstream_header provider with trusted-proxy verification

### DIFF
--- a/src/ogx/core/datatypes.py
+++ b/src/ogx/core/datatypes.py
@@ -408,28 +408,6 @@ class UpstreamHeaderAuthConfig(BaseModel):
             "Example: ['10.96.0.0/12', '10.244.0.0/16']"
         ),
     )
-    trusted_proxy_secret: SecretStr | None = Field(
-        default=None,
-        description=(
-            "Shared HMAC-SHA256 secret for proxy signature verification. "
-            "When set, the upstream proxy must sign identity headers and include "
-            "the signature in the trusted_proxy_signature_header. "
-            "Must be at least 32 characters."
-        ),
-    )
-    trusted_proxy_signature_header: str = Field(
-        default="x-ogx-proxy-signature",
-        description="HTTP header containing the HMAC-SHA256 signature from the upstream proxy.",
-    )
-
-    @field_validator("trusted_proxy_secret")
-    @classmethod
-    def validate_secret_length(cls, v: SecretStr | None) -> SecretStr | None:
-        if v is None:
-            return v
-        if len(v.get_secret_value()) < 32:
-            raise ValueError("trusted_proxy_secret must be at least 32 characters for HMAC-SHA256 security")
-        return v
 
     @field_validator("trusted_proxy_cidrs")
     @classmethod

--- a/src/ogx/core/datatypes.py
+++ b/src/ogx/core/datatypes.py
@@ -400,6 +400,52 @@ class UpstreamHeaderAuthConfig(BaseModel):
             "Example: {'X-MaaS-Group': 'teams', 'X-MaaS-Subscription': 'namespaces'}"
         ),
     )
+    trusted_proxy_cidrs: list[str] | None = Field(
+        default=None,
+        description=(
+            "CIDR allowlist for trusted proxy source IPs. "
+            "When set, requests from IPs outside these ranges are rejected with 403. "
+            "Example: ['10.96.0.0/12', '10.244.0.0/16']"
+        ),
+    )
+    trusted_proxy_secret: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Shared HMAC-SHA256 secret for proxy signature verification. "
+            "When set, the upstream proxy must sign identity headers and include "
+            "the signature in the trusted_proxy_signature_header. "
+            "Must be at least 32 characters."
+        ),
+    )
+    trusted_proxy_signature_header: str = Field(
+        default="x-ogx-proxy-signature",
+        description="HTTP header containing the HMAC-SHA256 signature from the upstream proxy.",
+    )
+
+    @field_validator("trusted_proxy_secret")
+    @classmethod
+    def validate_secret_length(cls, v: SecretStr | None) -> SecretStr | None:
+        if v is None:
+            return v
+        if len(v.get_secret_value()) < 32:
+            raise ValueError("trusted_proxy_secret must be at least 32 characters for HMAC-SHA256 security")
+        return v
+
+    @field_validator("trusted_proxy_cidrs")
+    @classmethod
+    def validate_cidrs(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return v
+        import ipaddress
+
+        if not v:
+            raise ValueError("trusted_proxy_cidrs must contain at least one entry when set")
+        for cidr in v:
+            try:
+                ipaddress.ip_network(cidr, strict=False)
+            except ValueError as e:
+                raise ValueError(f"Invalid CIDR notation '{cidr}': {e}") from e
+        return v
 
 
 AuthProviderConfig = Annotated[

--- a/src/ogx/core/server/auth.py
+++ b/src/ogx/core/server/auth.py
@@ -22,7 +22,12 @@ from ogx.core.server.routes import (
     find_matching_route,
 )
 from ogx.log import get_logger
-from ogx_api.common.errors import AuthServiceUnavailableError, OpenAIErrorResponse, TokenValidationError
+from ogx_api.common.errors import (
+    AuthServiceUnavailableError,
+    OpenAIErrorResponse,
+    TokenValidationError,
+    UntrustedProxyError,
+)
 
 logger = get_logger(name=__name__, category="core::auth")
 
@@ -152,6 +157,9 @@ class AuthenticationMiddleware:
             # Validate token and get access attributes
             try:
                 validation_result = await self.auth_provider.validate_token(token, scope)
+            except UntrustedProxyError as e:
+                logger.warning("Untrusted proxy rejected", error=str(e))
+                return await self._send_auth_error(send, str(e), status=403, is_websocket=is_websocket)
             except AuthServiceUnavailableError as e:
                 logger.warning("Authentication service unavailable", error=str(e))
                 return await self._send_auth_error(send, str(e), status=503, is_websocket=is_websocket)

--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -691,11 +691,13 @@ class UpstreamHeaderAuthProvider(AuthProvider):
         try:
             client_ip = ipaddress.ip_address(client_ip_str)
         except ValueError as err:
-            raise UntrustedProxyError(f"Request rejected: invalid client IP address '{client_ip_str}'") from err
+            logger.warning("Failed to parse client IP for proxy verification", client_ip=client_ip_str)
+            raise UntrustedProxyError("Request rejected: client IP is not in trusted proxy CIDR allowlist") from err
         for network in self._trusted_networks:
             if client_ip in network:
                 return
-        raise UntrustedProxyError(f"Request rejected: source IP {client_ip_str} is not in trusted proxy CIDR allowlist")
+        logger.warning("Client IP not in trusted proxy CIDR allowlist", client_ip=client_ip_str)
+        raise UntrustedProxyError("Request rejected: client IP is not in trusted proxy CIDR allowlist")
 
     async def validate_token(self, token: str, scope: Scope | None = None) -> User:
         if scope is None:

--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import hashlib
-import hmac as hmac_mod
 import ipaddress
 import json
 import re
@@ -670,8 +668,8 @@ class UpstreamHeaderAuthProvider(AuthProvider):
     authentication and injects user identity into request headers. This provider
     trusts the headers and performs no token validation or outbound calls.
 
-    When trusted_proxy_cidrs or trusted_proxy_secret is configured, requests are
-    verified against the allowlist or HMAC signature before identity headers are read.
+    When trusted_proxy_cidrs is configured, requests are verified against the
+    CIDR allowlist before identity headers are read.
     """
 
     def __init__(self, config: UpstreamHeaderAuthConfig) -> None:
@@ -679,28 +677,10 @@ class UpstreamHeaderAuthProvider(AuthProvider):
         self._trusted_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] | None = None
         if config.trusted_proxy_cidrs:
             self._trusted_networks = [ipaddress.ip_network(cidr, strict=False) for cidr in config.trusted_proxy_cidrs]
-        self._identity_header_names: list[str] | None = None
-        if config.trusted_proxy_secret:
-            names = [config.principal_header.lower()]
-            if config.tenant_header:
-                names.append(config.tenant_header.lower())
-            if config.attributes_header:
-                names.append(config.attributes_header.lower())
-            if config.attribute_headers:
-                for header_name in config.attribute_headers:
-                    names.append(header_name.lower())
-            names.sort()
-            self._identity_header_names = names
 
     @property
     def requires_http_bearer(self) -> bool:
         return False
-
-    def _verify_trusted_proxy(self, scope: Scope) -> None:
-        if self._trusted_networks is not None:
-            self._verify_proxy_cidr(scope)
-        if self.config.trusted_proxy_secret is not None:
-            self._verify_proxy_hmac(scope)
 
     def _verify_proxy_cidr(self, scope: Scope) -> None:
         assert self._trusted_networks is not None
@@ -717,35 +697,12 @@ class UpstreamHeaderAuthProvider(AuthProvider):
                 return
         raise UntrustedProxyError(f"Request rejected: source IP {client_ip_str} is not in trusted proxy CIDR allowlist")
 
-    def _verify_proxy_hmac(self, scope: Scope) -> None:
-        assert self.config.trusted_proxy_secret is not None
-        headers = dict(scope.get("headers", []))
-        sig_key = self.config.trusted_proxy_signature_header.lower().encode()
-        sig_value = headers.get(sig_key)
-        if not sig_value:
-            raise UntrustedProxyError(
-                f"Request rejected: missing proxy signature header {self.config.trusted_proxy_signature_header}"
-            )
-        canonical = self._build_canonical_signing_string(headers)
-        secret = self.config.trusted_proxy_secret.get_secret_value().encode("utf-8")
-        expected = hmac_mod.new(secret, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
-        if not hmac_mod.compare_digest(expected, sig_value.decode("utf-8", errors="replace")):
-            raise UntrustedProxyError("Request rejected: invalid proxy signature")
-
-    def _build_canonical_signing_string(self, headers: dict[bytes, bytes]) -> str:
-        assert self._identity_header_names is not None
-        parts = []
-        for name in self._identity_header_names:
-            value = headers.get(name.encode(), b"").decode("utf-8", errors="replace")
-            parts.append(f"{name}={value}")
-        return "\n".join(parts)
-
     async def validate_token(self, token: str, scope: Scope | None = None) -> User:
         if scope is None:
             raise ValueError("Missing required authentication header: " + self.config.principal_header)
 
-        if self._trusted_networks is not None or self.config.trusted_proxy_secret is not None:
-            self._verify_trusted_proxy(scope)
+        if self._trusted_networks is not None:
+            self._verify_proxy_cidr(scope)
 
         headers = dict(scope.get("headers", []))
 

--- a/src/ogx/core/server/auth_providers.py
+++ b/src/ogx/core/server/auth_providers.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import hashlib
+import hmac as hmac_mod
+import ipaddress
 import json
 import re
 import ssl
@@ -29,7 +32,7 @@ from ogx.core.datatypes import (
     _validate_tenant_id,
 )
 from ogx.log import get_logger
-from ogx_api import AuthServiceUnavailableError, TokenValidationError
+from ogx_api import AuthServiceUnavailableError, TokenValidationError, UntrustedProxyError
 
 logger = get_logger(name=__name__, category="core::auth")
 
@@ -666,18 +669,83 @@ class UpstreamHeaderAuthProvider(AuthProvider):
     Used when an upstream gateway (Authorino, Istio, or any reverse proxy) handles
     authentication and injects user identity into request headers. This provider
     trusts the headers and performs no token validation or outbound calls.
+
+    When trusted_proxy_cidrs or trusted_proxy_secret is configured, requests are
+    verified against the allowlist or HMAC signature before identity headers are read.
     """
 
     def __init__(self, config: UpstreamHeaderAuthConfig) -> None:
         self.config = config
+        self._trusted_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] | None = None
+        if config.trusted_proxy_cidrs:
+            self._trusted_networks = [ipaddress.ip_network(cidr, strict=False) for cidr in config.trusted_proxy_cidrs]
+        self._identity_header_names: list[str] | None = None
+        if config.trusted_proxy_secret:
+            names = [config.principal_header.lower()]
+            if config.tenant_header:
+                names.append(config.tenant_header.lower())
+            if config.attributes_header:
+                names.append(config.attributes_header.lower())
+            if config.attribute_headers:
+                for header_name in config.attribute_headers:
+                    names.append(header_name.lower())
+            names.sort()
+            self._identity_header_names = names
 
     @property
     def requires_http_bearer(self) -> bool:
         return False
 
+    def _verify_trusted_proxy(self, scope: Scope) -> None:
+        if self._trusted_networks is not None:
+            self._verify_proxy_cidr(scope)
+        if self.config.trusted_proxy_secret is not None:
+            self._verify_proxy_hmac(scope)
+
+    def _verify_proxy_cidr(self, scope: Scope) -> None:
+        assert self._trusted_networks is not None
+        client = scope.get("client")
+        if not client:
+            raise UntrustedProxyError("Request rejected: unable to determine client IP for proxy verification")
+        client_ip_str = client[0]
+        try:
+            client_ip = ipaddress.ip_address(client_ip_str)
+        except ValueError as err:
+            raise UntrustedProxyError(f"Request rejected: invalid client IP address '{client_ip_str}'") from err
+        for network in self._trusted_networks:
+            if client_ip in network:
+                return
+        raise UntrustedProxyError(f"Request rejected: source IP {client_ip_str} is not in trusted proxy CIDR allowlist")
+
+    def _verify_proxy_hmac(self, scope: Scope) -> None:
+        assert self.config.trusted_proxy_secret is not None
+        headers = dict(scope.get("headers", []))
+        sig_key = self.config.trusted_proxy_signature_header.lower().encode()
+        sig_value = headers.get(sig_key)
+        if not sig_value:
+            raise UntrustedProxyError(
+                f"Request rejected: missing proxy signature header {self.config.trusted_proxy_signature_header}"
+            )
+        canonical = self._build_canonical_signing_string(headers)
+        secret = self.config.trusted_proxy_secret.get_secret_value().encode("utf-8")
+        expected = hmac_mod.new(secret, canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+        if not hmac_mod.compare_digest(expected, sig_value.decode("utf-8", errors="replace")):
+            raise UntrustedProxyError("Request rejected: invalid proxy signature")
+
+    def _build_canonical_signing_string(self, headers: dict[bytes, bytes]) -> str:
+        assert self._identity_header_names is not None
+        parts = []
+        for name in self._identity_header_names:
+            value = headers.get(name.encode(), b"").decode("utf-8", errors="replace")
+            parts.append(f"{name}={value}")
+        return "\n".join(parts)
+
     async def validate_token(self, token: str, scope: Scope | None = None) -> User:
         if scope is None:
             raise ValueError("Missing required authentication header: " + self.config.principal_header)
+
+        if self._trusted_networks is not None or self.config.trusted_proxy_secret is not None:
+            self._verify_trusted_proxy(scope)
 
         headers = dict(scope.get("headers", []))
 

--- a/src/ogx_api/__init__.py
+++ b/src/ogx_api/__init__.py
@@ -109,6 +109,7 @@ from .common.errors import (
     TokenValidationError,
     ToolGroupNotFoundError,
     UnsupportedModelError,
+    UntrustedProxyError,
     VectorStoreNotFoundError,
 )
 from .common.job_types import Job, JobStatus
@@ -1019,6 +1020,7 @@ __all__ = [
     "TopKSamplingStrategy",
     "TopPSamplingStrategy",
     "UnsupportedModelError",
+    "UntrustedProxyError",
     "UploadFileRequest",
     "URL",
     "_URLOrData",

--- a/src/ogx_api/common/errors.py
+++ b/src/ogx_api/common/errors.py
@@ -265,6 +265,15 @@ class AuthServiceUnavailableError(OGXError):
         super().__init__(message)
 
 
+class UntrustedProxyError(OGXError):
+    """raised when a request fails trusted-proxy verification (CIDR or HMAC)"""
+
+    status_code: httpx.codes = httpx.codes.FORBIDDEN
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
 class InvalidParameterError(ValueError, OGXError):
     """Raised when a request parameter violates validation constraints.
 

--- a/src/ogx_api/common/errors.py
+++ b/src/ogx_api/common/errors.py
@@ -266,7 +266,7 @@ class AuthServiceUnavailableError(OGXError):
 
 
 class UntrustedProxyError(OGXError):
-    """raised when a request fails trusted-proxy verification (CIDR or HMAC)"""
+    """raised when a request fails trusted-proxy verification (CIDR allowlist)"""
 
     status_code: httpx.codes = httpx.codes.FORBIDDEN
 

--- a/tests/unit/server/test_auth_upstream_header.py
+++ b/tests/unit/server/test_auth_upstream_header.py
@@ -512,7 +512,7 @@ async def test_cidr_rejects_non_matching_ip():
         "client": ("192.168.1.1", 54321),
         "headers": [(b"x-user-id", b"alice")],
     }
-    with pytest.raises(UntrustedProxyError, match="not in trusted proxy CIDR allowlist"):
+    with pytest.raises(UntrustedProxyError, match="client IP is not in trusted proxy CIDR allowlist"):
         await provider.validate_token("", scope)
 
 

--- a/tests/unit/server/test_auth_upstream_header.py
+++ b/tests/unit/server/test_auth_upstream_header.py
@@ -4,15 +4,13 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
-import hashlib
-import hmac as hmac_mod
 import json
 import logging  # allow-direct-logging
 
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
-from pydantic import SecretStr, ValidationError
+from pydantic import ValidationError
 
 from ogx.core.datatypes import (
     AuthenticationConfig,
@@ -485,24 +483,6 @@ def test_empty_cidr_list_rejects():
         )
 
 
-def test_short_secret_rejects():
-    """Test that a secret shorter than 32 characters raises ValidationError."""
-    with pytest.raises(ValidationError, match="at least 32 characters"):
-        UpstreamHeaderAuthConfig(
-            principal_header="x-user-id",
-            trusted_proxy_secret=SecretStr("too-short"),
-        )
-
-
-def test_valid_length_secret_accepted():
-    """Test that a secret of exactly 32 characters is accepted."""
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_secret=SecretStr("a" * 32),
-    )
-    assert config.trusted_proxy_secret is not None
-
-
 # Trusted proxy verification — CIDR unit tests
 
 
@@ -580,160 +560,6 @@ async def test_cidr_ipv6_support():
     assert user.principal == "alice"
 
 
-# Trusted proxy verification — HMAC unit tests
-
-
-def _compute_hmac(secret: str, headers: dict[str, str], identity_header_names: list[str]) -> str:
-    """Helper to compute HMAC signature for tests."""
-    sorted_names = sorted(identity_header_names)
-    parts = [f"{name}={headers.get(name, '')}" for name in sorted_names]
-    canonical = "\n".join(parts)
-    return hmac_mod.new(secret.encode(), canonical.encode(), hashlib.sha256).hexdigest()
-
-
-async def test_hmac_valid_signature_passes():
-    """Test that a valid HMAC signature passes through."""
-    secret = "test-shared-secret-that-is-32-ch"
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_secret=SecretStr(secret),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
-    scope = {
-        "headers": [
-            (b"x-user-id", b"alice"),
-            (b"x-ogx-proxy-signature", sig.encode()),
-        ],
-    }
-    user = await provider.validate_token("", scope)
-    assert user.principal == "alice"
-
-
-async def test_hmac_invalid_signature_rejects():
-    """Test that an invalid HMAC signature is rejected."""
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    scope = {
-        "headers": [
-            (b"x-user-id", b"alice"),
-            (b"x-ogx-proxy-signature", b"0000000000000000000000000000000000000000000000000000000000000000"),
-        ],
-    }
-    with pytest.raises(UntrustedProxyError, match="invalid proxy signature"):
-        await provider.validate_token("", scope)
-
-
-async def test_hmac_missing_signature_header_rejects():
-    """Test that a missing signature header is rejected."""
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    scope = {
-        "headers": [(b"x-user-id", b"alice")],
-    }
-    with pytest.raises(UntrustedProxyError, match="missing proxy signature header"):
-        await provider.validate_token("", scope)
-
-
-async def test_hmac_tampered_identity_header_rejects():
-    """Test that changing identity headers after signing invalidates the HMAC."""
-    secret = "test-shared-secret-that-is-32-ch"
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_secret=SecretStr(secret),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
-    scope = {
-        "headers": [
-            (b"x-user-id", b"mallory"),
-            (b"x-ogx-proxy-signature", sig.encode()),
-        ],
-    }
-    with pytest.raises(UntrustedProxyError, match="invalid proxy signature"):
-        await provider.validate_token("", scope)
-
-
-async def test_hmac_with_all_identity_headers():
-    """Test HMAC covers principal, tenant, and attributes headers."""
-    secret = "test-shared-secret-that-is-32-ch"
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        tenant_header="x-tenant-id",
-        attributes_header="x-auth-attributes",
-        trusted_proxy_secret=SecretStr(secret),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    attrs = json.dumps({"roles": ["admin"]})
-    header_values = {
-        "x-auth-attributes": attrs,
-        "x-tenant-id": "acme",
-        "x-user-id": "alice",
-    }
-    sig = _compute_hmac(secret, header_values, ["x-user-id", "x-tenant-id", "x-auth-attributes"])
-    scope = {
-        "headers": [
-            (b"x-user-id", b"alice"),
-            (b"x-tenant-id", b"acme"),
-            (b"x-auth-attributes", attrs.encode()),
-            (b"x-ogx-proxy-signature", sig.encode()),
-        ],
-    }
-    user = await provider.validate_token("", scope)
-    assert user.principal == "alice"
-    assert user.tenant_id == "acme"
-    assert user.attributes == {"roles": ["admin"]}
-
-
-# Trusted proxy verification — combined CIDR + HMAC
-
-
-async def test_both_cidr_and_hmac_pass():
-    """Test that both CIDR and HMAC must pass when both are configured."""
-    secret = "test-shared-secret-that-is-32-ch"
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_cidrs=["10.0.0.0/8"],
-        trusted_proxy_secret=SecretStr(secret),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
-    scope = {
-        "client": ("10.0.0.1", 54321),
-        "headers": [
-            (b"x-user-id", b"alice"),
-            (b"x-ogx-proxy-signature", sig.encode()),
-        ],
-    }
-    user = await provider.validate_token("", scope)
-    assert user.principal == "alice"
-
-
-async def test_cidr_passes_hmac_fails():
-    """Test that CIDR passing but HMAC failing still rejects."""
-    config = UpstreamHeaderAuthConfig(
-        principal_header="x-user-id",
-        trusted_proxy_cidrs=["10.0.0.0/8"],
-        trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
-    )
-    provider = UpstreamHeaderAuthProvider(config)
-    scope = {
-        "client": ("10.0.0.1", 54321),
-        "headers": [
-            (b"x-user-id", b"alice"),
-            (b"x-ogx-proxy-signature", b"bad-signature"),
-        ],
-    }
-    with pytest.raises(UntrustedProxyError, match="invalid proxy signature"):
-        await provider.validate_token("", scope)
-
-
 # Trusted proxy verification — backwards compatibility
 
 
@@ -753,14 +579,14 @@ async def test_no_proxy_verification_configured_passes():
 # Trusted proxy verification — middleware integration tests
 
 
-def test_middleware_hmac_rejection_returns_403(suppress_auth_errors):
-    """Test that HMAC rejection returns HTTP 403 through the middleware."""
+def test_middleware_cidr_rejection_returns_403(suppress_auth_errors):
+    """Test that CIDR rejection returns HTTP 403 through the middleware."""
     app = FastAPI()
     auth_config = AuthenticationConfig(
         provider_config=UpstreamHeaderAuthConfig(
             type=AuthProviderType.UPSTREAM_HEADER,
             principal_header="x-user-id",
-            trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
+            trusted_proxy_cidrs=["10.0.0.0/8"],
         ),
         access_policy=[],
     )
@@ -773,40 +599,6 @@ def test_middleware_hmac_rejection_returns_403(suppress_auth_errors):
     client = TestClient(app)
     response = client.get(
         "/test",
-        headers={
-            "x-user-id": "alice",
-            "x-ogx-proxy-signature": "bad-signature",
-        },
+        headers={"x-user-id": "alice"},
     )
     assert response.status_code == 403
-    assert "invalid proxy signature" in response.json()["error"]["message"]
-
-
-def test_middleware_hmac_valid_returns_200():
-    """Test that valid HMAC passes through the middleware and returns 200."""
-    secret = "test-shared-secret-that-is-32-ch"
-    app = FastAPI()
-    auth_config = AuthenticationConfig(
-        provider_config=UpstreamHeaderAuthConfig(
-            type=AuthProviderType.UPSTREAM_HEADER,
-            principal_header="x-user-id",
-            trusted_proxy_secret=SecretStr(secret),
-        ),
-        access_policy=[],
-    )
-    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config)
-
-    @app.get("/test")
-    def test_endpoint():
-        return {"message": "ok"}
-
-    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
-    client = TestClient(app)
-    response = client.get(
-        "/test",
-        headers={
-            "x-user-id": "alice",
-            "x-ogx-proxy-signature": sig,
-        },
-    )
-    assert response.status_code == 200

--- a/tests/unit/server/test_auth_upstream_header.py
+++ b/tests/unit/server/test_auth_upstream_header.py
@@ -4,12 +4,15 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import hashlib
+import hmac as hmac_mod
 import json
 import logging  # allow-direct-logging
 
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
+from pydantic import SecretStr, ValidationError
 
 from ogx.core.datatypes import (
     AuthenticationConfig,
@@ -18,6 +21,7 @@ from ogx.core.datatypes import (
 )
 from ogx.core.server.auth import AuthenticationMiddleware
 from ogx.core.server.auth_providers import UpstreamHeaderAuthProvider
+from ogx_api.common.errors import UntrustedProxyError
 
 
 @pytest.fixture
@@ -446,6 +450,363 @@ def test_attribute_headers_middleware_integration(upstream_header_app):
             "x-auth-user-id": "alice",
             "x-maas-group": '["team-a"]',
             "x-maas-subscription": "premium",
+        },
+    )
+    assert response.status_code == 200
+
+
+# Trusted proxy verification — config validation
+
+
+def test_valid_cidr_config():
+    """Test that valid CIDR list is accepted."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8", "172.16.0.0/12", "::1/128"],
+    )
+    assert config.trusted_proxy_cidrs == ["10.0.0.0/8", "172.16.0.0/12", "::1/128"]
+
+
+def test_invalid_cidr_config_rejects():
+    """Test that invalid CIDR notation raises ValidationError."""
+    with pytest.raises(ValidationError, match="Invalid CIDR notation"):
+        UpstreamHeaderAuthConfig(
+            principal_header="x-user-id",
+            trusted_proxy_cidrs=["not-a-cidr"],
+        )
+
+
+def test_empty_cidr_list_rejects():
+    """Test that empty CIDR list raises ValidationError."""
+    with pytest.raises(ValidationError, match="must contain at least one entry"):
+        UpstreamHeaderAuthConfig(
+            principal_header="x-user-id",
+            trusted_proxy_cidrs=[],
+        )
+
+
+def test_short_secret_rejects():
+    """Test that a secret shorter than 32 characters raises ValidationError."""
+    with pytest.raises(ValidationError, match="at least 32 characters"):
+        UpstreamHeaderAuthConfig(
+            principal_header="x-user-id",
+            trusted_proxy_secret=SecretStr("too-short"),
+        )
+
+
+def test_valid_length_secret_accepted():
+    """Test that a secret of exactly 32 characters is accepted."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_secret=SecretStr("a" * 32),
+    )
+    assert config.trusted_proxy_secret is not None
+
+
+# Trusted proxy verification — CIDR unit tests
+
+
+async def test_cidr_allows_matching_ip():
+    """Test that a request from a trusted IP passes through."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8"],
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "client": ("10.0.0.1", 54321),
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+
+
+async def test_cidr_rejects_non_matching_ip():
+    """Test that a request from an untrusted IP is rejected."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8"],
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "client": ("192.168.1.1", 54321),
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    with pytest.raises(UntrustedProxyError, match="not in trusted proxy CIDR allowlist"):
+        await provider.validate_token("", scope)
+
+
+async def test_cidr_rejects_missing_client():
+    """Test that missing scope['client'] is rejected."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8"],
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    with pytest.raises(UntrustedProxyError, match="unable to determine client IP"):
+        await provider.validate_token("", scope)
+
+
+async def test_cidr_allows_multiple_cidrs():
+    """Test that matching any CIDR in the list passes."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8", "172.16.0.0/12"],
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "client": ("172.16.5.10", 54321),
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+
+
+async def test_cidr_ipv6_support():
+    """Test that IPv6 addresses are supported."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["fd00::/8"],
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "client": ("fd00::1", 54321),
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+
+
+# Trusted proxy verification — HMAC unit tests
+
+
+def _compute_hmac(secret: str, headers: dict[str, str], identity_header_names: list[str]) -> str:
+    """Helper to compute HMAC signature for tests."""
+    sorted_names = sorted(identity_header_names)
+    parts = [f"{name}={headers.get(name, '')}" for name in sorted_names]
+    canonical = "\n".join(parts)
+    return hmac_mod.new(secret.encode(), canonical.encode(), hashlib.sha256).hexdigest()
+
+
+async def test_hmac_valid_signature_passes():
+    """Test that a valid HMAC signature passes through."""
+    secret = "test-shared-secret-that-is-32-ch"
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_secret=SecretStr(secret),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
+    scope = {
+        "headers": [
+            (b"x-user-id", b"alice"),
+            (b"x-ogx-proxy-signature", sig.encode()),
+        ],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+
+
+async def test_hmac_invalid_signature_rejects():
+    """Test that an invalid HMAC signature is rejected."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "headers": [
+            (b"x-user-id", b"alice"),
+            (b"x-ogx-proxy-signature", b"0000000000000000000000000000000000000000000000000000000000000000"),
+        ],
+    }
+    with pytest.raises(UntrustedProxyError, match="invalid proxy signature"):
+        await provider.validate_token("", scope)
+
+
+async def test_hmac_missing_signature_header_rejects():
+    """Test that a missing signature header is rejected."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    with pytest.raises(UntrustedProxyError, match="missing proxy signature header"):
+        await provider.validate_token("", scope)
+
+
+async def test_hmac_tampered_identity_header_rejects():
+    """Test that changing identity headers after signing invalidates the HMAC."""
+    secret = "test-shared-secret-that-is-32-ch"
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_secret=SecretStr(secret),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
+    scope = {
+        "headers": [
+            (b"x-user-id", b"mallory"),
+            (b"x-ogx-proxy-signature", sig.encode()),
+        ],
+    }
+    with pytest.raises(UntrustedProxyError, match="invalid proxy signature"):
+        await provider.validate_token("", scope)
+
+
+async def test_hmac_with_all_identity_headers():
+    """Test HMAC covers principal, tenant, and attributes headers."""
+    secret = "test-shared-secret-that-is-32-ch"
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        tenant_header="x-tenant-id",
+        attributes_header="x-auth-attributes",
+        trusted_proxy_secret=SecretStr(secret),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    attrs = json.dumps({"roles": ["admin"]})
+    header_values = {
+        "x-auth-attributes": attrs,
+        "x-tenant-id": "acme",
+        "x-user-id": "alice",
+    }
+    sig = _compute_hmac(secret, header_values, ["x-user-id", "x-tenant-id", "x-auth-attributes"])
+    scope = {
+        "headers": [
+            (b"x-user-id", b"alice"),
+            (b"x-tenant-id", b"acme"),
+            (b"x-auth-attributes", attrs.encode()),
+            (b"x-ogx-proxy-signature", sig.encode()),
+        ],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+    assert user.tenant_id == "acme"
+    assert user.attributes == {"roles": ["admin"]}
+
+
+# Trusted proxy verification — combined CIDR + HMAC
+
+
+async def test_both_cidr_and_hmac_pass():
+    """Test that both CIDR and HMAC must pass when both are configured."""
+    secret = "test-shared-secret-that-is-32-ch"
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8"],
+        trusted_proxy_secret=SecretStr(secret),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
+    scope = {
+        "client": ("10.0.0.1", 54321),
+        "headers": [
+            (b"x-user-id", b"alice"),
+            (b"x-ogx-proxy-signature", sig.encode()),
+        ],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+
+
+async def test_cidr_passes_hmac_fails():
+    """Test that CIDR passing but HMAC failing still rejects."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+        trusted_proxy_cidrs=["10.0.0.0/8"],
+        trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "client": ("10.0.0.1", 54321),
+        "headers": [
+            (b"x-user-id", b"alice"),
+            (b"x-ogx-proxy-signature", b"bad-signature"),
+        ],
+    }
+    with pytest.raises(UntrustedProxyError, match="invalid proxy signature"):
+        await provider.validate_token("", scope)
+
+
+# Trusted proxy verification — backwards compatibility
+
+
+async def test_no_proxy_verification_configured_passes():
+    """Test that existing behavior is unchanged when no proxy fields are set."""
+    config = UpstreamHeaderAuthConfig(
+        principal_header="x-user-id",
+    )
+    provider = UpstreamHeaderAuthProvider(config)
+    scope = {
+        "headers": [(b"x-user-id", b"alice")],
+    }
+    user = await provider.validate_token("", scope)
+    assert user.principal == "alice"
+
+
+# Trusted proxy verification — middleware integration tests
+
+
+def test_middleware_hmac_rejection_returns_403(suppress_auth_errors):
+    """Test that HMAC rejection returns HTTP 403 through the middleware."""
+    app = FastAPI()
+    auth_config = AuthenticationConfig(
+        provider_config=UpstreamHeaderAuthConfig(
+            type=AuthProviderType.UPSTREAM_HEADER,
+            principal_header="x-user-id",
+            trusted_proxy_secret=SecretStr("test-shared-secret-that-is-32-ch"),
+        ),
+        access_policy=[],
+    )
+    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config)
+
+    @app.get("/test")
+    def test_endpoint():
+        return {"message": "ok"}
+
+    client = TestClient(app)
+    response = client.get(
+        "/test",
+        headers={
+            "x-user-id": "alice",
+            "x-ogx-proxy-signature": "bad-signature",
+        },
+    )
+    assert response.status_code == 403
+    assert "invalid proxy signature" in response.json()["error"]["message"]
+
+
+def test_middleware_hmac_valid_returns_200():
+    """Test that valid HMAC passes through the middleware and returns 200."""
+    secret = "test-shared-secret-that-is-32-ch"
+    app = FastAPI()
+    auth_config = AuthenticationConfig(
+        provider_config=UpstreamHeaderAuthConfig(
+            type=AuthProviderType.UPSTREAM_HEADER,
+            principal_header="x-user-id",
+            trusted_proxy_secret=SecretStr(secret),
+        ),
+        access_policy=[],
+    )
+    app.add_middleware(AuthenticationMiddleware, auth_config=auth_config)
+
+    @app.get("/test")
+    def test_endpoint():
+        return {"message": "ok"}
+
+    sig = _compute_hmac(secret, {"x-user-id": "alice"}, ["x-user-id"])
+    client = TestClient(app)
+    response = client.get(
+        "/test",
+        headers={
+            "x-user-id": "alice",
+            "x-ogx-proxy-signature": sig,
         },
     )
     assert response.status_code == 200


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Adds defense-in-depth to OGX's `UpstreamHeaderAuthProvider` so that identity headers are only trusted when the request comes from a verified upstream proxy (intended to help support multi-tenancy with Praxis), and preventing header spoofing if a `NetworkPolicy` is misconfigured.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes `RHAIENG-6643`

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
OpenShift integration testing:
- Deployed OGX with the operator on an OpenShift 4.22 dev cluster (UBI 9 / OLM)
- CIDR mode: verified port-forwarded requests (source IP 127.0.0.1) rejected with `403` when not in allowlist; health endpoint unaffected
- HMAC mode verified:
  - missing signature = 403,
  - bad signature = 403,
  - valid signature = 200,
  - tampered identity header = 403
  - health endpoint unaffected
- Combined mode: verified both checks enforced independently
- Backwards compatibility: confirmed no behavior change when neither trusted_proxy_cidrs nor trusted_proxy_secret is configured

<details>
<summary>Test script for reference</summary>

Script:

```bash
#!/bin/bash
# Test script for trusted-proxy verification on OpenShift
# Usage:
#   Test CIDR:  ./test-trusted-proxy.sh cidr
#   Test HMAC:  ./test-trusted-proxy.sh hmac
#   Test both:  ./test-trusted-proxy.sh both

set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
SVC_NAME="ogxserver-with-userconfig"
SVC_RESOURCE_NAME="ogxserver-with-userconfig-service"
SVC_PORT=8321
LOCAL_PORT=8321
SECRET="spike-test-secret-do-not-use-in-prod"
PF_PID=""

cleanup() {
    if [ -n "$PF_PID" ] && kill -0 "$PF_PID" 2>/dev/null; then
        kill "$PF_PID" 2>/dev/null
        wait "$PF_PID" 2>/dev/null || true
    fi
    rm -f /tmp/proxy-test-response.json
}
trap cleanup EXIT

start_port_forward() {
    # Kill any existing port-forward
    if [ -n "$PF_PID" ] && kill -0 "$PF_PID" 2>/dev/null; then
        kill "$PF_PID" 2>/dev/null
        wait "$PF_PID" 2>/dev/null || true
    fi

    oc port-forward "svc/${SVC_RESOURCE_NAME}" "${LOCAL_PORT}:${SVC_PORT}" &>/dev/null &
    PF_PID=$!

    # Wait until port-forward is ready by polling the public /v1/health endpoint
    echo "   Waiting for port-forward..."
    local retries=0
    while [ $retries -lt 30 ]; do
        if curl -sf -o /dev/null "http://localhost:${LOCAL_PORT}/v1/health" 2>/dev/null; then
            echo "   Port-forward ready."
            return 0
        fi
        sleep 1
        retries=$((retries + 1))
    done
    echo "   ERROR: Port-forward did not become ready after 30 seconds"
    return 1
}

do_curl() {
    # Run curl, capture HTTP code to a separate file to avoid output corruption
    local code_file
    code_file=$(mktemp)
    curl -s -o /tmp/proxy-test-response.json -w '%{http_code}' "$@" > "$code_file" 2>/dev/null || true
    cat "$code_file"
    rm -f "$code_file"
}

compute_hmac() {
    # Canonical signing string: sorted header-name=value joined by newlines
    local user_id="$1"
    shift
    # Remaining args are additional "header=value" pairs
    local -a parts=()
    parts+=("x-user-id=${user_id}")
    for arg in "$@"; do
        parts+=("$arg")
    done
    # Sort
    IFS=$'\n' sorted=($(sort <<<"${parts[*]}")); unset IFS
    local canonical
    canonical=$(printf "%s" "${sorted[0]}")
    for ((i=1; i<${#sorted[@]}; i++)); do
        canonical=$(printf "%s\n%s" "$canonical" "${sorted[$i]}")
    done
    printf '%s' "$canonical" | openssl dgst -sha256 -hmac "$SECRET" -hex 2>/dev/null | awk '{print $NF}'
}

apply_and_wait() {
    local config_file="$1"
    echo "   Applying config..."
    oc apply -f "${config_file}"
    echo "   Waiting for rollout..."
    oc rollout status "deployment/${SVC_NAME}" --timeout=120s 2>/dev/null || true
    # Wait for terminating pods to fully stop so port-forward doesn't latch onto a dying pod
    echo "   Waiting for old pods to terminate..."
    local retries=0
    while [ $retries -lt 30 ]; do
        local terminating
        terminating=$(oc get pods -l "app.kubernetes.io/instance=${SVC_NAME}" --field-selector=status.phase!=Running -o name 2>/dev/null | wc -l)
        if [ "$terminating" -eq 0 ]; then
            break
        fi
        sleep 2
        retries=$((retries + 1))
    done
    sleep 3
}

check_result() {
    local test_name="$1"
    local expected="$2"
    local actual="$3"

    if [ "$actual" = "$expected" ]; then
        echo "   PASS: ${test_name} (HTTP ${actual})"
    else
        echo "   FAIL: ${test_name} — expected HTTP ${expected}, got ${actual}"
        if [ -f /tmp/proxy-test-response.json ]; then
            echo "   Response body:"
            python3 -m json.tool /tmp/proxy-test-response.json 2>/dev/null | sed 's/^/   /' || cat /tmp/proxy-test-response.json | sed 's/^/   /'
        fi
    fi
    echo ""
}

test_cidr() {
    echo "=== CIDR Trusted Proxy Test ==="
    echo ""

    apply_and_wait "${SCRIPT_DIR}/test-trusted-proxy-cidr.yaml"

    # Test from outside the cluster via port-forward
    # Port-forward traffic arrives at the container as 127.0.0.1, which is NOT
    # in 10.128.0.0/14, so this should be rejected.
    echo "1. From outside cluster (port-forward, source IP = 127.0.0.1) — expect 403"
    start_port_forward
    HTTP_CODE=$(do_curl -H "x-user-id: alice" "http://localhost:${LOCAL_PORT}/v1/models")
    check_result "External request rejected by CIDR" "403" "$HTTP_CODE"

    # Verify that the public /v1/health endpoint still works (bypasses auth)
    echo "2. Health endpoint (public, bypasses auth) — expect 200"
    HTTP_CODE=$(do_curl "http://localhost:${LOCAL_PORT}/v1/health")
    check_result "Health endpoint accessible" "200" "$HTTP_CODE"
}

test_hmac() {
    echo "=== HMAC Trusted Proxy Test ==="
    echo ""

    apply_and_wait "${SCRIPT_DIR}/test-trusted-proxy-hmac.yaml"
    start_port_forward

    # Test 1: No signature header — should get 403
    echo "1. Without signature — expect 403"
    HTTP_CODE=$(do_curl -H "x-user-id: alice" "http://localhost:${LOCAL_PORT}/v1/models")
    check_result "Missing signature rejected" "403" "$HTTP_CODE"

    # Test 2: Bad signature — should get 403
    echo "2. With bad signature — expect 403"
    HTTP_CODE=$(do_curl \
        -H "x-user-id: alice" \
        -H "x-ogx-proxy-signature: deadbeef" \
        "http://localhost:${LOCAL_PORT}/v1/models")
    check_result "Bad signature rejected" "403" "$HTTP_CODE"

    # Test 3: Valid signature — should get 200
    # The server signs ALL configured identity headers (principal, tenant, attributes),
    # even when absent from the request (they default to empty string).
    echo "3. With valid signature — expect 200"
    SIG=$(compute_hmac "alice" "x-tenant-id=" "x-auth-attributes=")
    HTTP_CODE=$(do_curl \
        -H "x-user-id: alice" \
        -H "x-ogx-proxy-signature: ${SIG}" \
        "http://localhost:${LOCAL_PORT}/v1/models")
    check_result "Valid signature accepted" "200" "$HTTP_CODE"

    # Test 4: Valid signature for alice, but header says mallory — should get 403
    echo "4. Tampered identity (sig for alice, header says mallory) — expect 403"
    SIG=$(compute_hmac "alice" "x-tenant-id=" "x-auth-attributes=")
    HTTP_CODE=$(do_curl \
        -H "x-user-id: mallory" \
        -H "x-ogx-proxy-signature: ${SIG}" \
        "http://localhost:${LOCAL_PORT}/v1/models")
    check_result "Tampered identity rejected" "403" "$HTTP_CODE"

    # Test 5: Health endpoint still works without any signature
    echo "5. Health endpoint (public, bypasses auth) — expect 200"
    HTTP_CODE=$(do_curl "http://localhost:${LOCAL_PORT}/v1/health")
    check_result "Health endpoint accessible" "200" "$HTTP_CODE"
}

case "${1:-}" in
    cidr)
        test_cidr
        ;;
    hmac)
        test_hmac
        ;;
    both)
        test_cidr
        echo ""
        echo "========================================="
        echo ""
        test_hmac
        ;;
    *)
        echo "Usage: $0 {cidr|hmac|both}"
        exit 1
        ;;
esac

echo "=== All tests complete ==="
```

Output:
```
./test-trusted-proxy.sh both
=== CIDR Trusted Proxy Test ===

   Applying config...
configmap/ogx-server-config configured
ogxserver.ogx.io/ogxserver-with-userconfig unchanged
   Waiting for rollout...
Waiting for deployment "ogxserver-with-userconfig" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "ogxserver-with-userconfig" rollout to finish: 1 old replicas are pending termination...
deployment "ogxserver-with-userconfig" successfully rolled out
   Waiting for old pods to terminate...
1. From outside cluster (port-forward, source IP = 127.0.0.1) — expect 403
   Waiting for port-forward...
   Port-forward ready.
   PASS: External request rejected by CIDR (HTTP 403)

2. Health endpoint (public, bypasses auth) — expect 200
   PASS: Health endpoint accessible (HTTP 200)


=========================================

=== HMAC Trusted Proxy Test ===

   Applying config...
configmap/ogx-server-config configured
ogxserver.ogx.io/ogxserver-with-userconfig unchanged
   Waiting for rollout...
Waiting for deployment "ogxserver-with-userconfig" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "ogxserver-with-userconfig" rollout to finish: 1 old replicas are pending termination...
deployment "ogxserver-with-userconfig" successfully rolled out
   Waiting for old pods to terminate...
   Waiting for port-forward...
   Port-forward ready.
1. Without signature — expect 403
   PASS: Missing signature rejected (HTTP 403)

2. With bad signature — expect 403
   PASS: Bad signature rejected (HTTP 403)

3. With valid signature — expect 200
   PASS: Valid signature accepted (HTTP 200)

4. Tampered identity (sig for alice, header says mallory) — expect 403
   PASS: Tampered identity rejected (HTTP 403)

5. Health endpoint (public, bypasses auth) — expect 200
   PASS: Health endpoint accessible (HTTP 200)

=== All tests complete ===
```



<!-- For API changes, include:
1. A testing script (Python, curl, etc.) that exercises the new/modified endpoints
2. The output from running your script

Example:
```python
...
...
```

Output:
```
<paste actual output here>
```
-->