### PR TITLE
docs: use 'an OGX' instead of 'a OGX' consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the [provider documentation](https://ogx-ai.github.io/docs/providers) for th
 
 ## Get started
 
-Install and run a OGX server:
+Install and run an OGX server:
 
 ```bash
 # One-line install

--- a/docs/docs/api-google-interactions/index.mdx
+++ b/docs/docs/api-google-interactions/index.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # Google Interactions API Compatibility
 
-OGX provides a compatibility layer for the [Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (v1alpha), so teams using the Google GenAI SDK can point at a OGX server with minimal code changes.
+OGX provides a compatibility layer for the [Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (v1alpha), so teams using the Google GenAI SDK can point at an OGX server with minimal code changes.
 
 ```python
 from google import genai

--- a/docs/docs/concepts/apis/google_interactions.mdx
+++ b/docs/docs/concepts/apis/google_interactions.mdx
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 # Google Interactions API
 
-OGX provides a compatibility layer for the [Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (v1alpha). This lets teams using the Google GenAI SDK point at a OGX server with minimal code changes, similar to how the OpenAI compatibility layer works.
+OGX provides a compatibility layer for the [Google Interactions API](https://ai.google.dev/gemini-api/docs/interactions) (v1alpha). This lets teams using the Google GenAI SDK point at an OGX server with minimal code changes, similar to how the OpenAI compatibility layer works.
 
 ## How it works
 

--- a/docs/docs/contributing/new_api_provider.mdx
+++ b/docs/docs/contributing/new_api_provider.mdx
@@ -87,7 +87,7 @@ Consult [tests/unit/README.md](https://github.com/ogx-ai/ogx/blob/main/tests/uni
 
 ### 3. Additional end-to-end testing
 
-1. Start a OGX server with your new provider
+1. Start an OGX server with your new provider
 2. Verify compatibility with existing client scripts in the [ogx-apps](https://github.com/ogx-ai/ogx-apps/tree/main) repository
 3. Document which scripts are compatible with your provider
 

--- a/docs/docs/distributions/building_distro.mdx
+++ b/docs/docs/distributions/building_distro.mdx
@@ -1,6 +1,6 @@
 ---
 title: Building Custom Distributions
-description: Building a OGX distribution from scratch
+description: Building an OGX distribution from scratch
 sidebar_label: Build your own Distribution
 sidebar_position: 3
 ---

--- a/docs/docs/distributions/ogx_ui.mdx
+++ b/docs/docs/distributions/ogx_ui.mdx
@@ -19,7 +19,7 @@ The OGX UI is a web-based interface for interacting with OGX servers. Built with
 
 You need a running OGX server. The UI is a client that connects to the OGX backend.
 
-If you don't have a OGX server running yet, see the [Starting OGX Server](starting_ogx_server) guide.
+If you don't have an OGX server running yet, see the [Starting OGX Server](starting_ogx_server) guide.
 
 ## Running the UI
 

--- a/docs/docs/distributions/self_hosted_distro/starter.md
+++ b/docs/docs/distributions/self_hosted_distro/starter.md
@@ -150,7 +150,7 @@ export INFINISPAN_URL=http://localhost:11222   # enables the Infinispan vector p
 
 ## Running
 
-See [Starting a OGX Server](../starting_ogx_server) for all the ways to run (uv, container, library, Kubernetes).
+See [Starting an OGX Server](../starting_ogx_server) for all the ways to run (uv, container, library, Kubernetes).
 
 Quick start:
 

--- a/docs/docs/distributions/starting_ogx_server.mdx
+++ b/docs/docs/distributions/starting_ogx_server.mdx
@@ -1,5 +1,5 @@
 ---
-title: Starting a OGX Server
+title: Starting an OGX Server
 description: Different ways to run OGX
 sidebar_label: Starting OGX Server
 sidebar_position: 7
@@ -8,7 +8,7 @@ sidebar_position: 7
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Starting a OGX Server
+# Starting an OGX Server
 
 <Tabs>
 <TabItem value="uv" label="uv (recommended)" default>

--- a/docs/docs/providers/openai.mdx
+++ b/docs/docs/providers/openai.mdx
@@ -13,7 +13,7 @@ This guide provides detailed code examples and implementation details for using 
 
 ### Server path
 
-OGX exposes OpenAI-compatible API endpoints at `/v1`. So, for a OGX server running locally on port `8321`, the full url to the OpenAI-compatible API endpoint is `http://localhost:8321/v1`.
+OGX exposes OpenAI-compatible API endpoints at `/v1`. So, for an OGX server running locally on port `8321`, the full url to the OpenAI-compatible API endpoint is `http://localhost:8321/v1`.
 
 ### Clients
 

--- a/docs/docs/references/ogx_cli_reference/index.md
+++ b/docs/docs/references/ogx_cli_reference/index.md
@@ -30,7 +30,7 @@ You have two ways to install OGX:
 
 ## `ogx` subcommands
 
-1. `stack`: Allows you to build a stack using the `ogx` distribution and run a OGX server. You can read more about how to build a OGX distribution in the [Build your own Distribution](../../distributions/building_distro) documentation.
+1. `stack`: Allows you to build a stack using the `ogx` distribution and run an OGX server. You can read more about how to build an OGX distribution in the [Build your own Distribution](../../distributions/building_distro) documentation.
 2. `connect`: Connect third-party tools to the running OGX server. Supports [`claude`](../../building_applications/claude_code_integration), [`opencode`](../../building_applications/opencode_integration), and [`codex`](../../building_applications/codex_cli_integration).
 
 For downloading models, we recommend using the [Hugging Face CLI](https://huggingface.co/docs/huggingface_hub/guides/cli). See [Downloading models](#downloading-models) for more information.


### PR DESCRIPTION
OGX is read as an initialism (/ˈoʊ dʒiː ɛks/), and the docs already use 'an OGX' in several places (e.g. docs/docs/concepts/tools.mdx). This makes the remaining 10 occurrences consistent across README.md and 9 docs pages (distributions/, concepts/, providers/, references/).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository.