### PR TITLE
fix(vector_io): validate chunk_overlap_tokens < max_chunk_size_tokens for static chunking

### DIFF
--- a/src/ogx_api/vector_io/models.py
+++ b/src/ogx_api/vector_io/models.py
@@ -356,6 +356,12 @@ class VectorStoreChunkingStrategyStaticConfig(BaseModel):
     chunk_overlap_tokens: int = DEFAULT_CHUNK_OVERLAP_TOKENS
     max_chunk_size_tokens: int = Field(DEFAULT_CHUNK_SIZE_TOKENS, ge=100, le=4096)
 
+    @model_validator(mode="after")
+    def validate_config(self) -> "VectorStoreChunkingStrategyStaticConfig":
+        if self.chunk_overlap_tokens >= self.max_chunk_size_tokens:
+            raise ValueError("chunk_overlap_tokens must be less than max_chunk_size_tokens")
+        return self
+
 
 @json_schema_type
 class VectorStoreChunkingStrategyStatic(BaseModel):

--- a/tests/unit/providers/vector_io/test_chunking_strategy_static_config.py
+++ b/tests/unit/providers/vector_io/test_chunking_strategy_static_config.py
@@ -1,0 +1,55 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import pytest
+
+from ogx_api import VectorStoreChunkingStrategyStaticConfig
+
+
+def test_static_config_validation_overlap_equal_to_size():
+    """chunk_overlap_tokens == max_chunk_size_tokens must be rejected.
+
+    Regression test: unvalidated, this combination reaches
+    make_overlapped_chunks()'s range(0, len(tokens), window_len - overlap_len)
+    with a zero step, raising ValueError: range() arg 3 must not be zero deep
+    inside file processing instead of a clear validation error at request time.
+    """
+    with pytest.raises(ValueError, match="chunk_overlap_tokens must be less than max_chunk_size_tokens"):
+        VectorStoreChunkingStrategyStaticConfig(
+            max_chunk_size_tokens=100,
+            chunk_overlap_tokens=100,
+        )
+
+
+def test_static_config_validation_overlap_greater_than_size():
+    """chunk_overlap_tokens > max_chunk_size_tokens must be rejected.
+
+    Regression test: unvalidated, this combination gives
+    make_overlapped_chunks() a negative step, so the range is empty and it
+    silently returns zero chunks, discarding the document with a misleading
+    "No chunks were generated from the file" error instead of a validation error.
+    """
+    with pytest.raises(ValueError, match="chunk_overlap_tokens must be less than max_chunk_size_tokens"):
+        VectorStoreChunkingStrategyStaticConfig(
+            max_chunk_size_tokens=100,
+            chunk_overlap_tokens=150,
+        )
+
+
+def test_static_config_validation_overlap_less_than_size_is_valid():
+    """A properly configured overlap/size pair must still construct normally."""
+    config = VectorStoreChunkingStrategyStaticConfig(
+        max_chunk_size_tokens=800,
+        chunk_overlap_tokens=400,
+    )
+    assert config.max_chunk_size_tokens == 800
+    assert config.chunk_overlap_tokens == 400
+
+
+def test_static_config_default_values_are_valid():
+    """The default chunk_overlap_tokens/max_chunk_size_tokens must not trip the new validator."""
+    config = VectorStoreChunkingStrategyStaticConfig()
+    assert config.chunk_overlap_tokens < config.max_chunk_size_tokens


### PR DESCRIPTION
## What changed

`VectorStoreChunkingStrategyStaticConfig` in `src/ogx_api/vector_io/models.py` now has a `model_validator(mode="after")` that rejects `chunk_overlap_tokens >= max_chunk_size_tokens`, matching the validator already present on its sibling `VectorStoreChunkingStrategyContextualConfig` in the same file.

## Why

`chunking_strategy` is accepted directly from API clients on the OpenAI-compatible vector store endpoints (`openai_attach_file_to_vector_store` in `src/ogx/providers/utils/memory/openai_vector_store_mixin.py`), so a client can request `type: "static"` with any `chunk_overlap_tokens`/`max_chunk_size_tokens` combination. Those values flowed unchecked into `make_overlapped_chunks()` in `src/ogx/providers/utils/memory/vector_store.py`:

```python
for i in range(0, len(tokens), window_len - overlap_len):
```

Two broken cases, both reachable from an ordinary attach-file request:

1. `chunk_overlap_tokens == max_chunk_size_tokens`: `window_len - overlap_len == 0`, so `range(0, len(tokens), 0)` raises `ValueError: range() arg 3 must not be zero`. This propagates through every file processor (`pypdf.py`, `markitdown_processor.py`, `docling.py`, `unstructured.py`, none of which catch it) into `openai_attach_file_to_vector_store`'s broad `except Exception as e`, which sets the file status to `"failed"` with the raw Python error message leaking to the API caller.
2. `chunk_overlap_tokens > max_chunk_size_tokens`: the step is negative, so the range is empty and `make_overlapped_chunks` silently returns zero chunks with no exception. The file ends up `"failed"` with `message="No chunks were generated from the file"`, a message that reads like the file was empty or unparseable, when the real cause is the overlap/size misconfiguration. The extracted document text is silently discarded.

The contextual chunking strategy already guards against exactly this with its own `model_validator`. This PR gives the static strategy the same guard.

## How to test

Before the fix:
```python
from ogx_api import VectorStoreChunkingStrategyStaticConfig
VectorStoreChunkingStrategyStaticConfig(max_chunk_size_tokens=100, chunk_overlap_tokens=100)  # constructs fine, breaks later at chunk time
```

After the fix, this raises a clear `ValueError: chunk_overlap_tokens must be less than max_chunk_size_tokens` at request-validation time instead of surfacing as a confusing "failed" file status later.

Added `tests/unit/providers/vector_io/test_chunking_strategy_static_config.py` with 4 tests:
- `chunk_overlap_tokens == max_chunk_size_tokens` raises
- `chunk_overlap_tokens > max_chunk_size_tokens` raises
- a properly configured overlap/size pair still constructs normally
- the class's own defaults remain valid (regression guard against the validator accidentally rejecting the defaults)

The first two tests fail against the current code (no error is raised) and pass with the fix. The last two are sanity checks that the new validator does not reject valid configurations, including the class's own defaults.

Fixes #6448
