### PR TITLE
docs: remove/fix links to files that are not in the repository

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -60,7 +60,7 @@ A version is released when:
 
 ### Release Owner
 
-Each release has a designated **Release Owner** from the [CODEOWNERS](./CODEOWNERS) group who is responsible for:
+Each release has a designated **Release Owner** from the [CODEOWNERS](./.github/CODEOWNERS) group who is responsible for:
 
 1. Creating a dedicated Slack thread in `#release` channel
 2. Coordinating testing activities

--- a/docs/notebooks/nvidia/beginner_e2e/README.md
+++ b/docs/notebooks/nvidia/beginner_e2e/README.md
@@ -56,4 +56,3 @@ Ensure you have access to:
 
 ## Get Started
 
-Navigate to the [beginner E2E tutorial](./Llama_Stack_NVIDIA_E2E_Flow.ipynb) tutorial to get started.

--- a/docs/notebooks/nvidia/tool_calling/README.md
+++ b/docs/notebooks/nvidia/tool_calling/README.md
@@ -29,9 +29,8 @@ This end-to-end tutorial shows how to leverage the NeMo Microservices platform f
 The following stages will be covered in this set of tutorials:
 
 1. [Preparing Data for fine-tuning and evaluation](./1_data_preparation.ipynb)
-2. [Customizing the model with LoRA fine-tuning](./2_finetuning_and_inference.ipynb)
-3. [Evaluating the accuracy of the customized model](./3_model_evaluation.ipynb)
-4. [Adding Guardrails to safeguard your LLM behavior](./4_adding_safety_guardrails.ipynb)
+2. [Evaluating the accuracy of the customized model](./3_model_evaluation.ipynb)
+3. [Adding Guardrails to safeguard your LLM behavior](./4_adding_safety_guardrails.ipynb)
 
 > **Note:** The LoRA fine-tuning of the Llama-3.2-1B-Instruct model takes up to 45 minutes to complete.
 

--- a/docs/releases/RELEASE_NOTES_1.0.md
+++ b/docs/releases/RELEASE_NOTES_1.0.md
@@ -3,7 +3,7 @@
 
 **Release Date:** May 2026
 
-OGX 1.0 marks the project's first major-stable release. The `/v1` HTTP API surface is now covered by the stability contract documented in [`docs/docs/concepts/apis/api_leveling.mdx`](../concepts/apis/api_leveling.mdx): no breaking changes to `/v1` datatypes or on-disk storage schemas within the 1.x line. APIs that are not yet stable continue to live under `/v1alpha` and `/v1beta`.
+OGX 1.0 marks the project's first major-stable release. The `/v1` HTTP API surface is now covered by the stability contract documented in [`docs/docs/concepts/apis/api_leveling.mdx`](../docs/concepts/apis/api_leveling.mdx): no breaking changes to `/v1` datatypes or on-disk storage schemas within the 1.x line. APIs that are not yet stable continue to live under `/v1alpha` and `/v1beta`.
 
 The headline themes for 1.0:
 

--- a/tests/integration/openresponses/README.md
+++ b/tests/integration/openresponses/README.md
@@ -1,7 +1,7 @@
 # OpenResponses Conformance Recordings
 
 This directory holds inference recordings used by the
-[OpenResponses conformance CI job](../../.github/workflows/openresponses-conformance.yml)
+[OpenResponses conformance CI job](../../../.github/workflows/openresponses-conformance.yml)
 to replay underlying OpenAI API calls without needing a live API key.
 
 ## How recordings work


### PR DESCRIPTION
Fixes five broken relative links in GitHub-rendered markdown, each verified via `git ls-files`:

- `RELEASE_PROCESS.md`: CODEOWNERS lives at `.github/CODEOWNERS`, not `./CODEOWNERS`
- `tests/integration/openresponses/README.md`: the workflow link needed one more `../` (resolves from `tests/integration/openresponses/`)
- `docs/releases/RELEASE_NOTES_1.0.md`: the api_leveling.mdx link was one level short
- `docs/notebooks/nvidia/beginner_e2e/README.md`: linked `./Llama_Stack_NVIDIA_E2E_Flow.ipynb`, never committed at this path; removed the line
- `docs/notebooks/nvidia/tool_calling/README.md`: listed `./2_finetuning_and_inference.ipynb` while only 1/3/4 exist; removed the entry and renumbered the list