### PR TITLE
docs: Repair broken GitHub links on 1.0.

### DIFF
--- a/docs/docs/building_applications/tools.mdx
+++ b/docs/docs/building_applications/tools.mdx
@@ -185,7 +185,7 @@ Once defined, simply pass the tool to the agent config. `Agent` will take care o
 agent = Agent(client, ..., tools=[my_tool])
 ```
 
-Refer to [ogx-apps](https://github.com/ogx-ai/ogx-apps/) for an example of how to use client provided tools.
+Refer to [Llama Stack Apps](https://github.com/ogx-ai/llama-stack-apps/) for an example of how to use client provided tools.
 
 ## Complete Examples
 
@@ -310,4 +310,4 @@ response = agent.create_turn(
 - **[RAG (Retrieval Augmented Generation)](/docs/building_applications/rag)** - Using knowledge retrieval tools
 - **[Agent Execution Loop](/docs/building_applications/agent_execution_loop)** - Understanding tool execution flow
 - **[Building AI Applications Notebook](https://github.com/ogx-ai/ogx/blob/main/docs/getting_started.ipynb)** - Comprehensive examples
-- **[OGX Apps Examples](https://github.com/ogx-ai/ogx-apps)** - Real-world tool implementations
+- **[Llama Stack Apps Examples](https://github.com/ogx-ai/llama-stack-apps)** - Real-world tool implementations

--- a/docs/docs/contributing/index.mdx
+++ b/docs/docs/contributing/index.mdx
@@ -222,7 +222,7 @@ This process helps ensure that new providers are well-designed, avoid duplicatio
   that describes the configuration. These descriptions will be used to generate the provider
   documentation.
 - When possible, use keyword arguments only when calling functions.
-- OGX utilizes [custom Exception classes](https://github.com/ogx-ai/ogx/blob/main/ogx/apis/common/errors.py) for certain Resources that should be used where applicable.
+- OGX utilizes [custom Exception classes](https://github.com/ogx-ai/ogx/blob/main/src/ogx_api/common/errors.py) for certain Resources that should be used where applicable.
 
 ### License
 

--- a/docs/docs/contributing/new_api_provider.mdx
+++ b/docs/docs/contributing/new_api_provider.mdx
@@ -12,9 +12,9 @@ This guide will walk you through the process of adding a new API provider to OGX
 
 
 - Begin by reviewing the [core concepts](../concepts/) of OGX and choose the API your provider belongs to (Inference, Responses, VectorIO, etc.)
-- Determine the provider type ([Remote](https://github.com/ogx-ai/ogx/tree/main/ogx/providers/remote) or [Inline](https://github.com/ogx-ai/ogx/tree/main/ogx/providers/inline)). Remote providers make requests to external services, while inline providers execute implementation locally.
-- Add your provider to the appropriate [Registry](https://github.com/ogx-ai/ogx/tree/main/ogx/providers/registry/). Specify pip dependencies necessary.
-- Update any distribution [Templates](https://github.com/ogx-ai/ogx/tree/main/ogx/distributions/) `config.yaml` files if they should include your provider by default. Run [./scripts/distro_codegen.py](https://github.com/ogx-ai/ogx/blob/main/scripts/distro_codegen.py) if necessary. Note that `distro_codegen.py` will fail if the new provider causes any distribution template to attempt to import provider-specific dependencies. This usually means the distribution's `get_distribution_template()` code path should only import any necessary Config or model alias definitions from each provider and not the provider's actual implementation.
+- Determine the provider type ([Remote](https://github.com/ogx-ai/ogx/tree/main/src/ogx/providers/remote) or [Inline](https://github.com/ogx-ai/ogx/tree/main/src/ogx/providers/inline)). Remote providers make requests to external services, while inline providers execute implementation locally.
+- Add your provider to the appropriate [Registry](https://github.com/ogx-ai/ogx/tree/main/src/ogx/providers/registry/). Specify pip dependencies necessary.
+- Update any distribution [Templates](https://github.com/ogx-ai/ogx/tree/main/src/ogx/distributions/) `config.yaml` files if they should include your provider by default. Run [./scripts/distro_codegen.py](https://github.com/ogx-ai/ogx/blob/main/scripts/distro_codegen.py) if necessary. Note that `distro_codegen.py` will fail if the new provider causes any distribution template to attempt to import provider-specific dependencies. This usually means the distribution's `get_distribution_template()` code path should only import any necessary Config or model alias definitions from each provider and not the provider's actual implementation.
 
 
 Here are some example PRs to help you get started:
@@ -88,7 +88,7 @@ Consult [tests/unit/README.md](https://github.com/ogx-ai/ogx/blob/main/tests/uni
 ### 3. Additional end-to-end testing
 
 1. Start a OGX server with your new provider
-2. Verify compatibility with existing client scripts in the [ogx-apps](https://github.com/ogx-ai/ogx-apps/tree/main) repository
+2. Verify compatibility with existing client scripts in the [Llama Stack Apps](https://github.com/ogx-ai/llama-stack-apps/tree/main) repository
 3. Document which scripts are compatible with your provider
 
 ## Submitting Your PR

--- a/docs/docs/contributing/new_vector_database.mdx
+++ b/docs/docs/contributing/new_vector_database.mdx
@@ -39,7 +39,7 @@ filtering, sorting, and aggregating vectors.
         - `YourVectorIOAdapter.query_chunks()`
         - `YourVectorIOAdapter.delete_chunks()`
 3. **Add to Registry**: Register your provider in the appropriate registry file.
-   - Update [ogx/providers/registry/vector_io.py](https://github.com/ogx-ai/ogx/blob/main/ogx/providers/registry/vector_io.py) to include your new provider.
+   - Update [src/ogx/providers/registry/vector_io.py](https://github.com/ogx-ai/ogx/blob/main/src/ogx/providers/registry/vector_io.py) to include your new provider.
 ```python
 from ogx.providers.registry.specs import InlineProviderSpec
 from ogx.providers.registry.api import Api

--- a/docs/docs/distributions/self_hosted_distro/nvidia.md
+++ b/docs/docs/distributions/self_hosted_distro/nvidia.md
@@ -51,13 +51,9 @@ The deployed platform includes the NIM Proxy microservice, which is the service 
 
 The NeMo Data Store microservice serves as the default file storage solution for the NeMo microservices platform. It exposts APIs compatible with the Hugging Face Hub client (`HfApi`), so you can use the client to interact with Data Store. The `NVIDIA_DATASETS_URL` environment variable should point to your NeMo Data Store endpoint.
 
-See the [NVIDIA Datasetio docs](https://github.com/ogx-ai/ogx/blob/main/ogx/providers/remote/datasetio/nvidia/README.md) for supported features and example usage.
-
 ### Eval API: NeMo Evaluator
 
 The NeMo Evaluator microservice supports evaluation of LLMs. Launching an Evaluation job with NeMo Evaluator requires an Evaluation Config (an object that contains metadata needed by the job). A OGX Benchmark maps to an Evaluation Config, so registering a Benchmark creates an Evaluation Config in NeMo Evaluator. The `NVIDIA_EVALUATOR_URL` environment variable should point to your NeMo Microservices endpoint.
-
-See the [NVIDIA Eval docs](https://github.com/ogx-ai/ogx/blob/main/ogx/providers/remote/eval/nvidia/README.md) for supported features and example usage.
 
 ## Deploying models
 

--- a/docs/docs/getting_started/libraries.mdx
+++ b/docs/docs/getting_started/libraries.mdx
@@ -13,7 +13,7 @@ Since OGX is OpenAI-compatible, you can use any OpenAI SDK in any language. We a
 |  **Language** |  **Client SDK** | **Package** |
 | :----: | :----: | :----: |
 | Python |  [ogx-client-python](https://github.com/ogx-ai/ogx-client-python) | [![PyPI version](https://img.shields.io/pypi/v/ogx-client.svg)](https://pypi.org/project/ogx-client/)
-| Node   | [ogx-client-node](https://github.com/ogx-ai/ogx-client-node) | [![NPM version](https://img.shields.io/npm/v/ogx-client.svg)](https://npmjs.org/package/ogx-client)
+| Node   | [ogx-client-typescript](https://github.com/ogx-ai/ogx-client-typescript) | [![NPM version](https://img.shields.io/npm/v/ogx-client.svg)](https://npmjs.org/package/ogx-client)
 
 :::tip OpenAI SDK Compatibility
 Any language with an OpenAI SDK (Python, Node, Go, Ruby, Java, etc.) works with OGX out of the box. Just point `base_url` to your OGX server.

--- a/docs/docs/providers/external/external-providers-list.mdx
+++ b/docs/docs/providers/external/external-providers-list.mdx
@@ -4,8 +4,8 @@ Here's a list of known external providers that you can use with OGX:
 
 | Name | Description | API | Type | Repository |
 |------|-------------|-----|------|------------|
-| KubeFlow Training | Train models with KubeFlow | Post Training | Remote | [ogx-provider-kft](https://github.com/opendatahub-io/ogx-provider-kft) |
-| KubeFlow Pipelines | Train models with KubeFlow Pipelines | Post Training | Inline **and** Remote | [ogx-provider-kfp-trainer](https://github.com/opendatahub-io/ogx-provider-kfp-trainer) |
+| KubeFlow Training | Train models with KubeFlow | Post Training | Remote | [llama-stack-provider-kft](https://github.com/opendatahub-io/llama-stack-provider-kft) |
+| KubeFlow Pipelines | Train models with KubeFlow Pipelines | Post Training | Inline **and** Remote | [llama-stack-provider-kfp-trainer](https://github.com/opendatahub-io/llama-stack-provider-kfp-trainer) |
 | RamaLama | Inference models with RamaLama | Inference | Remote | [ramalama-stack](https://github.com/containers/ramalama-stack) |
-| TrustyAI LM-Eval | Evaluate models with TrustyAI LM-Eval | Eval | Remote | [ogx-provider-lmeval](https://github.com/trustyai-explainability/ogx-provider-lmeval) |
-| MongoDB | VectorIO with MongoDB | Vector_IO | Remote | [mongodb-ogx](https://github.com/mongodb-partners/mongodb-ogx) |
+| TrustyAI LM-Eval | Evaluate models with TrustyAI LM-Eval | Eval | Remote | [llama-stack-provider-lmeval](https://github.com/trustyai-explainability/llama-stack-provider-lmeval) |
+| MongoDB | VectorIO with MongoDB | Vector_IO | Remote | [mongodb-llama-stack](https://github.com/mongodb-partners/mongodb-llama-stack) |

--- a/docs/docs/references/evals_reference/index.mdx
+++ b/docs/docs/references/evals_reference/index.mdx
@@ -350,10 +350,10 @@ You need to write a script [example convert script](https://gist.github.com/yanx
 ### Find scoring function for your new benchmark
 The purpose of scoring function is to calculate the score for each example based on candidate model generation result and expected_answer. It also aggregates the scores from all the examples and generate the final evaluate results.
 
-Firstly, you can see if the existing [ogx scoring functions](https://github.com/ogx-ai/ogx/tree/main/ogx/providers/inline/scoring) can fulfill your need. If not, you need to write a new scoring function based on what benchmark author / other open source repo describe.
+Firstly, you can see if the existing OGX scoring functions can fulfill your need. If not, you need to write a new scoring function based on what benchmark author / other open source repo describe.
 
 ### Add new benchmark into template
-Firstly, you need to add the evaluation dataset associated with your benchmark under `datasets` resource in the [open-benchmark](https://github.com/ogx-ai/ogx/blob/main/ogx/distributions/open-benchmark/config.yaml)
+Firstly, you need to add the evaluation dataset associated with your benchmark under `datasets` resource in the [open-benchmark](https://github.com/ogx-ai/ogx/blob/main/src/ogx/distributions/open-benchmark/config.yaml)
 
 Secondly, you need to add the new benchmark you just created under the `benchmarks` resource in the same template. To add the new benchmark, you need to have
 - `benchmark_id`: identifier of the benchmark

--- a/docs/docs/references/python_sdk_reference/index.md
+++ b/docs/docs/references/python_sdk_reference/index.md
@@ -41,10 +41,10 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="get /v1/toolgroups">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/toolgroup_list_response.py">ToolgroupListResponse</a></code>
-- <code title="get /v1/toolgroups/{toolgroup_id}">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">get</a>(toolgroup_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_group.py">ToolGroup</a></code>
-- <code title="post /v1/toolgroups">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/toolgroup_register_params.py">params</a>) -> None</code>
-- <code title="delete /v1/toolgroups/{toolgroup_id}">client.toolgroups.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/toolgroups.py">unregister</a>(toolgroup_id) -> None</code>
+- <code title="get /v1/toolgroups">client.toolgroups.list() -> ToolgroupListResponse</code>
+- <code title="get /v1/toolgroups/{toolgroup_id}">client.toolgroups.get(toolgroup_id) -> ToolGroup</code>
+- <code title="post /v1/toolgroups">client.toolgroups.register(\*\*params) -> None</code>
+- <code title="delete /v1/toolgroups/{toolgroup_id}">client.toolgroups.unregister(toolgroup_id) -> None</code>
 
 ## Tools
 
@@ -56,8 +56,8 @@ from ogx_client.types import ListToolsResponse, Tool, ToolListResponse
 
 Methods:
 
-- <code title="get /v1/tools">client.tools.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tools.py">list</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_list_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_list_response.py">ToolListResponse</a></code>
-- <code title="get /v1/tools/{tool_name}">client.tools.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tools.py">get</a>(tool_name) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool.py">Tool</a></code>
+- <code title="get /v1/tools">client.tools.list(\*\*params) -> ToolListResponse</code>
+- <code title="get /v1/tools/{tool_name}">client.tools.get(tool_name) -> Tool</code>
 
 ## ToolRuntime
 
@@ -69,15 +69,15 @@ from ogx_client.types import ToolDef, ToolInvocationResult
 
 Methods:
 
-- <code title="post /v1/tool-runtime/invoke">client.tool_runtime.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/tool_runtime.py">invoke_tool</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime_invoke_tool_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_invocation_result.py">ToolInvocationResult</a></code>
-- <code title="get /v1/tool-runtime/list-tools">client.tool_runtime.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/tool_runtime.py">list_tools</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime_list_tools_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_def.py">JSONLDecoder[ToolDef]</a></code>
+- <code title="post /v1/tool-runtime/invoke">client.tool_runtime.invoke_tool(\*\*params) -> ToolInvocationResult</code>
+- <code title="get /v1/tool-runtime/list-tools">client.tool_runtime.list_tools(\*\*params) -> JSONLDecoder[ToolDef]</code>
 
 ### RagTool
 
 Methods:
 
-- <code title="post /v1/tool-runtime/rag-tool/insert">client.tool_runtime.rag_tool.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/rag_tool.py">insert</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime/rag_tool_insert_params.py">params</a>) -> None</code>
-- <code title="post /v1/tool-runtime/rag-tool/query">client.tool_runtime.rag_tool.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/tool_runtime/rag_tool.py">query</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/tool_runtime/rag_tool_query_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/shared/query_result.py">QueryResult</a></code>
+- <code title="post /v1/tool-runtime/rag-tool/insert">client.tool_runtime.rag_tool.insert(\*\*params) -> None</code>
+- <code title="post /v1/tool-runtime/rag-tool/query">client.tool_runtime.rag_tool.query(\*\*params) -> QueryResult</code>
 
 ## Agents
 
@@ -103,8 +103,8 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="post /v1/agents">client.agents.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/agents.py">create</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agent_create_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agent_create_response.py">AgentCreateResponse</a></code>
-- <code title="delete /v1/agents/{agent_id}">client.agents.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/agents.py">delete</a>(agent_id) -> None</code>
+- <code title="post /v1/agents">client.agents.create(\*\*params) -> AgentCreateResponse</code>
+- <code title="delete /v1/agents/{agent_id}">client.agents.delete(agent_id) -> None</code>
 
 ### Session
 
@@ -116,9 +116,9 @@ from ogx_client.types.agents import Session, SessionCreateResponse
 
 Methods:
 
-- <code title="post /v1/agents/{agent_id}/session">client.agents.session.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/session.py">create</a>(agent_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session_create_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session_create_response.py">SessionCreateResponse</a></code>
-- <code title="get /v1/agents/{agent_id}/session/{session_id}">client.agents.session.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/session.py">retrieve</a>(session_id, \*, agent_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session_retrieve_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/session.py">Session</a></code>
-- <code title="delete /v1/agents/{agent_id}/session/{session_id}">client.agents.session.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/session.py">delete</a>(session_id, \*, agent_id) -> None</code>
+- <code title="post /v1/agents/{agent_id}/session">client.agents.session.create(agent_id, \*\*params) -> SessionCreateResponse</code>
+- <code title="get /v1/agents/{agent_id}/session/{session_id}">client.agents.session.retrieve(session_id, \*, agent_id, \*\*params) -> Session</code>
+- <code title="delete /v1/agents/{agent_id}/session/{session_id}">client.agents.session.delete(session_id, \*, agent_id) -> None</code>
 
 ### Steps
 
@@ -130,7 +130,7 @@ from ogx_client.types.agents import StepRetrieveResponse
 
 Methods:
 
-- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}">client.agents.steps.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/steps.py">retrieve</a>(step_id, \*, agent_id, session_id, turn_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/step_retrieve_response.py">StepRetrieveResponse</a></code>
+- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}">client.agents.steps.retrieve(step_id, \*, agent_id, session_id, turn_id) -> StepRetrieveResponse</code>
 
 ### Turn
 
@@ -142,8 +142,8 @@ from ogx_client.types.agents import Turn, TurnCreateResponse
 
 Methods:
 
-- <code title="post /v1/agents/{agent_id}/session/{session_id}/turn">client.agents.turn.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/turn.py">create</a>(session_id, \*, agent_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/turn_create_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/turn_create_response.py">TurnCreateResponse</a></code>
-- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}">client.agents.turn.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/agents/turn.py">retrieve</a>(turn_id, \*, agent_id, session_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/agents/turn.py">Turn</a></code>
+- <code title="post /v1/agents/{agent_id}/session/{session_id}/turn">client.agents.turn.create(session_id, \*, agent_id, \*\*params) -> TurnCreateResponse</code>
+- <code title="get /v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}">client.agents.turn.retrieve(turn_id, \*, agent_id, session_id) -> Turn</code>
 
 ## Datasets
 
@@ -159,10 +159,10 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="get /v1/datasets/{dataset_id}">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">retrieve</a>(dataset_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/dataset_retrieve_response.py">Optional[DatasetRetrieveResponse]</a></code>
-- <code title="get /v1/datasets">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/dataset_list_response.py">DatasetListResponse</a></code>
-- <code title="post /v1/datasets">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/dataset_register_params.py">params</a>) -> None</code>
-- <code title="delete /v1/datasets/{dataset_id}">client.datasets.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasets.py">unregister</a>(dataset_id) -> None</code>
+- <code title="get /v1/datasets/{dataset_id}">client.datasets.retrieve(dataset_id) -> Optional[DatasetRetrieveResponse]</code>
+- <code title="get /v1/datasets">client.datasets.list() -> DatasetListResponse</code>
+- <code title="post /v1/datasets">client.datasets.register(\*\*params) -> None</code>
+- <code title="delete /v1/datasets/{dataset_id}">client.datasets.unregister(dataset_id) -> None</code>
 
 ## Eval
 
@@ -174,8 +174,8 @@ from ogx_client.types import EvaluateResponse, Job
 
 Methods:
 
-- <code title="post /v1/eval/tasks/{benchmark_id}/evaluations">client.eval.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/eval.py">evaluate_rows</a>(benchmark_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/eval_evaluate_rows_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/evaluate_response.py">EvaluateResponse</a></code>
-- <code title="post /v1/eval/tasks/{benchmark_id}/jobs">client.eval.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/eval.py">run_eval</a>(benchmark_id, \*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/eval_run_eval_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/job.py">Job</a></code>
+- <code title="post /v1/eval/tasks/{benchmark_id}/evaluations">client.eval.evaluate_rows(benchmark_id, \*\*params) -> EvaluateResponse</code>
+- <code title="post /v1/eval/tasks/{benchmark_id}/jobs">client.eval.run_eval(benchmark_id, \*\*params) -> Job</code>
 
 ### Jobs
 
@@ -187,9 +187,9 @@ from ogx_client.types.eval import JobStatusResponse
 
 Methods:
 
-- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}/result">client.eval.jobs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">retrieve</a>(job_id, \*, benchmark_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/evaluate_response.py">EvaluateResponse</a></code>
-- <code title="delete /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">cancel</a>(job_id, \*, benchmark_id) -> None</code>
-- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/eval/jobs.py">status</a>(job_id, \*, benchmark_id) -> Optional[JobStatusResponse]</code>
+- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}/result">client.eval.jobs.retrieve(job_id, \*, benchmark_id) -> EvaluateResponse</code>
+- <code title="delete /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.cancel(job_id, \*, benchmark_id) -> None</code>
+- <code title="get /v1/eval/tasks/{benchmark_id}/jobs/{job_id}">client.eval.jobs.status(job_id, \*, benchmark_id) -> Optional[JobStatusResponse]</code>
 
 ## Inspect
 
@@ -201,8 +201,8 @@ from ogx_client.types import HealthInfo, ProviderInfo, RouteInfo, VersionInfo
 
 Methods:
 
-- <code title="get /v1/health">client.inspect.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/inspect.py">health</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/health_info.py">HealthInfo</a></code>
-- <code title="get /v1/version">client.inspect.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/inspect.py">version</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/version_info.py">VersionInfo</a></code>
+- <code title="get /v1/health">client.inspect.health() -> HealthInfo</code>
+- <code title="get /v1/version">client.inspect.version() -> VersionInfo</code>
 
 ## Inference
 
@@ -220,7 +220,7 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="post /v1/inference/embeddings">client.inference.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/inference.py">embeddings</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/inference_embeddings_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/embeddings_response.py">EmbeddingsResponse</a></code>
+- <code title="post /v1/inference/embeddings">client.inference.embeddings(\*\*params) -> EmbeddingsResponse</code>
 
 ## VectorIo
 
@@ -247,8 +247,8 @@ from ogx_client.types import QueryChunksResponse
 
 Methods:
 
-- <code title="post /v1/vector-io/insert">client.vector_io.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_io.py">insert</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_io_insert_params.py">params</a>) -> None</code>
-- <code title="post /v1/vector-io/query">client.vector_io.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_io.py">query</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_io_query_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/query_chunks_response.py">QueryChunksResponse</a></code>
+- <code title="post /v1/vector-io/insert">client.vector_io.insert(\*\*params) -> None</code>
+- <code title="post /v1/vector-io/query">client.vector_io.query(\*\*params) -> QueryChunksResponse</code>
 
 ## VectorDBs
 
@@ -282,10 +282,10 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="get /v1/vector-dbs/{vector_db_id}">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">retrieve</a>(vector_db_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_retrieve_response.py">Optional[VectorDBRetrieveResponse]</a></code>
-- <code title="get /v1/vector-dbs">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_list_response.py">VectorDBListResponse</a></code>
-- <code title="post /v1/vector-dbs">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_register_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/vector_db_register_response.py">VectorDBRegisterResponse</a></code>
-- <code title="delete /v1/vector-dbs/{vector_db_id}">client.vector_dbs.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/vector_dbs.py">unregister</a>(vector_db_id) -> None</code>
+- <code title="get /v1/vector-dbs/{vector_db_id}">client.vector_dbs.retrieve(vector_db_id) -> Optional[VectorDBRetrieveResponse]</code>
+- <code title="get /v1/vector-dbs">client.vector_dbs.list() -> VectorDBListResponse</code>
+- <code title="post /v1/vector-dbs">client.vector_dbs.register(\*\*params) -> VectorDBRegisterResponse</code>
+- <code title="delete /v1/vector-dbs/{vector_db_id}">client.vector_dbs.unregister(vector_db_id) -> None</code>
 
 ## Models
 
@@ -297,10 +297,10 @@ from ogx_client.types import ListModelsResponse, Model, ModelListResponse
 
 Methods:
 
-- <code title="get /v1/models/{model_id}">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">retrieve</a>(model_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model.py">Optional[Model]</a></code>
-- <code title="get /v1/models">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model_list_response.py">ModelListResponse</a></code>
-- <code title="post /v1/models">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model_register_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/model.py">Model</a></code>
-- <code title="delete /v1/models/{model_id}">client.models.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/models.py">unregister</a>(model_id) -> None</code>
+- <code title="get /v1/models/{model_id}">client.models.retrieve(model_id) -> Optional[Model]</code>
+- <code title="get /v1/models">client.models.list() -> ModelListResponse</code>
+- <code title="post /v1/models">client.models.register(\*\*params) -> Model</code>
+- <code title="delete /v1/models/{model_id}">client.models.unregister(model_id) -> None</code>
 
 ## PostTraining
 
@@ -318,8 +318,8 @@ from ogx_client.types import ListPostTrainingJobsResponse, PostTrainingJob
 
 Methods:
 
-- <code title="post /v1/post-training/preference-optimize">client.post_training.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/post_training.py">preference_optimize</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_preference_optimize_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_job.py">PostTrainingJob</a></code>
-- <code title="post /v1/post-training/supervised-fine-tune">client.post_training.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/post_training.py">supervised_fine_tune</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_supervised_fine_tune_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training_job.py">PostTrainingJob</a></code>
+- <code title="post /v1/post-training/preference-optimize">client.post_training.preference_optimize(\*\*params) -> PostTrainingJob</code>
+- <code title="post /v1/post-training/supervised-fine-tune">client.post_training.supervised_fine_tune(\*\*params) -> PostTrainingJob</code>
 
 ### Job
 
@@ -335,10 +335,10 @@ from ogx_client.types.post_training import (
 
 Methods:
 
-- <code title="get /v1/post-training/jobs">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_list_response.py">JobListResponse</a></code>
-- <code title="get /v1/post-training/job/artifacts">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">artifacts</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_artifacts_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_artifacts_response.py">Optional[JobArtifactsResponse]</a></code>
-- <code title="post /v1/post-training/job/cancel">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">cancel</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_cancel_params.py">params</a>) -> None</code>
-- <code title="get /v1/post-training/job/status">client.post_training.job.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/post_training/job.py">status</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_status_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/post_training/job_status_response.py">Optional[JobStatusResponse]</a></code>
+- <code title="get /v1/post-training/jobs">client.post_training.job.list() -> JobListResponse</code>
+- <code title="get /v1/post-training/job/artifacts">client.post_training.job.artifacts(\*\*params) -> Optional[JobArtifactsResponse]</code>
+- <code title="post /v1/post-training/job/cancel">client.post_training.job.cancel(\*\*params) -> None</code>
+- <code title="get /v1/post-training/job/status">client.post_training.job.status(\*\*params) -> Optional[JobStatusResponse]</code>
 
 ## Providers
 
@@ -350,7 +350,7 @@ from ogx_client.types import ListProvidersResponse, ProviderListResponse
 
 Methods:
 
-- <code title="get /v1/inspect/providers">client.providers.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/providers.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/provider_list_response.py">ProviderListResponse</a></code>
+- <code title="get /v1/inspect/providers">client.providers.list() -> ProviderListResponse</code>
 
 ## Routes
 
@@ -362,7 +362,7 @@ from ogx_client.types import ListRoutesResponse, RouteListResponse
 
 Methods:
 
-- <code title="get /v1/inspect/routes">client.routes.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/routes.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/route_list_response.py">RouteListResponse</a></code>
+- <code title="get /v1/inspect/routes">client.routes.list() -> RouteListResponse</code>
 
 ## SyntheticDataGeneration
 
@@ -380,7 +380,7 @@ from ogx_client.types import SyntheticDataGenerationResponse
 
 Methods:
 
-- <code title="post /v1/synthetic-data-generation/generate">client.synthetic_data_generation.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/synthetic_data_generation.py">generate</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/synthetic_data_generation_generate_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/synthetic_data_generation_response.py">SyntheticDataGenerationResponse</a></code>
+- <code title="post /v1/synthetic-data-generation/generate">client.synthetic_data_generation.generate(\*\*params) -> SyntheticDataGenerationResponse</code>
 
 ## Datasetio
 
@@ -392,8 +392,8 @@ from ogx_client.types import PaginatedRowsResult
 
 Methods:
 
-- <code title="post /v1/datasetio/rows">client.datasetio.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasetio.py">append_rows</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/datasetio_append_rows_params.py">params</a>) -> None</code>
-- <code title="get /v1/datasetio/rows">client.datasetio.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/datasetio.py">get_rows_paginated</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/datasetio_get_rows_paginated_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/paginated_rows_result.py">PaginatedRowsResult</a></code>
+- <code title="post /v1/datasetio/rows">client.datasetio.append_rows(\*\*params) -> None</code>
+- <code title="get /v1/datasetio/rows">client.datasetio.get_rows_paginated(\*\*params) -> PaginatedRowsResult</code>
 
 ## Scoring
 
@@ -405,8 +405,8 @@ from ogx_client.types import ScoringScoreResponse, ScoringScoreBatchResponse
 
 Methods:
 
-- <code title="post /v1/scoring/score">client.scoring.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring.py">score</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_response.py">ScoringScoreResponse</a></code>
-- <code title="post /v1/scoring/score-batch">client.scoring.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring.py">score_batch</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_batch_params.py">params</a>) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_score_batch_response.py">ScoringScoreBatchResponse</a></code>
+- <code title="post /v1/scoring/score">client.scoring.score(\*\*params) -> ScoringScoreResponse</code>
+- <code title="post /v1/scoring/score-batch">client.scoring.score_batch(\*\*params) -> ScoringScoreBatchResponse</code>
 
 ## ScoringFunctions
 
@@ -422,9 +422,9 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="get /v1/scoring-functions/{scoring_fn_id}">client.scoring_functions.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">retrieve</a>(scoring_fn_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_fn.py">Optional[ScoringFn]</a></code>
-- <code title="get /v1/scoring-functions">client.scoring_functions.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_function_list_response.py">ScoringFunctionListResponse</a></code>
-- <code title="post /v1/scoring-functions">client.scoring_functions.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/scoring_functions.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/scoring_function_register_params.py">params</a>) -> None</code>
+- <code title="get /v1/scoring-functions/{scoring_fn_id}">client.scoring_functions.retrieve(scoring_fn_id) -> Optional[ScoringFn]</code>
+- <code title="get /v1/scoring-functions">client.scoring_functions.list() -> ScoringFunctionListResponse</code>
+- <code title="post /v1/scoring-functions">client.scoring_functions.register(\*\*params) -> None</code>
 
 ## Benchmarks
 
@@ -440,6 +440,6 @@ from ogx_client.types import (
 
 Methods:
 
-- <code title="get /v1/eval-tasks/{benchmark_id}">client.benchmarks.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/benchmarks.py">retrieve</a>(benchmark_id) -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/benchmark.py">Optional[Benchmark]</a></code>
-- <code title="get /v1/eval-tasks">client.benchmarks.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/benchmarks.py">list</a>() -> <a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/benchmark_list_response.py">BenchmarkListResponse</a></code>
-- <code title="post /v1/eval-tasks">client.benchmarks.<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/resources/benchmarks.py">register</a>(\*\*<a href="https://github.com/ogx-ai/ogx-client-python/tree/main/src/ogx_client/types/benchmark_register_params.py">params</a>) -> None</code>
+- <code title="get /v1/eval-tasks/{benchmark_id}">client.benchmarks.retrieve(benchmark_id) -> Optional[Benchmark]</code>
+- <code title="get /v1/eval-tasks">client.benchmarks.list() -> BenchmarkListResponse</code>
+- <code title="post /v1/eval-tasks">client.benchmarks.register(\*\*params) -> None</code>

--- a/docs/original_rfc.md
+++ b/docs/original_rfc.md
@@ -72,9 +72,9 @@ The API is defined in the [YAML](_static/ogx-spec.yaml) and [HTML](_static/ogx-s
 
 ## Sample implementations
 
-To prove out the API, we implemented a handful of use cases to make things more concrete. The [ogx-apps](https://github.com/ogx-ai/ogx-apps) repository contains [6 different examples](https://github.com/ogx-ai/ogx-apps/tree/main/examples) ranging from very basic to a multi turn agent.
+To prove out the API, we implemented a handful of use cases to make things more concrete. The [Llama Stack Apps](https://github.com/ogx-ai/llama-stack-apps) repository contains [6 different examples](https://github.com/ogx-ai/llama-stack-apps/tree/main/examples) ranging from very basic to a multi turn agent.
 
-There is also a sample inference endpoint implementation in the [ogx](https://github.com/ogx-ai/ogx/blob/main/ogx.core/server/server.py) repository.
+There is also a sample inference endpoint implementation in the [OGX](https://github.com/ogx-ai/ogx/blob/main/src/ogx/core/server/server.py) repository.
 
 ## Limitations
 

--- a/docs/releases/GENERATE.md
+++ b/docs/releases/GENERATE.md
@@ -68,7 +68,7 @@ Write the detailed release notes to `docs/releases/RELEASE_NOTES_{NEW_VERSION}.m
 
 Formatting rules for the detailed notes:
 
-- All PR references link to GitHub: `[#NNNN](https://github.com/ogx-ai/ogx/pull/NNNN)`
+- All PR references use a linked `#NNNN` pull request number.
 - For each change, fetch the PR author's full name from GitHub. Include company affiliation in parentheses.
 - Do NOT put author names in the summary overview tables, only in the detailed sections.
 - Use code blocks with language hints for before/after examples.

--- a/docs/zero_to_hero_guide/README.md
+++ b/docs/zero_to_hero_guide/README.md
@@ -50,7 +50,7 @@ If you're looking for more specific topics, we have a [Zero to Hero Guide](#next
    ```
 
    **Note**:
-     - The supported models for ogx for now is listed in the [Ollama models file](https://github.com/ogx-ai/ogx/blob/main/ogx/providers/remote/inference/ollama/models.py)
+     - Browse the [Ollama model library](https://ollama.com/library) for models available to run locally.
      - `keepalive -1m` is used so that ollama continues to keep the model in memory indefinitely. Otherwise, ollama frees up memory and you would have to run `ollama run` again.
 
 ---
@@ -295,12 +295,12 @@ This command initializes the model to interact with your local OGX instance.
 **Explore Client SDKs**: Utilize our client SDKs for various languages to integrate OGX into your applications:
 
 - [Python SDK](https://github.com/ogx-ai/ogx-client-python)
-- [Node SDK](https://github.com/ogx-ai/ogx-client-node)
-- [Swift SDK](https://github.com/ogx-ai/ogx-client-swift)
-- [Kotlin SDK](https://github.com/ogx-ai/ogx-client-kotlin)
+- [Node SDK](https://github.com/ogx-ai/ogx-client-typescript)
+- [Swift SDK](https://github.com/ogx-ai/llama-stack-client-swift)
+- [Kotlin SDK](https://github.com/ogx-ai/llama-stack-client-kotlin)
 
 **Advanced Configuration**: Learn how to customize your OGX distribution by referring to the [Building a OGX Distribution](https://ogx-ai.github.io/latest/distributions/building_distro.html) guide.
 
-**Explore Example Apps**: Check out [ogx-apps](https://github.com/ogx-ai/ogx-apps/tree/main/examples) for example applications built using OGX.
+**Explore Example Apps**: Check out [Llama Stack Apps](https://github.com/ogx-ai/llama-stack-apps/tree/main/examples) for example applications built using OGX.
 
 ---

--- a/src/ogx/distributions/nvidia/doc_template.md
+++ b/src/ogx/distributions/nvidia/doc_template.md
@@ -53,13 +53,9 @@ The deployed platform includes the NIM Proxy microservice, which is the service 
 
 The NeMo Data Store microservice serves as the default file storage solution for the NeMo microservices platform. It exposts APIs compatible with the Hugging Face Hub client (`HfApi`), so you can use the client to interact with Data Store. The `NVIDIA_DATASETS_URL` environment variable should point to your NeMo Data Store endpoint.
 
-See the [NVIDIA Datasetio docs](https://github.com/ogx-ai/ogx/blob/main/ogx/providers/remote/datasetio/nvidia/README.md) for supported features and example usage.
-
 ### Eval API: NeMo Evaluator
 
 The NeMo Evaluator microservice supports evaluation of LLMs. Launching an Evaluation job with NeMo Evaluator requires an Evaluation Config (an object that contains metadata needed by the job). A OGX Benchmark maps to an Evaluation Config, so registering a Benchmark creates an Evaluation Config in NeMo Evaluator. The `NVIDIA_EVALUATOR_URL` environment variable should point to your NeMo Microservices endpoint.
-
-See the [NVIDIA Eval docs](https://github.com/ogx-ai/ogx/blob/main/ogx/providers/remote/eval/nvidia/README.md) for supported features and example usage.
 
 ## Deploying models
 


### PR DESCRIPTION
# What does this PR do?

Repairs the broken GitHub links reported in #6458 on the `release-1.0.x` documentation.

The changes:

- point application and SDK references at repositories that actually exist, including `llama-stack-apps`, `ogx-client-typescript`, and the retained Kotlin and Swift repository names;
- restore the original `llama-stack-provider-*` external-provider repository names and the current MongoDB integration URL;
- add the missing `src/` prefix to OGX source links;
- remove links to deleted NVIDIA provider documentation;
- remove obsolete source anchors from the legacy Python SDK reference while preserving its method and type signatures. Those APIs were removed from the client before its package was renamed, so no valid `ogx_client` source targets exist.

Addresses #6458.

## Test Plan

1. Scanned every distinct GitHub URL in all Markdown and MDX files with concurrent `curl -L -I` requests.

Before:

```text
109 GitHub URLs returned HTTP 404
```

After:

```text
0 GitHub URLs returned HTTP errors
```

2. Ran the documentation CI build sequence:

```bash
cd docs
npm ci
npm run gen-api-docs all
npm run build
```

Result:

```text
[SUCCESS] Generated static files in "build".
```

3. All commit-time pre-commit hooks passed, including Blacken Docs, distribution template codegen, action pin validation, and Markdown linting.