### PR TITLE
fix(docs): fix broken internal links and fail the build on new ones

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,6 +3,11 @@ name: Documentation Build
 run-name: Build and validate documentation
 
 on:
+  pull_request:
+    paths: ['docs/**']
+  push:
+    branches: [main]
+    paths: ['docs/**']
   schedule:
     - cron: '0 0 * * *'  # Daily at 12 AM UTC
   workflow_dispatch:

--- a/docs/docs/api-deprecated/index.mdx
+++ b/docs/docs/api-deprecated/index.mdx
@@ -22,17 +22,17 @@ When using deprecated APIs, please refer to the migration guides provided for ea
 ### Legacy Inference APIs
 Some older inference endpoints that have been superseded by the standardized Inference API.
 
-**Migration Path:** Use the [Inference API](../api/) instead.
+**Migration Path:** Use the [Inference API](/docs/api/) instead.
 
 ### Legacy Vector Operations
 Older vector database operations that have been replaced by the Vector IO API.
 
-**Migration Path:** Use the [Vector IO API](../api/) instead.
+**Migration Path:** Use the [Vector IO API](/docs/api/) instead.
 
 ### Legacy File Operations
 Older file management endpoints that have been replaced by the Files API.
 
-**Migration Path:** Use the [Files API](../api/) instead.
+**Migration Path:** Use the [Files API](/docs/api/) instead.
 
 ## Support Timeline
 
@@ -47,7 +47,7 @@ Deprecated APIs will be supported according to the following timeline:
 If you need assistance migrating from deprecated APIs:
 
 1. Check the specific migration guides for each API
-2. Review the [API Reference](../api/) for current alternatives
+2. Review the [API Reference](/docs/api/) for current alternatives
 3. Consult the [Community Forums](https://github.com/ogx-ai/ogx/discussions) for migration support
 4. Open an issue on GitHub for specific migration questions
 
@@ -59,4 +59,4 @@ If you find issues with deprecated APIs or have suggestions for improving the mi
 2. Submitting a pull request with improvements
 3. Updating migration documentation
 
-For more information on contributing, see our [Contributing Guide](../contributing/).
+For more information on contributing, see our [Contributing Guide](/docs/contributing/).

--- a/docs/docs/api/index.mdx
+++ b/docs/docs/api/index.mdx
@@ -129,15 +129,15 @@ For detailed setup instructions, see our [Getting Started Guide](/docs/getting_s
 
 ## Provider Details
 
-For complete provider compatibility and setup instructions, see our [Providers Documentation](../providers/).
+For complete provider compatibility and setup instructions, see our [Providers Documentation](/docs/providers/).
 
 ## API Stability
 
 OGX APIs are organized by stability level:
 - **[Stable APIs](/docs/api/)** - Production-ready APIs with full support
-- **[Experimental APIs](../api-experimental/)** - APIs in development with limited support
-- **[Deprecated APIs](../api-deprecated/)** - Legacy APIs being phased out
+- **[Experimental APIs](/docs/api-experimental/)** - APIs in development with limited support
+- **[Deprecated APIs](/docs/api-deprecated/)** - Legacy APIs being phased out
 
 ## OpenAI Integration
 
-For specific OpenAI API compatibility features, see our [OpenAI Compatibility Guide](../api-openai/).
+For specific OpenAI API compatibility features, see our [OpenAI Compatibility Guide](/docs/api-openai/).

--- a/docs/docs/building_applications/telemetry.mdx
+++ b/docs/docs/building_applications/telemetry.mdx
@@ -315,7 +315,7 @@ The container image sets this automatically when any `OTEL_*` environment variab
 
 ## Related resources
 
-- **[Setup script and configs](/scripts/telemetry/)** - One-command observability stack deployment
+- **[Setup script and configs](https://github.com/ogx-ai/ogx/tree/main/scripts/telemetry)** - One-command observability stack deployment
 - **[OpenTelemetry Documentation](https://opentelemetry.io/)** - Comprehensive observability framework
 - **[OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/)** - Standard GenAI metric naming
 - **[Jaeger Documentation](https://www.jaegertracing.io/)** - Distributed tracing visualization

--- a/docs/docs/concepts/evaluation_concepts.mdx
+++ b/docs/docs/concepts/evaluation_concepts.mdx
@@ -16,7 +16,7 @@ We introduce a set of APIs in OGX for supporting running evaluations of LLM appl
 
 This guide goes over the sets of APIs and developer experience flow of using OGX to run evaluations for different use cases. Checkout our Colab notebook on working examples with evaluations [here](https://colab.research.google.com/drive/10CHyykee9j2OigaIcRv47BKG9mrNm0tJ?usp=sharing).
 
-The Evaluation APIs are associated with a set of Resources. Please visit the Resources section in our [Core Concepts](./index) guide for better high-level understanding.
+The Evaluation APIs are associated with a set of Resources. Please visit the Resources section in our [Core Concepts](/docs/concepts) guide for better high-level understanding.
 
 - **DatasetIO**: defines interface with datasets and data loaders.
   - Associated with `Dataset` resource.

--- a/docs/docs/concepts/file_operations_vector_stores.mdx
+++ b/docs/docs/concepts/file_operations_vector_stores.mdx
@@ -491,6 +491,6 @@ async def analyze_document(vector_store_id, file_id):
 
 ## Next Steps
 
-- Explore the [Files API documentation](../../providers/files/) for detailed API reference
+- Explore the [Files API documentation](../providers/files/) for detailed API reference
 - Check [Vector Store Providers](/docs/providers/vector_io/) for specific implementation details
 - Review [Getting Started](../getting_started/quickstart) for quick setup instructions

--- a/docs/docs/distributions/configuration.mdx
+++ b/docs/docs/distributions/configuration.mdx
@@ -322,7 +322,7 @@ server:
       - "ogk_mykey2"
 ```
 
-This is the simplest authentication provider — any key in the list authenticates successfully and is granted `admin` and `owner` [roles](../configuration.mdx#access-control) so the default owner-based access-controls work out of the box. Use it for development, internal services, or when you prefer to manage keys outside an identity provider.
+This is the simplest authentication provider — any key in the list authenticates successfully and is granted `admin` and `owner` [roles](#access-control) so the default owner-based access-controls work out of the box. Use it for development, internal services, or when you prefer to manage keys outside an identity provider.
 
 The token is validated as `Authorization: Bearer <key>` and the key string itself becomes the user principal. Because this provider does not resolve a `tenant_id`, it is only compatible with `server.tenancy.mode` `single` or `disabled` — startup will fail with `multi`.
 
@@ -534,7 +534,7 @@ scoring_function, benchmark, tool, tool_group and session. In
 addition, stored data such as conversations, conversation items,
 responses, and files use the `sql_record::<table_name>` resource
 type (e.g. `sql_record::openai_conversations`,
-`sql_record::responses`). See [Multi-Tenant Isolation for Conversations and Responses](#multi-tenant-isolation-for-conversations-and-responses) for details.
+`sql_record::responses`). See [Combining Tenant Isolation with Access Control](#combining-tenant-isolation-with-access-control) for details.
 
 A rule may also specify a condition, either a 'when' or an 'unless',
 with additional constraints as to where the rule applies. The

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -122,7 +122,7 @@ OGX works with any OpenAI-compatible client. Point your existing code at `http:/
 OGX is secure by default. `--insecure` forces the server to listen on http. By default it runs on https with a self-signed cert. You'll have to skip cert verification or trust the automatically generated cert.
 :::
 
-[Quick Start Guide](/docs/getting_started/quickstart) | [OpenAI API Compatibility](./api-openai) | [GitHub](https://github.com/ogx-ai/ogx)
+[Quick Start Guide](/docs/getting_started/quickstart) | [OpenAI API Compatibility](/docs/api-openai) | [GitHub](https://github.com/ogx-ai/ogx)
 
 ## Found an issue with the docs?
 

--- a/docs/docs/providers/files/openai_file_operations_support.md
+++ b/docs/docs/providers/files/openai_file_operations_support.md
@@ -287,5 +287,5 @@ Planned improvements for file operations support:
 - **Documentation**: [File Operations and Vector Store Integration](../../concepts/file_operations_vector_stores)
 - **API Reference**: Files API
 - **Provider Docs**: [Vector Store Providers](../vector_io/)
-- **Examples**: [Getting Started](../../getting_started/)
+- **Examples**: [Getting Started](/docs/getting_started/quickstart)
 - **Community**: [GitHub Issues](https://github.com/ogx-ai/ogx/issues)

--- a/docs/docs/references/ogx_cli_reference/index.md
+++ b/docs/docs/references/ogx_cli_reference/index.md
@@ -30,8 +30,8 @@ You have two ways to install OGX:
 
 ## `ogx` subcommands
 
-1. `stack`: Allows you to build a stack using the `ogx` distribution and run a OGX server. You can read more about how to build a OGX distribution in the [Build your own Distribution](../../distributions/building_distro) documentation.
-2. `connect`: Connect third-party tools to the running OGX server. Supports [`claude`](../../building_applications/claude_code_integration), [`opencode`](../../building_applications/opencode_integration), and [`codex`](../../building_applications/codex_cli_integration).
+1. `stack`: Allows you to build a stack using the `ogx` distribution and run a OGX server. You can read more about how to build a OGX distribution in the [Build your own Distribution](/docs/distributions/building_distro) documentation.
+2. `connect`: Connect third-party tools to the running OGX server. Supports [`claude`](/docs/building_applications/claude_code_integration), [`opencode`](/docs/building_applications/opencode_integration), and [`codex`](/docs/building_applications/codex_cli_integration).
 
 For downloading models, we recommend using the [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/guides/cli). See [Downloading models](#downloading-models) for more information.
 

--- a/docs/docs/references/python_sdk_reference/index.md
+++ b/docs/docs/references/python_sdk_reference/index.md
@@ -83,7 +83,7 @@ Methods:
 
 :::warning DEPRECATED API
 
-**The Agents API is deprecated. Use the [Responses API](/docs/building_applications/responses) instead.**
+**The Agents API is deprecated. Use the [Responses API](/docs/building_applications/responses_vs_agents) instead.**
 
 The Responses API provides equivalent functionality with an OpenAI-compatible interface. New applications should use `client.responses.create()` rather than the agents workflow below.
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -11,7 +11,8 @@ const config: Config = {
   tagline: 'The open-source framework for building generative AI applications',
   url: 'https://ogx-ai.github.io',
   baseUrl: '/',
-  onBrokenLinks: "warn",
+  onBrokenLinks: "throw",
+  onBrokenAnchors: "throw",
   favicon: "img/favicon.ico",
 
   // Enhanced favicon and meta configuration
@@ -399,7 +400,7 @@ const config: Config = {
     mermaid: true,
     format: 'detect',
     hooks: {
-      onBrokenMarkdownLinks: 'warn',
+      onBrokenMarkdownLinks: 'throw',
     },
   },
 };


### PR DESCRIPTION
# What does this PR do?

Running `npm run gen-api-docs all && npm run build` in `docs/` surfaced 15 broken internal links/anchors across 9 pages, plus one broken same-page anchor. All were caused by the same class of mistake: hand-written relative markdown links (`../foo`, `./index`) miscounting directory depth relative to a page's clean URL (which drops the trailing "index" segment), rather than using the site-absolute `/docs/...` links already used elsewhere in the same files.

Fixed each to point at its actual target:

- `docs/index.mdx`, `docs/api/index.mdx`, `docs/api-deprecated/index.mdx`: wrong relative depth on category index pages
- `docs/concepts/evaluation_concepts.mdx`, `docs/concepts/file_operations_vector_stores.mdx`: same issue on regular pages
- `docs/distributions/configuration.mdx`: a self-link with an unnecessary `../` prefix, and a same-page anchor referencing a heading that had since been renamed (now points at "Combining Tenant Isolation with Access Control", which is what the surrounding text actually describes)
- `docs/building_applications/telemetry.mdx`: linked to a repo-relative `scripts/` path as if it were a docs route; now an absolute GitHub URL
- `docs/providers/files/openai_file_operations_support.md`: linked to `/docs/getting_started/`, which has no index page; now points at the quickstart guide
- `docs/references/ogx_cli_reference/index.md`: wrong relative depth (file lives one level deeper than a same-named `.md` file would)
- `docs/references/python_sdk_reference/index.md`: linked to a page that doesn't exist; now points at the actual Responses-vs-Agents guide

Also flips `onBrokenLinks`/`onBrokenMarkdownLinks`/`onBrokenAnchors` from `"warn"` to `"throw"` per the report's request, and adds `pull_request`/`push` triggers (scoped to `docs/**`) to `.github/workflows/docs-build.yml` — it previously only ran on a daily cron and `workflow_dispatch`, so broken links were never actually caught in PR CI, only reported a day later.

Closes #6457

## Test Plan

Ran the exact repro from the issue, plus a sanity check that the new `throw` config actually fails the build:

```bash
cd docs
npm ci
npm run gen-api-docs all
npm run build
