### PR TITLE
ci: Make tenancy configurable in the ci-tests distribution

### DIFF
--- a/src/ogx/distributions/ci-tests/ci_tests.py
+++ b/src/ogx/distributions/ci-tests/ci_tests.py
@@ -86,6 +86,16 @@ def get_distribution_template() -> DistributionTemplate:
         }
     }
 
+    # Env-gated tenancy config. Defaults to DISABLED (no tenant_id column), matching
+    # the stock behaviour; the Praxis migration e2e workflow flips OGX_TENANCY_MODE=single
+    # + OGX_DEFAULT_TENANT_ID=<tenant> for the single-tenant leg so OGX stamps a
+    # populated tenant_id column. default_tenant_id is only validated when mode=single,
+    # so the empty default is safe when tenancy is disabled.
+    tenancy_config = {
+        "mode": "${env.OGX_TENANCY_MODE:=disabled}",
+        "default_tenant_id": "${env.OGX_DEFAULT_TENANT_ID:=}",
+    }
+
     watsonx_provider = Provider(
         provider_id="${env.WATSONX_API_KEY:+watsonx}",
         provider_type="remote::watsonx",
@@ -113,5 +123,8 @@ def get_distribution_template() -> DistributionTemplate:
 
         # Add conditional auth config
         run_config.auth_config = auth_config
+
+        # Add env-gated tenancy config (disabled by default)
+        run_config.tenancy_config = tenancy_config
 
     return template

--- a/src/ogx/distributions/ci-tests/config.yaml
+++ b/src/ogx/distributions/ci-tests/config.yaml
@@ -336,6 +336,9 @@ server:
         uri: ${env.AUTH_JWKS_URI:=}
         key_recheck_period: ${env.AUTH_JWKS_RECHECK_PERIOD:=3600}
       verify_tls: ${env.AUTH_VERIFY_TLS:=true}
+  tenancy:
+    mode: ${env.OGX_TENANCY_MODE:=disabled}
+    default_tenant_id: ${env.OGX_DEFAULT_TENANT_ID:=}
 vector_stores:
   default_provider_id: faiss
   default_embedding_model:

--- a/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
+++ b/src/ogx/distributions/ci-tests/run-with-postgres-store.yaml
@@ -349,6 +349,9 @@ server:
         uri: ${env.AUTH_JWKS_URI:=}
         key_recheck_period: ${env.AUTH_JWKS_RECHECK_PERIOD:=3600}
       verify_tls: ${env.AUTH_VERIFY_TLS:=true}
+  tenancy:
+    mode: ${env.OGX_TENANCY_MODE:=disabled}
+    default_tenant_id: ${env.OGX_DEFAULT_TENANT_ID:=}
 vector_stores:
   default_provider_id: faiss
   default_embedding_model:

--- a/src/ogx/distributions/template.py
+++ b/src/ogx/distributions/template.py
@@ -144,6 +144,7 @@ class RunConfigSettings(BaseModel):
     default_connectors: list[ConnectorInput] | None = None
     vector_stores_config: VectorStoresConfig | None = None
     auth_config: dict[str, Any] | None = None
+    tenancy_config: dict[str, Any] | None = None
     storage_backends: dict[str, Any] | None = None
     storage_stores: dict[str, Any] | None = None
 
@@ -246,6 +247,9 @@ class RunConfigSettings(BaseModel):
 
         if self.auth_config:
             config["server"]["auth"] = self.auth_config
+
+        if self.tenancy_config:
+            config["server"]["tenancy"] = self.tenancy_config
 
         if self.vector_stores_config:
             config["vector_stores"] = self.vector_stores_config.model_dump(exclude_none=True)


### PR DESCRIPTION
## Summary

- Make tenancy configurable in the `ci-tests` distribution.
- Preserve the existing default of disabled tenancy.
- Regenerate both the standard and PostgreSQL-backed ci-tests configs from the distribution template.

This allows CI and integration workflows to exercise disabled, single-tenant, and multi-tenant source configurations without maintaining a separate duplicate distribution.

## Configuration

- `OGX_TENANCY_MODE`: defaults to `disabled`
- `OGX_DEFAULT_TENANT_ID`: used for single-tenant mode

## Validation

- `uv run --python 3.12 pytest -q tests/unit/distribution/test_distribution.py tests/backward_compat/test_run_config.py` — 32 passed
- `uv run --python 3.12 python scripts/distro_codegen.py`
- Verified default resolution: `disabled / None`
- Verified single-tenant resolution: `single / acme-corp`
- Targeted pre-commit checks passed