### PR TITLE
refactor: consolidate SSE streaming helpers in ogx_api.utils

### DIFF
--- a/src/ogx_api/common/sse_context.py
+++ b/src/ogx_api/common/sse_context.py
@@ -1,0 +1,33 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import asyncio
+import contextvars
+from collections.abc import AsyncGenerator
+
+
+def preserve_context_for_sse(event_gen: AsyncGenerator[str, None]) -> AsyncGenerator[str, None]:
+    """Preserve request context for SSE streaming.
+
+    StreamingResponse runs in a different task, losing request contextvars.
+    This wrapper captures and restores the context.
+    """
+    context = contextvars.copy_context()
+
+    async def wrapper() -> AsyncGenerator[str, None]:
+        try:
+            while True:
+                try:
+                    task: asyncio.Task[str] = context.run(asyncio.create_task, event_gen.__anext__())
+                    item = await task
+                except StopAsyncIteration:
+                    break
+                yield item
+        except (asyncio.CancelledError, GeneratorExit):
+            await event_gen.aclose()
+            raise
+
+    return wrapper()

--- a/src/ogx_api/inference/fastapi_routes.py
+++ b/src/ogx_api/inference/fastapi_routes.py
@@ -11,12 +11,9 @@ FastAPI route decorators. The router is defined in the API package to keep
 all API-related code together.
 """
 
-import asyncio
-import contextvars
-import json
 import logging  # allow-direct-logging
 from collections.abc import AsyncIterator
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from fastapi.responses import StreamingResponse
@@ -25,6 +22,7 @@ from pydantic import BaseModel, Field
 from ogx_api.common.errors import OpenAIErrorResponse
 from ogx_api.common.responses import Order
 from ogx_api.router_utils import create_path_dependency, create_query_dependency, standard_responses
+from ogx_api.utils import _preserve_context_for_sse, create_sse_event, sse_stream
 from ogx_api.version import OGX_API_V1, OGX_API_V1ALPHA
 
 from .api import Inference
@@ -48,28 +46,11 @@ from .models import (
 logger = logging.LoggerAdapter(logging.getLogger(__name__), {"category": "inference"})
 
 
-def _create_sse_event(data: Any) -> str:
-    """Create a Server-Sent Event string from data."""
-    if isinstance(data, BaseModel):
-        data = data.model_dump_json()
-    else:
-        data = json.dumps(data)
-    return f"data: {data}\n\n"
-
-
-async def _sse_generator(event_gen: AsyncIterator[Any], context: str = "inference") -> AsyncIterator[str]:
-    """Convert an async generator to SSE format."""
-    try:
-        async for item in event_gen:
-            yield _create_sse_event(item)
-    except asyncio.CancelledError:
-        if hasattr(event_gen, "aclose"):
-            await event_gen.aclose()
-        raise
-    except Exception as e:
-        logger.exception(f"Error in SSE generator ({context})")
-        exc = _http_exception_from_sse_error(e)
-        yield _create_sse_event(OpenAIErrorResponse.from_message(exc.detail, code=str(exc.status_code)).to_dict())
+def _format_inference_sse_error_event(e: Exception) -> str:
+    """Log and format an SSE stream error as an OpenAI error event."""
+    logger.exception("Error in inference SSE generator")
+    exc = _http_exception_from_sse_error(e)
+    return create_sse_event(OpenAIErrorResponse.from_message(exc.detail, code=str(exc.status_code)).to_dict())
 
 
 def _http_exception_from_value_error(exc: ValueError) -> HTTPException:
@@ -88,31 +69,6 @@ def _http_exception_from_sse_error(exc: Exception) -> HTTPException:
     if isinstance(status_code, int):
         return HTTPException(status_code=status_code, detail=str(exc))
     return HTTPException(status_code=500, detail="Internal server error: An unexpected error occurred.")
-
-
-def _preserve_context_for_sse(event_gen: AsyncIterator[str]) -> AsyncIterator[str]:
-    """Preserve request context for SSE streaming.
-
-    StreamingResponse runs in a different task, losing request contextvars.
-    This wrapper captures and restores the context.
-    """
-    context = contextvars.copy_context()
-
-    async def wrapper() -> AsyncIterator[str]:
-        try:
-            while True:
-                try:
-                    task: asyncio.Task[str] = context.run(asyncio.create_task, event_gen.__anext__())  # type: ignore[arg-type]
-                    item = await task
-                except StopAsyncIteration:
-                    break
-                yield item
-        except (asyncio.CancelledError, GeneratorExit):
-            if hasattr(event_gen, "aclose"):
-                await event_gen.aclose()
-            raise
-
-    return wrapper()
 
 
 # Automatically generate dependency functions from Pydantic models
@@ -174,7 +130,7 @@ def create_router(impl: Inference) -> APIRouter:
         result = await impl.openai_chat_completion(params)
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_sse_generator(result, context="chat_completion")),
+                _preserve_context_for_sse(sse_stream(result, create_sse_event, _format_inference_sse_error_event)),
                 media_type="text/event-stream",
             )
         return result
@@ -252,7 +208,7 @@ def create_router(impl: Inference) -> APIRouter:
         result = await impl.openai_completion(params)
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_sse_generator(result, context="completion")),
+                _preserve_context_for_sse(sse_stream(result, create_sse_event, _format_inference_sse_error_event)),
                 media_type="text/event-stream",
             )
         return result

--- a/src/ogx_api/interactions/fastapi_routes.py
+++ b/src/ogx_api/interactions/fastapi_routes.py
@@ -10,19 +10,16 @@ This module defines the FastAPI router for the /v1/interactions endpoint,
 serving the Google Interactions API format.
 """
 
-import asyncio
-import contextvars
-import json
 import logging  # allow-direct-logging
 from collections.abc import AsyncIterator
 from typing import Annotated, Any, cast
 
 from fastapi import APIRouter, Body, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
 
 from ogx_api.common.errors import ModelNotFoundError
 from ogx_api.router_utils import standard_responses
+from ogx_api.utils import _preserve_context_for_sse, create_sse_event_with_type, sse_stream
 from ogx_api.version import OGX_API_V1ALPHA
 
 from .api import Interactions
@@ -36,59 +33,19 @@ from .models import (
 logger = logging.LoggerAdapter(logging.getLogger(__name__), {"category": "interactions"})
 
 
-def _create_google_sse_event(event_type: str, data: Any) -> str:
-    """Create a Google-format SSE event with named event type.
-
-    Google SSE format: event: <type>\ndata: <json>\n\n
-    """
-    if isinstance(data, BaseModel):
-        data = data.model_dump_json()
-    else:
-        data = json.dumps(data)
-    return f"event: {event_type}\ndata: {data}\n\n"
+def _format_google_sse_event(event: Any) -> str:
+    """Format a Google stream event as a named SSE event."""
+    event_type = event.event_type if hasattr(event, "event_type") else "unknown"
+    return create_sse_event_with_type(event_type, event)
 
 
-async def _google_sse_generator(event_gen: AsyncIterator) -> AsyncIterator[str]:
-    """Convert an async generator of Google stream events to SSE format."""
-    try:
-        async for event in event_gen:
-            event_type = event.event_type if hasattr(event, "event_type") else "unknown"
-            yield _create_google_sse_event(event_type, event)
-    except asyncio.CancelledError:
-        if hasattr(event_gen, "aclose"):
-            await event_gen.aclose()
-        raise
-    except Exception as e:
-        logger.exception("Error in Google SSE generator")
-        error_resp = GoogleErrorResponse(
-            error=_GoogleErrorDetail(code=500, message=str(e)),
-        )
-        yield _create_google_sse_event("error", error_resp)
-
-
-def _preserve_context_for_sse(event_gen):
-    """Preserve request context for SSE streaming.
-
-    StreamingResponse runs in a different task, losing request contextvars.
-    This wrapper captures and restores the context.
-    """
-    context = contextvars.copy_context()
-
-    async def wrapper():
-        try:
-            while True:
-                try:
-                    task = context.run(asyncio.create_task, event_gen.__anext__())
-                    item = await task
-                except StopAsyncIteration:
-                    break
-                yield item
-        except (asyncio.CancelledError, GeneratorExit):
-            if hasattr(event_gen, "aclose"):
-                await event_gen.aclose()
-            raise
-
-    return wrapper()
+def _format_google_sse_error_event(e: Exception) -> str:
+    """Log and format an SSE stream error as a Google error event."""
+    logger.exception("Error in Google SSE generator")
+    error_resp = GoogleErrorResponse(
+        error=_GoogleErrorDetail(code=500, message=str(e)),
+    )
+    return create_sse_event_with_type("error", error_resp)
 
 
 def _google_error_response(status_code: int, message: str) -> JSONResponse:
@@ -156,7 +113,13 @@ def create_router(impl: Interactions) -> APIRouter:
             return result
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_google_sse_generator(cast(AsyncIterator[Any], result))),
+                _preserve_context_for_sse(
+                    sse_stream(
+                        cast(AsyncIterator[Any], result),
+                        _format_google_sse_event,
+                        _format_google_sse_error_event,
+                    )
+                ),
                 media_type="text/event-stream",
             )
 

--- a/src/ogx_api/messages/fastapi_routes.py
+++ b/src/ogx_api/messages/fastapi_routes.py
@@ -10,19 +10,16 @@ This module defines the FastAPI router for the /v1/messages endpoint,
 serving the Anthropic Messages API format.
 """
 
-import asyncio
-import contextvars
-import json
 import logging  # allow-direct-logging
 from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
 
 from ogx_api.common.errors import ModelNotFoundError
 from ogx_api.router_utils import standard_responses
+from ogx_api.utils import _preserve_context_for_sse, create_sse_event_with_type, sse_stream
 from ogx_api.version import OGX_API_V1
 
 from .api import Messages
@@ -46,59 +43,19 @@ from .models import (
 logger = logging.LoggerAdapter(logging.getLogger(__name__), {"category": "messages"})
 
 
-def _create_anthropic_sse_event(event_type: str, data: Any) -> str:
-    """Create an Anthropic-format SSE event with named event type.
-
-    Anthropic SSE format: event: <type>\ndata: <json>\n\n
-    """
-    if isinstance(data, BaseModel):
-        data = data.model_dump_json()
-    else:
-        data = json.dumps(data)
-    return f"event: {event_type}\ndata: {data}\n\n"
+def _format_anthropic_sse_event(event: Any) -> str:
+    """Format an Anthropic stream event as a named SSE event."""
+    event_type = event.type if hasattr(event, "type") else "unknown"
+    return create_sse_event_with_type(event_type, event)
 
 
-async def _anthropic_sse_generator(event_gen: AsyncIterator) -> AsyncIterator[str]:
-    """Convert an async generator of Anthropic stream events to SSE format."""
-    try:
-        async for event in event_gen:
-            event_type = event.type if hasattr(event, "type") else "unknown"
-            yield _create_anthropic_sse_event(event_type, event)
-    except asyncio.CancelledError:
-        if hasattr(event_gen, "aclose"):
-            await event_gen.aclose()
-        raise
-    except Exception as e:
-        logger.exception("Error in Anthropic SSE generator")
-        error_resp = AnthropicErrorResponse(
-            error=_AnthropicErrorDetail(type="api_error", message=str(e)),
-        )
-        yield _create_anthropic_sse_event("error", error_resp)
-
-
-def _preserve_context_for_sse(event_gen):
-    """Preserve request context for SSE streaming.
-
-    StreamingResponse runs in a different task, losing request contextvars.
-    This wrapper captures and restores the context.
-    """
-    context = contextvars.copy_context()
-
-    async def wrapper():
-        try:
-            while True:
-                try:
-                    task = context.run(asyncio.create_task, event_gen.__anext__())
-                    item = await task
-                except StopAsyncIteration:
-                    break
-                yield item
-        except (asyncio.CancelledError, GeneratorExit):
-            if hasattr(event_gen, "aclose"):
-                await event_gen.aclose()
-            raise
-
-    return wrapper()
+def _format_anthropic_sse_error_event(e: Exception) -> str:
+    """Log and format an SSE stream error as an Anthropic error event."""
+    logger.exception("Error in Anthropic SSE generator")
+    error_resp = AnthropicErrorResponse(
+        error=_AnthropicErrorDetail(type="api_error", message=str(e)),
+    )
+    return create_sse_event_with_type("error", error_resp)
 
 
 def _anthropic_error_response(status_code: int, message: str) -> JSONResponse:
@@ -169,7 +126,9 @@ def create_router(impl: Messages) -> APIRouter:
 
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_anthropic_sse_generator(result)),
+                _preserve_context_for_sse(
+                    sse_stream(result, _format_anthropic_sse_event, _format_anthropic_sse_error_event)
+                ),
                 media_type="text/event-stream",
                 headers=response_headers,
             )

--- a/src/ogx_api/pyproject.toml
+++ b/src/ogx_api/pyproject.toml
@@ -86,6 +86,7 @@ py-modules = [
     "ogx_api.rag_tool",
     "ogx_api.resource",
     "ogx_api.router_utils",
+    "ogx_api.utils",
     "ogx_api.schema_utils",
     "ogx_api.vector_stores",
     "ogx_api.version",

--- a/src/ogx_api/responses/fastapi_routes.py
+++ b/src/ogx_api/responses/fastapi_routes.py
@@ -10,16 +10,14 @@ This module defines the FastAPI router for the Responses API using standard
 FastAPI route decorators.
 """
 
-import asyncio
-import contextvars
 import json
 import logging  # allow-direct-logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from ogx_api.common.responses import Order
 from ogx_api.openai_responses import (
@@ -37,6 +35,7 @@ from ogx_api.router_utils import (
     standard_responses,
     try_translate_to_http_exception,
 )
+from ogx_api.utils import _preserve_context_for_sse, create_sse_event, sse_stream
 from ogx_api.version import OGX_API_V1
 
 from .api import Responses
@@ -111,16 +110,7 @@ class FormURLEncodedRoute(ExceptionTranslatingRoute):
         return handler
 
 
-def create_sse_event(data: Any) -> str:
-    """Create a Server-Sent Event string from data."""
-    if isinstance(data, BaseModel):
-        data = data.model_dump_json()
-    else:
-        data = json.dumps(data)
-    return f"data: {data}\n\n"
-
-
-async def sse_generator(event_gen: AsyncIterator[Any]) -> AsyncIterator[str]:
+def sse_generator(event_gen: AsyncIterator[Any]) -> AsyncGenerator[str, None]:
     """Convert an async generator to SSE format.
 
     This function iterates over an async generator and formats each yielded
@@ -129,27 +119,27 @@ async def sse_generator(event_gen: AsyncIterator[Any]) -> AsyncIterator[str]:
     # Track the last sequence_number seen so that if an error occurs mid-stream,
     # the error event can continue the sequence (last seen + 1).
     sequence_number = 0
-    try:
-        async for item in event_gen:
-            if hasattr(item, "sequence_number"):
-                sequence_number = item.sequence_number
-            yield create_sse_event(item)
-    except asyncio.CancelledError:
-        if hasattr(event_gen, "aclose"):
-            await event_gen.aclose()
-        raise  # Re-raise to maintain proper cancellation semantics
-    except Exception as e:
+
+    def _format_event(item: Any) -> str:
+        nonlocal sequence_number
+        if hasattr(item, "sequence_number"):
+            sequence_number = item.sequence_number
+        return create_sse_event(item)
+
+    def _format_error_event(e: Exception) -> str:
         logger.exception("Error in SSE generator")
         http_exc = try_translate_to_http_exception(e)
         status_code = str(http_exc.status_code) if http_exc else "server_error"
         detail = http_exc.detail if http_exc else "Internal server error: An unexpected error occurred."
-        yield create_sse_event(
+        return create_sse_event(
             OpenAIResponseObjectStreamError(
                 code=status_code,
                 message=detail,
                 sequence_number=sequence_number + 1,
             )
         )
+
+    return sse_stream(event_gen, _format_event, _format_error_event)
 
 
 # Automatically generate dependency functions from Pydantic models
@@ -190,28 +180,6 @@ async def get_list_response_input_items_request(
         limit=limit,
         order=order,
     )
-
-
-def _preserve_context_for_sse(event_gen: AsyncIterator[str]) -> AsyncIterator[str]:
-    # StreamingResponse runs in a different task, losing request contextvars.
-    # create_task inside context.run captures the context at task creation.
-    context = contextvars.copy_context()
-
-    async def wrapper() -> AsyncIterator[str]:
-        try:
-            while True:
-                try:
-                    task: asyncio.Task[str] = context.run(asyncio.create_task, event_gen.__anext__())  # type: ignore[arg-type]
-                    item = await task
-                except StopAsyncIteration:
-                    break
-                yield item
-        except (asyncio.CancelledError, GeneratorExit):
-            if hasattr(event_gen, "aclose"):
-                await event_gen.aclose()
-            raise
-
-    return wrapper()
 
 
 # Fields that the WebSocket response.create event forbids (they only apply to

--- a/src/ogx_api/utils.py
+++ b/src/ogx_api/utils.py
@@ -1,0 +1,77 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Shared utility functions for the OGX API."""
+
+import asyncio
+import contextvars
+import json
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def _preserve_context_for_sse(event_gen: AsyncGenerator[str, None]) -> AsyncGenerator[str, None]:
+    """Preserve request context for SSE streaming.
+
+    StreamingResponse runs in a different task, losing request contextvars.
+    This wrapper captures and restores the context.
+    """
+    context = contextvars.copy_context()
+
+    async def wrapper() -> AsyncGenerator[str, None]:
+        try:
+            while True:
+                try:
+                    task: asyncio.Task[str] = context.run(asyncio.create_task, event_gen.__anext__())
+                    item = await task
+                except StopAsyncIteration:
+                    break
+                yield item
+        except (asyncio.CancelledError, GeneratorExit):
+            await event_gen.aclose()
+            raise
+
+    return wrapper()
+
+
+def _serialize_sse_data(data: Any) -> str:
+    if isinstance(data, BaseModel):
+        return data.model_dump_json()
+    return json.dumps(data)
+
+
+def create_sse_event(data: Any) -> str:
+    """Create a Server-Sent Event string: data: <json>\\n\\n."""
+    return f"data: {_serialize_sse_data(data)}\n\n"
+
+
+def create_sse_event_with_type(event_type: str, data: Any) -> str:
+    """Create a named Server-Sent Event string: event: <type>\\ndata: <json>\\n\\n."""
+    return f"event: {event_type}\ndata: {_serialize_sse_data(data)}\n\n"
+
+
+async def sse_stream(
+    event_gen: AsyncIterator[Any],
+    format_event: Callable[[Any], str],
+    format_error_event: Callable[[Exception], str],
+) -> AsyncGenerator[str, None]:
+    """Yield SSE events from an async generator.
+
+    Each item is serialized with ``format_event``. Cancellation closes the
+    underlying generator. Any other exception is reported as the final event
+    via ``format_error_event``, which should also log the exception.
+    """
+    try:
+        async for item in event_gen:
+            yield format_event(item)
+    except asyncio.CancelledError:
+        if hasattr(event_gen, "aclose"):
+            await event_gen.aclose()
+        raise
+    except Exception as e:
+        yield format_error_event(e)


### PR DESCRIPTION
Extract the duplicated _preserve_context_for_sse function from 4 API route files (inference, messages, responses, interactions) into a shared utility in src/ogx_api/utils.py.

Unify the four near-identical SSE streaming loops and event serializers in those route files into shared create_sse_event, create_sse_event_with_type, and sse_stream helpers. Each route file now only provides its API-specific event and error-event formatting.
