### PR TITLE
fix: typos in the documentation

### DIFF
--- a/docs/blog/2026-06-16-claude-code-blog.md
+++ b/docs/blog/2026-06-16-claude-code-blog.md
@@ -13,7 +13,7 @@ Today we are happy to announce `ogx connect` support for Claude Code, allowing O
 Using OGX as your backend for Claude Code can provide some strong advantages over different backend options:
 
 - Control your budget by offering a mixture of different models from different sources, rather than relying on a single backend provider
-- Take advantage of Claude Code's mapping of models to seemlessly switch between self-hosted and SaaS options with no server interactions required
+- Take advantage of Claude Code's mapping of models to seamlessly switch between self-hosted and SaaS options with no server interactions required
 - Ensure redundancy by never being reliant on one SaaS backend, always keeping Claude Code running for users of your OGX server
 
 In this blog I am going to share how to start running Claude Code using models on an OGX server, using a remote server that has both self-hosted and SaaS models enabled.

--- a/docs/blog/2026-06-30-codex-ogx-cli.md
+++ b/docs/blog/2026-06-30-codex-ogx-cli.md
@@ -28,7 +28,7 @@ OGX gives those tools a common front door:
 
 That makes OGX a good fit for agentic development across laptops, shared dev servers, and production-like environments. It is not just a proxy. It is a control plane for model access, auth shape, provider routing, and day-to-day debugging.
 
-Codex uses OGX through the Responses API, but the provider setup is useful beyond Codex. Once a model provider such as vLLM, Ollama, or OpenAI is registered in OGX, other OpenAI-compatible clients can use the same model access layer through chat completions or completions when those endpoints are enabled. That includes Python scripts using the OpenAI SDK, notebooks, OpenCode, LiteLLM or LangChain-style apps, and internal tools that already speak OpenAI-compatible APIs. Teams can configure routing and auth once in OGX, then reuse that setup from Codex and from simpler inference clients.
+Codex uses OGX through the Responses API, but the provider setup is useful beyond Codex. Once a model provider such as vLLM, Ollama, or OpenAI is registered in OGX, other OpenAI-compatible clients can use the same model access layer through chat completions or completions when those endpoints are enabled. That includes Python scripts using the OpenAI SDK, notebooks, OpenCode, LiteLLM or LangChain-style apps, and internal tools that already speak OpenAI-compatible APIs. Teams can configure routing and auth once in OGX, then re-use that setup from Codex and from simpler inference clients.
 
 ## What the command does
 


### PR DESCRIPTION
Fixes 2 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, module paths, package names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.