### PR TITLE
fix: repair mangled route_policy warning and existance docstring typo

### DIFF
--- a/src/ogx/core/server/auth.py
+++ b/src/ogx/core/server/auth.py
@@ -345,7 +345,7 @@ class RouteAuthorizationMiddleware:
                         return True
                 except re.error as e:
                     logger.warning(
-                        "Invalid regex pattern in route_policy: . Error: . Skipping this pattern.",
+                        "Invalid regex pattern in route_policy, skipping this pattern.",
                         regex_pattern=regex_pattern,
                         error=str(e),
                     )

--- a/src/ogx/providers/inline/batches/reference/batches.py
+++ b/src/ogx/providers/inline/batches/reference/batches.py
@@ -373,7 +373,7 @@ class ReferenceBatchesImpl(Batches):
         Read & validate input, return errors and valid input.
 
         Validation of
-        - input_file_id existance
+        - input_file_id existence
         - valid json
         - custom_id, method, url, body presence and valid
         - no streaming


### PR DESCRIPTION
Two small operator-facing text fixes:

1. `src/ogx/core/server/auth.py:348`: the mechanical f-string → structlog conversion stripped the interpolations but left the punctuation, so a `route_policy` with an invalid regex logs `"Invalid regex pattern in route_policy: . Error: . Skipping this pattern."` — the values already ride along as structlog kwargs (`regex_pattern=`, `error=`); the message now reads cleanly. (Kept kwargs form — f-string logging is banned by `scripts/check-no-fstring-logging.sh`.)
2. `src/ogx/providers/inline/batches/reference/batches.py:376`: `existance` → `existence` in the docstring.