### PR TITLE
fix(docs): correct list-deps CLI commands after the OGX rename

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -352,6 +352,26 @@ repos:
         language: system
         types: [python]
         pass_filenames: true
+      - id: no-stale-list-deps-cli
+        name: Block removed llama CLI and invalid top-level ogx list-deps
+        entry: bash
+        language: system
+        pass_filenames: true
+        files: '^(docs/|.*\.mdx?$)'
+        args:
+          - -c
+          - |
+            matches=$(grep -EnH '\bllama stack list-deps\b|\bogx list-deps\b' "$@" || true)
+            if [ -n "$matches" ]; then
+              echo
+              echo "Stale list-deps CLI usage found."
+              echo "The 'llama' CLI entry point was removed and there is no top-level 'ogx list-deps' command."
+              echo "Use 'ogx stack list-deps' instead."
+              echo
+              echo "$matches"
+              exit 1
+            fi
+            exit 0
 
 # markdownlint must run after distro-codegen and provider-codegen which generate markdown files
 -   repo: https://github.com/igorshubovych/markdownlint-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -372,6 +372,7 @@ repos:
               exit 1
             fi
             exit 0
+          - --
 
 # markdownlint must run after distro-codegen and provider-codegen which generate markdown files
 -   repo: https://github.com/igorshubovych/markdownlint-cli

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ Some tips about common tasks you work on while contributing to OGX:
 
 ### Installing dependencies of distributions
 
-When installing dependencies for a distribution, you can use `ogx list-deps` to view and install the required packages.
+When installing dependencies for a distribution, you can use `ogx stack list-deps` to view and install the required packages.
 
 Example:
 
@@ -238,10 +238,10 @@ git clone https://github.com/ogx-ai/ogx-client-python.git
 cd ogx
 
 # Show dependencies for a distribution
-ogx list-deps <distro-name>
+ogx stack list-deps <distro-name>
 
 # Install dependencies
-ogx list-deps <distro-name> | xargs -L1 uv pip install
+ogx stack list-deps <distro-name> | xargs -L1 uv pip install
 ```
 
 ### Updating distribution configurations

--- a/docs/blog/2026-01-30-how-to-get-started.md
+++ b/docs/blog/2026-01-30-how-to-get-started.md
@@ -53,7 +53,7 @@ If you already have Ollama installed as a service, you can simply pull the model
 
 ```bash
 ollama pull gpt-oss:20b
-uv run --with ogx ogx list-deps --providers inference=remote::ollama --format uv | sh
+uv run --with ogx ogx stack list-deps --providers inference=remote::ollama --format uv | sh
 uv run --with ogx ogx stack run --providers inference=remote::ollama
 
 ```
@@ -75,7 +75,7 @@ For a more feature-rich setup, you can use the starter distribution which gives 
 ```bash
 ollama serve > /dev/null 2>&1 &
 ollama run gpt-oss:20b --keepalive 60m # you can exit this once the model is running due to --keepalive
-uv run --with ogx ogx list-deps starter --format uv | sh
+uv run --with ogx ogx stack list-deps starter --format uv | sh
 export OLLAMA_URL=http://localhost:11434/v1
 uv run --with ogx ogx run starter
 

--- a/docs/blog/2026-03-20-open-responses-openai-compatibility.md
+++ b/docs/blog/2026-03-20-open-responses-openai-compatibility.md
@@ -192,7 +192,7 @@ Whether you're prototyping locally or deploying at scale, OGX makes it easy:
 uv venv --python 3.12 --seed
 source .venv/bin/activate
 uv pip install -U ogx
-uv run ogx list-deps starter | xargs -L1 uv pip install
+uv run ogx stack list-deps starter | xargs -L1 uv pip install
 
 # Start Ollama and pull a model
 ollama serve

--- a/docs/docs/building_applications/rag.mdx
+++ b/docs/docs/building_applications/rag.mdx
@@ -20,7 +20,7 @@ RAG enables your applications to reference and recall information from external 
 In one terminal, start the OGX server:
 
 ```bash
-ogx list-deps starter | xargs -L1 uv pip install
+ogx stack list-deps starter | xargs -L1 uv pip install
 ogx run starter
 ```
 

--- a/docs/docs/contributing/index.mdx
+++ b/docs/docs/contributing/index.mdx
@@ -235,7 +235,7 @@ Some tips about common tasks you work on while contributing to OGX:
 
 ### Installing dependencies of distributions
 
-When installing dependencies for a distribution, you can use `ogx list-deps` to view and install the required packages.
+When installing dependencies for a distribution, you can use `ogx stack list-deps` to view and install the required packages.
 
 Example:
 
@@ -246,10 +246,10 @@ git clone https://github.com/ogx-ai/ogx-client-python.git
 cd ogx
 
 # Show dependencies for a distribution
-ogx list-deps <distro-name>
+ogx stack list-deps <distro-name>
 
 # Install dependencies
-ogx list-deps <distro-name> | xargs -L1 uv pip install
+ogx stack list-deps <distro-name> | xargs -L1 uv pip install
 ```
 
 ### Updating distribution configurations

--- a/docs/docs/contributing/new_api_provider.mdx
+++ b/docs/docs/contributing/new_api_provider.mdx
@@ -67,7 +67,7 @@ def get_base_url(self) -> str:
 
 ## Testing the Provider
 
-Before running tests, you must have required dependencies installed. This depends on the providers or distributions you are testing. For example, if you are testing the `together` distribution, install its dependencies with `ogx list-deps together | xargs -L1 uv pip install`.
+Before running tests, you must have required dependencies installed. This depends on the providers or distributions you are testing. For example, if you are testing the `together` distribution, install its dependencies with `ogx stack list-deps together | xargs -L1 uv pip install`.
 
 ### 1. Integration Testing
 

--- a/docs/docs/distributions/building_distro.mdx
+++ b/docs/docs/distributions/building_distro.mdx
@@ -23,7 +23,7 @@ import TabItem from '@theme/TabItem';
 <Tabs>
 <TabItem value="container" label="Building a container">
 
-Use the Containerfile at `containers/Containerfile`, which installs `ogx`, resolves distribution dependencies via `ogx list-deps`, and sets the entrypoint to `ogx stack run`.
+Use the Containerfile at `containers/Containerfile`, which installs `ogx`, resolves distribution dependencies via `ogx stack list-deps`, and sets the entrypoint to `ogx stack run`.
 
 **Single-architecture build:**
 

--- a/docs/docs/distributions/importing_as_library.mdx
+++ b/docs/docs/distributions/importing_as_library.mdx
@@ -12,7 +12,7 @@ This avoids the overhead of setting up a server.
 ```bash
 # setup
 uv pip install ogx ogx-client
-ogx list-deps starter | xargs -L1 uv pip install
+ogx stack list-deps starter | xargs -L1 uv pip install
 ```
 
 ```python

--- a/docs/docs/distributions/self_hosted_distro/nvidia.md
+++ b/docs/docs/distributions/self_hosted_distro/nvidia.md
@@ -153,7 +153,7 @@ If you've set up your local development environment, you can also install the di
 
 ```bash
 INFERENCE_MODEL=meta-llama/Llama-3.1-8B-Instruct
-ogx list-deps nvidia | xargs -L1 uv pip install
+ogx stack list-deps nvidia | xargs -L1 uv pip install
 NVIDIA_API_KEY=$NVIDIA_API_KEY \
 INFERENCE_MODEL=$INFERENCE_MODEL \
 ogx stack run ./config.yaml \

--- a/docs/docs/providers/external/external-providers-guide.mdx
+++ b/docs/docs/providers/external/external-providers-guide.mdx
@@ -239,6 +239,6 @@ server:
   port: 8321
 ```
 
-No other steps are required beyond installing dependencies with `ogx list-deps <distro> | xargs -L1 uv pip install` and then running `ogx stack run`. The CLI will use `module` to install the provider dependencies, retrieve the spec, etc.
+No other steps are required beyond installing dependencies with `ogx stack list-deps <distro> | xargs -L1 uv pip install` and then running `ogx stack run`. The CLI will use `module` to install the provider dependencies, retrieve the spec, etc.
 
 The provider will now be available in OGX with the type `remote::ramalama`.

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -110,7 +110,7 @@
     "!uv pip install ogx ogx-client\n",
     "\n",
     "# Installs dependencies for the starter distribution\n",
-    "!uv run --with ogx llama stack list-deps starter | xargs -L1 uv pip install"
+    "!uv run --with ogx ogx stack list-deps starter | xargs -L1 uv pip install"
    ]
   },
   {

--- a/docs/getting_started_ogx_api.ipynb
+++ b/docs/getting_started_ogx_api.ipynb
@@ -223,7 +223,7 @@
     "  del os.environ[\"UV_SYSTEM_PYTHON\"]\n",
     "\n",
     "# this command installs all the dependencies needed for the llama stack server\n",
-    "!uv run --with ogx llama stack list-deps llama_api | xargs -L1 uv pip install\n",
+    "!uv run --with ogx ogx stack list-deps llama_api | xargs -L1 uv pip install\n",
     "!uv run --with ogx llama stack run llama_api\n",
     "\n",
     "def run_ogx_server_background():\n",

--- a/docs/notebooks/Llama_Stack_Agent_Workflows.ipynb
+++ b/docs/notebooks/Llama_Stack_Agent_Workflows.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "# NBVAL_SKIP\n",
     "!pip install -U ogx ogx-client\n",
-    "llama stack list-deps fireworks | xargs -L1 uv pip install\n"
+    "ogx stack list-deps fireworks | xargs -L1 uv pip install\n"
    ]
   },
   {

--- a/docs/notebooks/crewai/Llama_Stack_CrewAI.ipynb
+++ b/docs/notebooks/crewai/Llama_Stack_CrewAI.ipynb
@@ -136,7 +136,7 @@
     "    \"\"\"Build and run OGX server in one step using --run flag\"\"\"\n",
     "    log_file = open(\"ogx_server.log\", \"w\")\n",
     "    process = subprocess.Popen(\n",
-    "        \"uv run --with ogx llama stack list-deps starter | xargs -L1 uv pip install\",\n",
+    "        \"uv run --with ogx ogx stack list-deps starter | xargs -L1 uv pip install\",\n",
     "        \"uv run --with ogx llama stack run starter\",\n",
     "        shell=True,\n",
     "        stdout=log_file,\n",

--- a/docs/notebooks/langchain/Llama_Stack_LangChain.ipynb
+++ b/docs/notebooks/langchain/Llama_Stack_LangChain.ipynb
@@ -105,7 +105,7 @@
     "    \"\"\"Build and run OGX server in one step using --run flag\"\"\"\n",
     "    log_file = open(\"ogx_server.log\", \"w\")\n",
     "    process = subprocess.Popen(\n",
-    "        \"uv run --with ogx llama stack list-deps starter | xargs -L1 uv pip install\",\n",
+    "        \"uv run --with ogx ogx stack list-deps starter | xargs -L1 uv pip install\",\n",
     "        \"uv run --with ogx llama stack run starter\",\n",
     "        shell=True,\n",
     "        stdout=log_file,\n",

--- a/docs/notebooks/nvidia/tool_calling/1_data_preparation.ipynb
+++ b/docs/notebooks/nvidia/tool_calling/1_data_preparation.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "source": [
     "```bash\n",
-    "uv run --with ogx llama stack list-deps nvidia | xargs -L1 uv pip install\n",
+    "uv run --with ogx ogx stack list-deps nvidia | xargs -L1 uv pip install\n",
     "```"
    ]
   },

--- a/docs/quick_start.ipynb
+++ b/docs/quick_start.ipynb
@@ -148,7 +148,7 @@
     "  del os.environ[\"UV_SYSTEM_PYTHON\"]\n",
     "\n",
     "# this command installs all the dependencies needed for the llama stack server with the ollama inference provider\n",
-    "!uv run --with ogx llama stack list-deps starter | xargs -L1 uv pip install\n",
+    "!uv run --with ogx ogx stack list-deps starter | xargs -L1 uv pip install\n",
     "\n",
     "def run_ogx_server_background():\n",
     "    log_file = open(\"ogx_server.log\", \"w\")\n",

--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -89,7 +89,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
 1. **Install dependencies**:
 
    ```bash
-   ogx list-deps starter | xargs -L1 uv pip install
+   ogx stack list-deps starter | xargs -L1 uv pip install
    ```
 
 2. **Start the distribution**:

--- a/src/ogx/cli/stack/list_deps.py
+++ b/src/ogx/cli/stack/list_deps.py
@@ -15,7 +15,7 @@ class StackListDeps(Subcommand):
         super().__init__()
         self.parser = subparsers.add_parser(
             "list-deps",
-            prog="ogx list-deps",
+            prog="ogx stack list-deps",
             description="list the dependencies for a ogx distribution",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )

--- a/src/ogx/core/library_client.py
+++ b/src/ogx/core/library_client.py
@@ -708,7 +708,7 @@ class AsyncOGXAsLibraryClient(AsyncOgxClient):
             else:
                 prefix = "!" if in_notebook() else ""  # type: ignore[no-untyped-call]
                 cprint(
-                    f"Please run:\n\n{prefix}ogx list-deps {self.config_path_or_distro_name} | xargs -L1 uv pip install\n\n",
+                    f"Please run:\n\n{prefix}ogx stack list-deps {self.config_path_or_distro_name} | xargs -L1 uv pip install\n\n",
                     "yellow",
                     file=sys.stderr,
                 )

--- a/src/ogx/distributions/nvidia/doc_template.md
+++ b/src/ogx/distributions/nvidia/doc_template.md
@@ -159,7 +159,7 @@ If you've set up your local development environment, you can also install the di
 
 ```bash
 INFERENCE_MODEL=meta-llama/Llama-3.1-8B-Instruct
-ogx list-deps nvidia | xargs -L1 uv pip install
+ogx stack list-deps nvidia | xargs -L1 uv pip install
 NVIDIA_API_KEY=$NVIDIA_API_KEY \
 INFERENCE_MODEL=$INFERENCE_MODEL \
 ogx stack run ./config.yaml \

--- a/src/ogx/providers/remote/inference/nvidia/NVIDIA.md
+++ b/src/ogx/providers/remote/inference/nvidia/NVIDIA.md
@@ -20,7 +20,7 @@ Build the NVIDIA environment:
 
 ```bash
 uv pip install ogx-client
-uv run ogx list-deps nvidia | xargs -L1 uv pip install
+uv run ogx stack list-deps nvidia | xargs -L1 uv pip install
 ```
 
 ### Basic Usage using the OGX Python Client

--- a/src/ogx/providers/remote/inference/nvidia/__init__.py
+++ b/src/ogx/providers/remote/inference/nvidia/__init__.py
@@ -8,7 +8,7 @@ from .config import NVIDIAConfig
 
 
 async def get_adapter_impl(config: NVIDIAConfig, _deps):
-    # import dynamically so `ogx list-deps` does not fail due to missing dependencies
+    # import dynamically so `ogx stack list-deps` does not fail due to missing dependencies
     from .nvidia import NVIDIAInferenceAdapter
 
     if not isinstance(config, NVIDIAConfig):

--- a/tests/unit/cli/test_stack_list_deps.py
+++ b/tests/unit/cli/test_stack_list_deps.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 """
-Unit tests for `ogx list-deps` CLI command.
+Unit tests for `ogx stack list-deps` CLI command.
 
 Categories:
   - Arguments: --providers flag is registered and parsed correctly


### PR DESCRIPTION
Replace the removed 'llama stack list-deps' command with 'ogx stack list-deps' in the quick-start and getting-started notebooks, and replace the invalid top-level 'ogx list-deps' form with 'ogx stack list-deps' in the contributing guides, blog posts, and provider and distribution docs.

Also correct the user-facing library-client hint, the NVIDIA provider docs and its doc template, and the list-deps argparse prog string, and add a pre-commit hook that blocks the removed 'llama' CLI form and the invalid top-level 'ogx list-deps' form in docs.

closes #6456 