### PR TITLE
fix: qualify tenant column in PostgreSQL upserts

### DIFF
--- a/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/authorized_sqlstore.py
@@ -226,15 +226,18 @@ class AuthorizedSqlStore:
         current_user = get_authenticated_user()
         await self._check_access_for_rows(table, where, action, current_user)
 
-    def _build_tenant_filter(self, current_user: User | None) -> tuple[str, dict[str, Any]]:
+    def _build_tenant_filter(
+        self, current_user: User | None, *, table: str | None = None
+    ) -> tuple[str, dict[str, Any]]:
         """Non-bypassable tenant partition filter. Applied before ABAC."""
+        tenant_column = f'"{table}"."tenant_id"' if table is not None else "tenant_id"
         if self.tenancy_mode == TenancyMode.DISABLED:
             return "1=1", {}
         if not current_user or not current_user.tenant_id:
             if self.tenancy_mode == TenancyMode.SINGLE and self.default_tenant_id:
-                return "tenant_id = :_tenant_id_filter", {"_tenant_id_filter": self.default_tenant_id}
+                return f"{tenant_column} = :_tenant_id_filter", {"_tenant_id_filter": self.default_tenant_id}
             return "1=0", {}
-        return "tenant_id = :_tenant_id_filter", {"_tenant_id_filter": current_user.tenant_id}
+        return f"{tenant_column} = :_tenant_id_filter", {"_tenant_id_filter": current_user.tenant_id}
 
     def _tenant_id_for_current_context(self, current_user: User | None) -> str | None:
         if self.tenancy_mode == TenancyMode.DISABLED:
@@ -333,7 +336,7 @@ class AuthorizedSqlStore:
         else:
             update_columns = [c for c in enhanced_data.keys() if c not in conflict_columns and c not in frozen_fields]
 
-        tenant_update_where, tenant_update_params = self._build_tenant_filter(current_user)
+        tenant_update_where, tenant_update_params = self._build_tenant_filter(current_user, table=table)
 
         await self.sql_store.upsert(
             table=table,

--- a/tests/unit/utils/test_tenant_isolation.py
+++ b/tests/unit/utils/test_tenant_isolation.py
@@ -208,6 +208,29 @@ async def test_single_mode_requestless_write_uses_default_tenant(mock_user):
 
 
 @patch("ogx.core.storage.sqlstore.authorized_sqlstore.get_authenticated_user")
+async def test_tenant_upsert_qualifies_conflict_update_filter(mock_user):
+    """Tenant-aware upserts must qualify tenant_id in conflict updates."""
+    with TemporaryDirectory() as tmp:
+        store = _make_store(tmp, "tenant_upsert.db")
+        await store.create_table(
+            "docs",
+            {
+                "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
+                "title": ColumnType.STRING,
+            },
+        )
+
+        user = User("alice", {"roles": ["admin"]}, tenant_id="tenant-a")
+        mock_user.return_value = user
+        await store.upsert("docs", {"id": "doc1", "title": "Original"}, conflict_columns=["id"])
+        await store.upsert("docs", {"id": "doc1", "title": "Updated"}, conflict_columns=["id"])
+
+        row = await store.fetch_one("docs", where={"id": "doc1"})
+        assert row is not None
+        assert row["title"] == "Updated"
+
+
+@patch("ogx.core.storage.sqlstore.authorized_sqlstore.get_authenticated_user")
 async def test_single_mode_backfills_existing_disabled_mode_rows(mock_user):
     """Enabling single tenancy should keep legacy disabled-mode rows visible."""
     with TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes https://github.com/ogx-ai/ogx/issues/6508

## Summary

Qualify the tenant column in `AuthorizedSqlStore.upsert()` conflict-update predicates.

With PostgreSQL, an unqualified `tenant_id` in `ON CONFLICT DO UPDATE` is ambiguous because both the target table and the `excluded` row expose that column. This causes stored Responses API requests to fail during persistence when tenancy is enabled.

The predicate now uses the target table, for example:

```sql
WHERE responses.tenant_id = :_tenant_id_filter
```

## Testing

- `tests/unit/utils/test_tenant_isolation.py`
- `tests/unit/utils/test_authorized_sqlstore.py`
- Result: 31 passed
- `git diff --check`

Added a regression test covering a tenant-aware upsert conflict update.
