### PR TITLE
docs: fix relative link depth in evals reference and vector stores pages

### DIFF
--- a/docs/docs/concepts/file_operations_vector_stores.mdx
+++ b/docs/docs/concepts/file_operations_vector_stores.mdx
@@ -491,6 +491,6 @@ async def analyze_document(vector_store_id, file_id):
 
 ## Next Steps
 
-- Explore the [Files API documentation](../../providers/files/) for detailed API reference
+- Explore the [Files API documentation](../providers/files/) for detailed API reference
 - Check [Vector Store Providers](/docs/providers/vector_io/) for specific implementation details
 - Review [Getting Started](../getting_started/quickstart) for quick setup instructions

--- a/docs/docs/references/evals_reference/index.mdx
+++ b/docs/docs/references/evals_reference/index.mdx
@@ -11,7 +11,7 @@ This guide goes over the sets of APIs and developer experience flow of using OGX
 
 ## Evaluation Concepts
 
-The Evaluation APIs are associated with a set of Resources as shown in the following diagram. Please visit the Resources section in our [Core Concepts](../concepts/) guide for better high-level understanding.
+The Evaluation APIs are associated with a set of Resources as shown in the following diagram. Please visit the Resources section in our [Core Concepts](../../concepts/) guide for better high-level understanding.
 
 ![Eval Concepts](/img/eval-concept.png)
 
@@ -197,7 +197,7 @@ pprint(response)
 
 OGX offers a library of scoring functions and the `/scoring` API, allowing you to run evaluations on your pre-annotated AI application datasets.
 
-In this example, we will work with an example RAG dataset you have built previously, label with an annotation, and use LLM-As-Judge with custom judge prompt for scoring. Please checkout our [OGX Playground](../building_applications/playground) for an interactive interface to upload datasets and run scorings.
+In this example, we will work with an example RAG dataset you have built previously, label with an annotation, and use LLM-As-Judge with custom judge prompt for scoring. Please checkout our [OGX Playground](../../building_applications/playground) for an interactive interface to upload datasets and run scorings.
 
 ```python
 judge_model_id = "meta-llama/Llama-3.1-405B-Instruct-FP8"


### PR DESCRIPTION
Three relative links resolved to nonexistent paths:

- `docs/docs/references/evals_reference/index.mdx`: `[Core Concepts](../concepts/)` and `[OGX Playground](../building_applications/playground)` resolved one level short of `docs/docs/concepts` / `docs/docs/building_applications`; added the missing `../`.
- `docs/docs/concepts/file_operations_vector_stores.mdx`: `[Files API documentation](../../providers/files/)` escaped the docs root (`docs/providers/` does not exist); the Files API docs live at `docs/docs/providers/files/`; changed to `../providers/files/`.