### PR TITLE
fix: bump nltk>=3.10.3

### DIFF
--- a/src/llama_stack/providers/registry/tool_runtime.py
+++ b/src/llama_stack/providers/registry/tool_runtime.py
@@ -30,7 +30,7 @@ def available_providers() -> list[ProviderSpec]:
                 "numpy",
                 "scikit-learn",
                 "scipy",
-                "nltk>=3.9.4",
+                "nltk>=3.10.3",
                 "sentencepiece",
                 "transformers",
             ],


### PR DESCRIPTION
pyproject.toml was updated in the previous commit but this file was overlooked


