### PR TITLE
fix(vertexai): persist Gemini thought_signature across tool-call round trips

### DIFF
--- a/docs/docs/providers/inference/remote_vertexai.mdx
+++ b/docs/docs/providers/inference/remote_vertexai.mdx
@@ -11,6 +11,7 @@ description: |
   - Set VERTEX_AI_PROJECT environment variable (required)
   - Set VERTEX_AI_LOCATION environment variable (optional, defaults to global)
   - Use Google Cloud Application Default Credentials or service account key
+  - For Gemini 3 tool loops, set thought_signature_store to a shared KV backend
 
   Authentication Setup:
   Option 1 (Recommended): gcloud auth application-default login
@@ -38,6 +39,7 @@ Configuration:
 - Set VERTEX_AI_PROJECT environment variable (required)
 - Set VERTEX_AI_LOCATION environment variable (optional, defaults to global)
 - Use Google Cloud Application Default Credentials or service account key
+- For Gemini 3 tool loops, set thought_signature_store to a shared KV backend
 
 Authentication Setup:
 Option 1 (Recommended): gcloud auth application-default login
@@ -76,10 +78,16 @@ Short names like vertexai/gemini-2.5-flash also work in API requests.
 | `network.limits.keepalive_expiry` | `float \| None` | No | 5.0 | Time in seconds to keep idle keep-alive connections open before closing them. None means no expiry. Values must be >= 0 if set. |
 | `project` | `str` | No |  | Google Cloud project ID for Vertex AI |
 | `location` | `str` | No | global | Google Cloud location for Vertex AI |
+| `thought_signature_store` | `KVStoreReference \| None` | No |  | KV store for Gemini thought_signature values (keyed by tool call id). Needed for multi-worker / restart-safe Gemini 3 tool loops; use a shared backend (Redis/Postgres) across replicas. |
+| `thought_signature_store.namespace` | `str` | No |  | Key prefix for KVStore backends |
+| `thought_signature_store.backend` | `str` | No |  | Name of backend from storage.backends |
 
 ## Sample Configuration
 
 ```yaml
 project: ${env.VERTEX_AI_PROJECT:=}
 location: ${env.VERTEX_AI_LOCATION:=global}
+thought_signature_store:
+  namespace: vertexai_thought_signatures
+  backend: kv_default
 ```

--- a/src/ogx/distributions/ci-tests/config.yaml
+++ b/src/ogx/distributions/ci-tests/config.yaml
@@ -73,6 +73,9 @@ providers:
     config:
       project: ${env.VERTEX_AI_PROJECT:=}
       location: ${env.VERTEX_AI_LOCATION:=global}
+      thought_signature_store:
+        namespace: vertexai_thought_signatures
+        backend: kv_default
   - provider_id: groq
     provider_type: remote::groq
     config:

--- a/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
@@ -73,6 +73,9 @@ providers:
     config:
       project: ${env.VERTEX_AI_PROJECT:=}
       location: ${env.VERTEX_AI_LOCATION:=global}
+      thought_signature_store:
+        namespace: vertexai_thought_signatures
+        backend: kv_default
   - provider_id: groq
     provider_type: remote::groq
     config:

--- a/src/ogx/distributions/starter/config.yaml
+++ b/src/ogx/distributions/starter/config.yaml
@@ -73,6 +73,9 @@ providers:
     config:
       project: ${env.VERTEX_AI_PROJECT:=}
       location: ${env.VERTEX_AI_LOCATION:=global}
+      thought_signature_store:
+        namespace: vertexai_thought_signatures
+        backend: kv_default
   - provider_id: groq
     provider_type: remote::groq
     config:

--- a/src/ogx/distributions/starter/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/starter/run-with-postgres-store.yaml
@@ -73,6 +73,9 @@ providers:
     config:
       project: ${env.VERTEX_AI_PROJECT:=}
       location: ${env.VERTEX_AI_LOCATION:=global}
+      thought_signature_store:
+        namespace: vertexai_thought_signatures
+        backend: kv_default
   - provider_id: groq
     provider_type: remote::groq
     config:

--- a/src/ogx/providers/registry/inference.py
+++ b/src/ogx/providers/registry/inference.py
@@ -218,6 +218,7 @@ Configuration:
 - Set VERTEX_AI_PROJECT environment variable (required)
 - Set VERTEX_AI_LOCATION environment variable (optional, defaults to global)
 - Use Google Cloud Application Default Credentials or service account key
+- For Gemini 3 tool loops, set thought_signature_store to a shared KV backend
 
 Authentication Setup:
 Option 1 (Recommended): gcloud auth application-default login

--- a/src/ogx/providers/remote/inference/vertexai/config.py
+++ b/src/ogx/providers/remote/inference/vertexai/config.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
+from ogx.core.storage.datatypes import KVStoreReference
 from ogx.providers.utils.inference.model_registry import RemoteInferenceProviderConfig
 from ogx_api import json_schema_type
 
@@ -52,6 +53,14 @@ class VertexAIConfig(RemoteInferenceProviderConfig):
         default="global",
         description="Google Cloud location for Vertex AI",
     )
+    thought_signature_store: KVStoreReference | None = Field(
+        default=None,
+        description=(
+            "KV store for Gemini thought_signature values (keyed by tool call id). "
+            "Needed for multi-worker / restart-safe Gemini 3 tool loops; "
+            "use a shared backend (Redis/Postgres) across replicas."
+        ),
+    )
 
     @classmethod
     def sample_run_config(
@@ -64,4 +73,8 @@ class VertexAIConfig(RemoteInferenceProviderConfig):
         return {
             "project": project,
             "location": location,
+            "thought_signature_store": KVStoreReference(
+                backend="kv_default",
+                namespace="vertexai_thought_signatures",
+            ).model_dump(exclude_none=True),
         }

--- a/src/ogx/providers/remote/inference/vertexai/converters.py
+++ b/src/ogx/providers/remote/inference/vertexai/converters.py
@@ -16,6 +16,7 @@ import json
 import re
 import time
 import uuid
+from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -243,6 +244,30 @@ def _convert_user_message(msg: dict[str, Any]) -> dict[str, Any]:
     return {"role": "user", "parts": parts}
 
 
+def _normalize_thought_signature(value: Any) -> str | None:
+    """Normalize a Gemini thought_signature to a JSON-safe string (bytes → base64)."""
+    if value is None:
+        return None
+    if isinstance(value, bytes | bytearray):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    value = str(value)
+    return value or None
+
+
+def _thought_signature_from_part(part: Any) -> str | None:
+    """Read thought_signature from a Gemini part (snake_case or camelCase)."""
+    raw = getattr(part, "thought_signature", None)
+    if raw is None:
+        raw = getattr(part, "thoughtSignature", None)
+    if raw is None:
+        fc = getattr(part, "function_call", None)
+        if fc is not None:
+            raw = getattr(fc, "thought_signature", None)
+            if raw is None:
+                raw = getattr(fc, "thoughtSignature", None)
+    return _normalize_thought_signature(raw)
+
+
 def _parse_tool_call_arguments(arguments: str | dict[str, Any]) -> dict[str, Any]:
     """Parse tool call arguments from string or dict form."""
     if not isinstance(arguments, str):
@@ -254,7 +279,27 @@ def _parse_tool_call_arguments(arguments: str | dict[str, Any]) -> dict[str, Any
     return parsed
 
 
-def _convert_assistant_message(msg: dict[str, Any]) -> dict[str, Any] | None:
+def collect_tool_call_ids(messages: list[Any]) -> list[str]:
+    """Return unique OpenAI tool-call ids from assistant messages."""
+    seen: set[str] = set()
+    ids: list[str] = []
+    for raw_msg in messages:
+        msg = _to_dict(raw_msg)
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            tc = _to_dict(tc)
+            call_id = tc.get("id")
+            if isinstance(call_id, str) and call_id and call_id not in seen:
+                seen.add(call_id)
+                ids.append(call_id)
+    return ids
+
+
+def _convert_assistant_message(
+    msg: dict[str, Any],
+    signature_by_call_id: Mapping[str, str] | None = None,
+) -> dict[str, Any] | None:
     """Convert an OpenAI assistant message to a Gemini Content dict.
 
     Returns ``None`` when the message has no text content and no tool calls.
@@ -275,17 +320,29 @@ def _convert_assistant_message(msg: dict[str, Any]) -> dict[str, Any] | None:
     if text:
         parts.append({"text": text})
 
-    for tc in msg.get("tool_calls") or []:
+    tool_calls = msg.get("tool_calls") or []
+    for index, tc in enumerate(tool_calls):
         tc = _to_dict(tc)
         func = tc.get("function", {})
-        parts.append(
-            {
-                "function_call": {
-                    "name": func.get("name", ""),
-                    "args": _parse_tool_call_arguments(func.get("arguments", "{}")),
-                }
-            }
-        )
+        function_call: dict[str, Any] = {
+            "name": func.get("name", ""),
+            "args": _parse_tool_call_arguments(func.get("arguments", "{}")),
+        }
+        part: dict[str, Any] = {"function_call": function_call}
+        call_id = tc.get("id") if isinstance(tc, dict) else None
+        # Only re-attach persisted signatures. Omit on miss (default): Gemini 2.x
+        # must not receive skip_thought_signature_validator; Gemini 3 gets real
+        # signatures from the store when the model emitted them.
+        if isinstance(call_id, str) and signature_by_call_id:
+            thought_signature = signature_by_call_id.get(call_id)
+            if thought_signature:
+                part["thought_signature"] = thought_signature
+            elif index == 0:
+                logger.debug(
+                    "Missing thought_signature for first function call; omitting",
+                    call_id=call_id,
+                )
+        parts.append(part)
 
     return {"role": "model", "parts": parts} if parts else None
 
@@ -310,6 +367,7 @@ def _convert_tool_message(msg: dict[str, Any], all_messages: list[Any]) -> dict[
 
 def convert_openai_messages_to_gemini(
     messages: list[Any],
+    signature_by_call_id: Mapping[str, str] | None = None,
 ) -> tuple[str | None, list[dict[str, Any]]]:
     """Convert OpenAI-format messages to Gemini Content dicts.
 
@@ -334,7 +392,10 @@ def convert_openai_messages_to_gemini(
         elif role == "user":
             contents.append(_convert_user_message(msg))
         elif role == "assistant":
-            converted = _convert_assistant_message(msg)
+            converted = _convert_assistant_message(
+                msg,
+                signature_by_call_id,
+            )
             if converted:
                 contents.append(converted)
         elif role == "tool":
@@ -432,6 +493,7 @@ def generate_completion_id() -> str:
 
 def _extract_candidate_parts(
     candidate: Any,
+    signatures_out: MutableMapping[str, str] | None = None,
 ) -> tuple[list[str], list[str], list[OpenAIChatCompletionToolCall | OpenAIChatCompletionCustomToolCall]]:
     """Extract text segments, thinking segments, and tool calls from a Gemini candidate's parts."""
     content_obj = getattr(candidate, "content", None)
@@ -458,10 +520,11 @@ def _extract_candidate_parts(
 
         fc = getattr(part, "function_call", None)
         if fc is not None:
+            call_id = f"call_{uuid.uuid4().hex[:24]}"
             tool_calls.append(
                 OpenAIChatCompletionToolCall(
                     index=len(tool_calls),
-                    id=f"call_{uuid.uuid4().hex[:24]}",
+                    id=call_id,
                     type="function",
                     function=OpenAIChatCompletionToolCallFunction(
                         name=getattr(fc, "name", "") or "",
@@ -469,6 +532,9 @@ def _extract_candidate_parts(
                     ),
                 )
             )
+            normalized = _thought_signature_from_part(part)
+            if normalized and signatures_out is not None:
+                signatures_out[call_id] = normalized
 
     return text_parts, thinking_parts, tool_calls
 
@@ -540,11 +606,17 @@ def _extract_logprobs(candidate: Any) -> OpenAIChoiceLogprobs | None:
     return OpenAIChoiceLogprobs(content=token_logprobs)
 
 
-def _process_candidates(response_or_chunk: Any) -> list[_CandidateData]:
+def _process_candidates(
+    response_or_chunk: Any,
+    signatures_out: MutableMapping[str, str] | None = None,
+) -> list[_CandidateData]:
     """Extract and process all candidates from a Gemini response or streaming chunk."""
     result: list[_CandidateData] = []
     for i, candidate in enumerate(getattr(response_or_chunk, "candidates", None) or []):
-        text_parts, thinking_parts, tool_calls = _extract_candidate_parts(candidate)
+        text_parts, thinking_parts, tool_calls = _extract_candidate_parts(
+            candidate,
+            signatures_out,
+        )
         result.append(
             _CandidateData(
                 index=i,
@@ -583,13 +655,14 @@ def _resolve_finish_reason(
 def convert_gemini_response_to_openai(
     response: genai_types.GenerateContentResponse,
     model: str,
+    signatures_out: MutableMapping[str, str] | None = None,
 ) -> OpenAIChatCompletion:
     """Map a google-genai ``GenerateContentResponse`` to ``OpenAIChatCompletion``."""
     completion_id = generate_completion_id()
     created = int(time.time())
 
     choices: list[OpenAIChoice] = []
-    for cd in _process_candidates(response):
+    for cd in _process_candidates(response, signatures_out):
         # NOTE: reasoning_content is only available on streaming deltas (OpenAIChoiceDelta).
         # Non-streaming responses include thinking text in content because
         # OpenAIChatCompletionResponseMessage has no reasoning_content field.
@@ -679,6 +752,7 @@ def convert_gemini_stream_chunk_to_openai(
     model: str,
     completion_id: str,
     is_first_chunk: bool,
+    signatures_out: MutableMapping[str, str] | None = None,
 ) -> OpenAIChatCompletionChunk:
     """Map a Gemini streaming chunk to ``OpenAIChatCompletionChunk``."""
     created = int(time.time())
@@ -696,7 +770,7 @@ def convert_gemini_stream_chunk_to_openai(
             index=cd.index,
             logprobs=cd.logprobs,
         )
-        for cd in _process_candidates(chunk)
+        for cd in _process_candidates(chunk, signatures_out)
     ]
 
     if not choices:

--- a/src/ogx/providers/remote/inference/vertexai/thought_signature_store.py
+++ b/src/ogx/providers/remote/inference/vertexai/thought_signature_store.py
@@ -1,0 +1,73 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""KV-backed persistence for Gemini thought_signature ↔ OpenAI tool call id."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime, timedelta
+
+from ogx.log import get_logger
+from ogx.providers.remote.inference.vertexai.converters import _normalize_thought_signature
+from ogx_api.internal.kvstore import KVStore
+
+logger = get_logger(__name__, category="inference")
+
+_KEY_PREFIX = "thought_sig:"
+# Gemini only validates signatures within the current tool-call turn. 24h covers
+# multi-step loops, restarts, slow tools, and brief human-in-the-loop pauses
+# without unbounded KV growth.
+_DEFAULT_TTL = timedelta(hours=24)
+
+
+class ThoughtSignatureStore:
+    """Persist Gemini thought_signature values keyed by OpenAI tool call id."""
+
+    def __init__(self, kv: KVStore, ttl: timedelta = _DEFAULT_TTL) -> None:
+        self._kv = kv
+        self._ttl = ttl
+
+    def _key(self, call_id: str) -> str:
+        return f"{_KEY_PREFIX}{call_id}"
+
+    def _expiration(self) -> datetime:
+        return datetime.now(tz=UTC) + self._ttl
+
+    async def put(self, call_id: str, signature: str | None) -> None:
+        normalized = _normalize_thought_signature(signature)
+        if not normalized or not call_id:
+            return
+        await self._kv.set(self._key(call_id), normalized, expiration=self._expiration())
+        logger.debug(
+            "Persisted thought_signature",
+            call_id=call_id,
+            ttl_seconds=int(self._ttl.total_seconds()),
+        )
+
+    async def put_many(self, signatures: Mapping[str, str]) -> None:
+        for call_id, signature in signatures.items():
+            await self.put(call_id, signature)
+
+    async def get(self, call_id: str) -> str | None:
+        if not call_id:
+            return None
+        value = await self._kv.get(self._key(call_id))
+        if value is None:
+            logger.debug("thought_signature cache miss", call_id=call_id)
+            return None
+        logger.debug("thought_signature cache hit", call_id=call_id)
+        return value
+
+    async def get_many(self, call_ids: Iterable[str]) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for call_id in call_ids:
+            if not call_id or call_id in result:
+                continue
+            value = await self.get(call_id)
+            if value is not None:
+                result[call_id] = value
+        return result

--- a/src/ogx/providers/remote/inference/vertexai/vertexai.py
+++ b/src/ogx/providers/remote/inference/vertexai/vertexai.py
@@ -19,12 +19,14 @@ from google.oauth2.credentials import Credentials
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from ogx.core.request_headers import NeedsRequestProviderData
+from ogx.core.storage.kvstore import kvstore_impl
 from ogx.log import get_logger
 from ogx.providers.remote.inference.vertexai import converters
 from ogx.providers.remote.inference.vertexai.config import (
     VertexAIConfig,
     VertexAIProviderDataValidator,
 )
+from ogx.providers.remote.inference.vertexai.thought_signature_store import ThoughtSignatureStore
 from ogx.providers.remote.inference.vertexai.utils import build_http_options as _build_http_options
 from ogx.providers.utils.inference.openai_compat import get_stream_options_for_telemetry
 from ogx.providers.utils.inference.prompt_adapter import localize_image_content
@@ -148,6 +150,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
     _http_options: genai_types.HttpOptions | None = PrivateAttr(default=None)
     _http_options_initialized: bool = PrivateAttr(default=False)
     _model_cache: dict[str, Model] = PrivateAttr(default_factory=dict)
+    _thought_signature_store: ThoughtSignatureStore | None = PrivateAttr(default=None)
     embedding_model_metadata: dict[str, dict[str, int]] = {
         "publishers/google/models/text-embedding-004": {"embedding_dimension": 768, "context_length": 2048},
         "publishers/google/models/gemini-embedding-001": {"embedding_dimension": 3072, "context_length": 2048},
@@ -190,6 +193,14 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         _ensure_http_options() and create httpx.AsyncClient in the wrong event loop.
         The client will be created on first use via _get_client().
         """
+        if self.config.thought_signature_store is not None:
+            kv = await kvstore_impl(self.config.thought_signature_store)
+            self._thought_signature_store = ThoughtSignatureStore(kv)
+            logger.info(
+                "VertexAI thought_signature store configured",
+                backend=self.config.thought_signature_store.backend,
+                namespace=self.config.thought_signature_store.namespace,
+            )
         try:
             # Don't create the client here - it will be created lazily on first use
             # This avoids calling _ensure_http_options() in the temporary startup event loop
@@ -209,6 +220,7 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         self._http_options = None
         self._http_options_initialized = False
         self._default_client = None
+        self._thought_signature_store = None
 
     async def register_model(self, model: Model) -> Model:
         provider_resource_id = model.provider_resource_id or model.identifier
@@ -625,12 +637,20 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             is_first_chunk = True
             last_chunk: Any = None
             async for chunk in stream:
-                yield converters.convert_gemini_stream_chunk_to_openai(
+                signatures: dict[str, str] = {}
+                openai_chunk = converters.convert_gemini_stream_chunk_to_openai(
                     chunk=chunk,
                     model=model,
                     completion_id=completion_id,
                     is_first_chunk=is_first_chunk,
+                    signatures_out=signatures,
                 )
+                # Persist before yield: code after yield only runs when the
+                # consumer pulls the next item, and is skipped if the stream is
+                # closed after this chunk (client has the call id already).
+                if signatures and self._thought_signature_store is not None:
+                    await self._thought_signature_store.put_many(signatures)
+                yield openai_chunk
                 is_first_chunk = False
                 last_chunk = chunk
 
@@ -757,7 +777,13 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
         tools, tool_choice = self._resolve_deprecated_tools(params)
 
         messages = list(await asyncio.gather(*[self._localize_image_url(message) for message in params.messages]))
-        system_instruction, contents = converters.convert_openai_messages_to_gemini(messages)
+        store = self._thought_signature_store
+        call_ids = converters.collect_tool_call_ids(messages) if store else []
+        signature_by_call_id = await store.get_many(call_ids) if store and call_ids else {}
+        system_instruction, contents = converters.convert_openai_messages_to_gemini(
+            messages,
+            signature_by_call_id or None,
+        )
         tools_input = converters.convert_openai_tools_to_gemini(tools)
         config = self._build_generation_config(
             params,
@@ -785,7 +811,15 @@ class VertexAIInferenceAdapter(NeedsRequestProviderData, BaseModel):
             contents=request_contents,
             config=config,
         )
-        return converters.convert_gemini_response_to_openai(response=response, model=params.model)
+        signatures: dict[str, str] = {}
+        completion = converters.convert_gemini_response_to_openai(
+            response=response,
+            model=params.model,
+            signatures_out=signatures,
+        )
+        if self._thought_signature_store is not None and signatures:
+            await self._thought_signature_store.put_many(signatures)
+        return completion
 
     @staticmethod
     def _validate_completion_prompt(prompt: Any) -> list[str]:

--- a/tests/unit/providers/inference/vertexai/conftest.py
+++ b/tests/unit/providers/inference/vertexai/conftest.py
@@ -177,14 +177,14 @@ def patch_chat_completion_dependencies(monkeypatch):
 
         if capture_messages:
 
-            def _convert_messages(messages):
+            def _convert_messages(messages, signature_by_call_id=None):
                 """Convert messages."""
                 captured["messages"] = messages
                 return None, [{"role": "user", "parts": [{"text": "ok"}]}]
 
         else:
 
-            def _convert_messages(messages):
+            def _convert_messages(messages, signature_by_call_id=None):
                 """Convert messages."""
                 return None, [{"role": "user", "parts": [{"text": "ok"}]}]
 
@@ -215,7 +215,7 @@ def patch_chat_completion_dependencies(monkeypatch):
         )
         monkeypatch.setattr(
             "ogx.providers.remote.inference.vertexai.vertexai.converters.convert_gemini_response_to_openai",
-            lambda response, model: fake_completion,
+            lambda response, model, signatures_out=None: fake_completion,
         )
 
         return captured

--- a/tests/unit/providers/inference/vertexai/test_adapter_params.py
+++ b/tests/unit/providers/inference/vertexai/test_adapter_params.py
@@ -326,7 +326,7 @@ class TestTelemetryStreamOptions:
         monkeypatch.setattr(adapter, "_build_generation_config", lambda *_args, **_kwargs: object())
         monkeypatch.setattr(
             "ogx.providers.remote.inference.vertexai.vertexai.converters.convert_openai_messages_to_gemini",
-            lambda messages: (None, [{"role": "user", "parts": [{"text": "ok"}]}]),
+            lambda messages, signature_by_call_id=None: (None, [{"role": "user", "parts": [{"text": "ok"}]}]),
         )
         monkeypatch.setattr(
             "ogx.providers.remote.inference.vertexai.vertexai.converters.convert_openai_tools_to_gemini",

--- a/tests/unit/providers/inference/vertexai/test_config.py
+++ b/tests/unit/providers/inference/vertexai/test_config.py
@@ -106,6 +106,8 @@ class TestVertexAIConfig:
         sample = VertexAIConfig.sample_run_config(**sample_kwargs)
         assert sample["project"] == expected_project
         assert sample["location"] == expected_location
+        assert sample["thought_signature_store"]["backend"] == "kv_default"
+        assert sample["thought_signature_store"]["namespace"] == "vertexai_thought_signatures"
 
     def test_config_missing_required_project(self):
         """Test that project field is required."""

--- a/tests/unit/providers/inference/vertexai/test_thought_signature_roundtrip.py
+++ b/tests/unit/providers/inference/vertexai/test_thought_signature_roundtrip.py
@@ -1,0 +1,274 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Unit tests for VertexAI thought_signature persistence across tool-call round trips."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ogx.core.storage.kvstore.kvstore import InmemoryKVStoreImpl
+from ogx.providers.remote.inference.vertexai import converters
+from ogx.providers.remote.inference.vertexai.config import VertexAIConfig
+from ogx.providers.remote.inference.vertexai.thought_signature_store import ThoughtSignatureStore
+from ogx.providers.remote.inference.vertexai.vertexai import VertexAIInferenceAdapter
+from ogx_api.inference.models import OpenAIChatCompletionRequestWithExtraBody
+
+_WEATHER_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        },
+    }
+]
+
+
+def _make_function_call_part(name: str, args: dict, thought_signature: Any = None) -> Any:
+    return SimpleNamespace(
+        text=None,
+        thought=None,
+        function_call=SimpleNamespace(name=name, args=args),
+        thought_signature=thought_signature,
+    )
+
+
+def _make_candidate(parts: list) -> Any:
+    return SimpleNamespace(content=SimpleNamespace(parts=parts), finish_reason="STOP")
+
+
+def _make_gemini_response(parts: list) -> Any:
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(parts=parts),
+                finish_reason="STOP",
+                index=0,
+                logprobs_result=None,
+            )
+        ],
+        usage_metadata=None,
+    )
+
+
+class TestNormalizeThoughtSignature:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (b"\x9a\x04\x00", "mgQA"),
+            ("sig-abc", "sig-abc"),
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_normalize(self, value, expected):
+        assert converters._normalize_thought_signature(value) == expected
+
+
+class TestExtractSignatures:
+    def test_extracts_string_signature(self):
+        signatures: dict[str, str] = {}
+        _, _, tool_calls = converters._extract_candidate_parts(
+            _make_candidate([_make_function_call_part("get_weather", {"city": "Paris"}, thought_signature="sig-abc")]),
+            signatures,
+        )
+
+        assert len(tool_calls) == 1
+        assert signatures[tool_calls[0].id] == "sig-abc"
+        assert getattr(tool_calls[0].function, "thought_signature", None) is None
+
+    def test_extracts_bytes_as_base64(self):
+        signatures: dict[str, str] = {}
+        _, _, tool_calls = converters._extract_candidate_parts(
+            _make_candidate(
+                [_make_function_call_part("get_weather", {"city": "Paris"}, thought_signature=b"\x9a\x04\x00")]
+            ),
+            signatures,
+        )
+
+        assert signatures[tool_calls[0].id] == "mgQA"
+
+    def test_extracts_camel_case_attribute(self):
+        part = SimpleNamespace(
+            text=None,
+            thought=None,
+            function_call=SimpleNamespace(name="get_weather", args={"city": "Paris"}),
+            thoughtSignature="sig-camel",
+        )
+        signatures: dict[str, str] = {}
+        _, _, tool_calls = converters._extract_candidate_parts(_make_candidate([part]), signatures)
+
+        assert signatures[tool_calls[0].id] == "sig-camel"
+
+    def test_absent_signature_not_recorded(self):
+        signatures: dict[str, str] = {}
+        _, _, tool_calls = converters._extract_candidate_parts(
+            _make_candidate([_make_function_call_part("get_weather", {"city": "Paris"})]),
+            signatures,
+        )
+
+        assert len(tool_calls) == 1
+        assert signatures == {}
+
+
+class TestEmitSignatures:
+    def test_emits_stored_signature(self):
+        _, contents = converters.convert_openai_messages_to_gemini(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                        }
+                    ],
+                }
+            ],
+            {"call_1": "sig-abc"},
+        )
+
+        assert contents[0]["parts"][0]["thought_signature"] == "sig-abc"
+
+    def test_parallel_sibling_omits_missing_signature(self):
+        _, contents = converters.convert_openai_messages_to_gemini(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                        },
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "London"}'},
+                        },
+                    ],
+                }
+            ],
+            {"call_1": "sig-first"},
+        )
+
+        assert contents[0]["parts"][0]["thought_signature"] == "sig-first"
+        assert "thought_signature" not in contents[0]["parts"][1]
+
+
+class TestThoughtSignatureStore:
+    async def test_put_get_across_store_instances(self):
+        kv = InmemoryKVStoreImpl(namespace="shared")
+        store_a = ThoughtSignatureStore(kv)
+        store_b = ThoughtSignatureStore(kv)
+
+        await store_a.put("call_1", "sig-abc")
+        assert await store_b.get("call_1") == "sig-abc"
+
+    async def test_expired_entry_is_miss(self):
+        kv = InmemoryKVStoreImpl()
+        store = ThoughtSignatureStore(kv)
+        await store.put("call_1", "sig-abc")
+        await kv.set(
+            "thought_sig:call_1",
+            "sig-abc",
+            expiration=datetime.now(tz=UTC) - timedelta(seconds=1),
+        )
+
+        assert await store.get("call_1") is None
+
+
+class TestAdapterRoundTrip:
+    async def test_chat_completion_persists_and_reloads_across_workers(self, monkeypatch):
+        shared_kv = InmemoryKVStoreImpl(namespace="e2e")
+
+        adapter_a = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
+        cast(Any, adapter_a).__provider_id__ = "vertexai"
+        monkeypatch.setattr(adapter_a, "_thought_signature_store", ThoughtSignatureStore(shared_kv))
+        monkeypatch.setattr(adapter_a, "_validate_model_allowed", lambda _: None)
+        monkeypatch.setattr(
+            adapter_a,
+            "_get_client",
+            lambda: SimpleNamespace(
+                aio=SimpleNamespace(
+                    models=SimpleNamespace(
+                        generate_content=AsyncMock(
+                            return_value=_make_gemini_response(
+                                [
+                                    _make_function_call_part(
+                                        "get_weather",
+                                        {"city": "Paris"},
+                                        thought_signature="e2e-sig",
+                                    )
+                                ]
+                            )
+                        )
+                    )
+                )
+            ),
+        )
+
+        turn1 = await adapter_a.openai_chat_completion(
+            OpenAIChatCompletionRequestWithExtraBody(
+                model="publishers/google/models/gemini-3-flash",
+                messages=cast(Any, [{"role": "user", "content": "weather?"}]),
+                tools=cast(Any, _WEATHER_TOOLS),
+            )
+        )
+        tool_calls = turn1.choices[0].message.tool_calls
+        assert tool_calls is not None and len(tool_calls) == 1
+        call_id = tool_calls[0].id
+        assert await shared_kv.get(f"thought_sig:{call_id}") == "e2e-sig"
+
+        adapter_b = VertexAIInferenceAdapter(config=VertexAIConfig(project="p", location="l"))
+        cast(Any, adapter_b).__provider_id__ = "vertexai"
+        monkeypatch.setattr(adapter_b, "_thought_signature_store", ThoughtSignatureStore(shared_kv))
+        monkeypatch.setattr(adapter_b, "_validate_model_allowed", lambda _: None)
+
+        captured: dict[str, Any] = {}
+
+        async def _generate(model, contents, config):
+            captured["contents"] = contents
+            return _make_gemini_response([SimpleNamespace(text="Sunny", thought=None, function_call=None)])
+
+        monkeypatch.setattr(
+            adapter_b,
+            "_get_client",
+            lambda: SimpleNamespace(
+                aio=SimpleNamespace(models=SimpleNamespace(generate_content=AsyncMock(side_effect=_generate)))
+            ),
+        )
+
+        turn2 = await adapter_b.openai_chat_completion(
+            OpenAIChatCompletionRequestWithExtraBody(
+                model="publishers/google/models/gemini-3-flash",
+                messages=cast(
+                    Any,
+                    [
+                        {"role": "user", "content": "weather?"},
+                        {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [tc.model_dump() for tc in tool_calls],
+                        },
+                        {"role": "tool", "tool_call_id": call_id, "content": '{"temp": 22}'},
+                    ],
+                ),
+                tools=cast(Any, _WEATHER_TOOLS),
+            )
+        )
+        assert turn2.choices[0].message.content == "Sunny"
+
+        model_msg = next(content for content in captured["contents"] if content["role"] == "model")
+        fc_part = next(part for part in model_msg["parts"] if "function_call" in part)
+        assert fc_part["thought_signature"] == "e2e-sig"


### PR DESCRIPTION
# What does this PR do?

Persists Gemini `thought_signature` values across OpenAI chat tool-call round trips in the Vertex AI provider so Gemini 3 multi-step function calling works after restarts and across multiple workers.

Gemini 3 requires a `thought_signature` on the first `functionCall` of each step when prior tool results are replayed. Those signatures are not part of the shared OpenAI API surface, so OGX stores them server-side in a KV backend keyed by tool call id.

- Adds optional `thought_signature_store: KVStoreReference` on `VertexAIConfig` (sample/distros use `kv_default` / `vertexai_thought_signatures`)
- Extracts signatures from Gemini responses and re-emits them on subsequent requests
- Omits `thought_signature` on store miss (safe for Gemini 2.x); parallel siblings correctly omit the key
- Does **not** expose `thought_signature` on OpenAI/Responses API models

Closes #6419

Supersedes the in-memory approach in #6430.

## Test Plan

- [x] Thought-signature unit suite (extract / emit / store / multi-worker adapter round trip)

```bash
uv run pytest tests/unit/providers/inference/vertexai/test_thought_signature_roundtrip.py -q --tb=short
```

```
14 passed in 0.02s
```

- [x] Full Vertex AI unit suite (regression)

```bash
uv run pytest tests/unit/providers/inference/vertexai/ -q --tb=short
```

```
289 passed in 0.36s
```

- [x] Live end-to-end validation with a Pydantic-based agent doing multi-step tool calling through OGX against Vertex AI Gemini 3

- Exercised a real multi-turn agent workflow with tool calls routed through OGX to Vertex AI
- Round trip completed successfully; thought signatures were persisted in the configured KV store across tool-call steps
