### PR TITLE
fix: Backport integration dependency preflight to 1.0.x.

### DIFF
--- a/.github/actions/run-and-record-tests/action.yml
+++ b/.github/actions/run-and-record-tests/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'Skip committing recordings (upload as artifacts instead)'
     required: false
     default: 'false'
+  install-deps:
+    description: 'Pass --install-deps to integration-tests.sh so missing provider dependencies are installed automatically'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -56,6 +60,7 @@ runs:
         INPUT_SUITE: ${{ inputs.suite }}
         INPUT_SUBDIRS: ${{ inputs.subdirs }}
         INPUT_PATTERN: ${{ inputs.pattern }}
+        INPUT_INSTALL_DEPS: ${{ inputs.install-deps }}
       run: |
         SCRIPT_ARGS="--stack-config ${INPUT_STACK_CONFIG} --inference-mode ${INPUT_INFERENCE_MODE}"
 
@@ -71,6 +76,9 @@ runs:
         fi
         if [ -n "${INPUT_PATTERN}" ]; then
           SCRIPT_ARGS="${SCRIPT_ARGS} --pattern ${INPUT_PATTERN}"
+        fi
+        if [ "${INPUT_INSTALL_DEPS}" != "false" ]; then
+          SCRIPT_ARGS="${SCRIPT_ARGS} --install-deps"
         fi
 
         echo "=== Running command ==="

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Test Environment'
-description: 'Common setup steps for integration tests including dependencies, providers, and build'
+description: 'Common setup steps for integration tests including runner dependencies, provider setup, and caches'
 
 inputs:
   python-version:
@@ -112,14 +112,10 @@ runs:
         echo "All installed ogx packages:"
         uv pip list | grep ogx || true
 
-    - name: Build OGX
-      shell: bash
-      run: |
-        # Client is already installed by setup-runner (handles both main and release branches)
-        echo "Building OGX"
-
-        OGX_DIR=. \
-          uv run --no-sync ogx stack list-deps ci-tests | xargs -L1 uv pip install
+    # Provider dependencies for the stack config are no longer installed here.
+    # scripts/integration-tests.sh installs them via its --install-deps flag
+    # (passed by the run-and-record-tests action), so CI and local runs share
+    # the same setup path.
 
     - name: Configure git for commits
       shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,13 @@ uv run --no-sync ./scripts/integration-tests.sh \
 
 Key flags: `--stack-config` (required), `--setup` (`gpt`, `ollama`, `vllm`),
 `--inference-mode` (`replay`, `record`, `record-if-missing`), `--file` (single file),
-`--pattern` (pytest `-k` filter), `--suite` (`base`, `responses`, `vision`).
+`--pattern` (pytest `-k` filter), `--suite` (`base`, `responses`, `vision`),
+`--install-deps` (install missing provider dependencies before running tests).
+
+The runner preflights the provider dependencies for the stack config — the
+same `ogx stack list-deps <config> | xargs -L1 uv pip install` step CI runs —
+and fails early with the exact install command when any are missing. Pass
+`--install-deps` to install them automatically (this is what CI does).
 
 If a test fails in replay mode with "Recording not found", re-run with
 `--inference-mode record-if-missing` and commit the new recording files.

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -24,6 +24,7 @@ VISION_MODEL=""
 EXTRA_PARAMS=""
 COLLECT_ONLY=false
 TYPESCRIPT_ONLY=false
+INSTALL_DEPS=false
 
 # Function to display usage
 usage() {
@@ -42,6 +43,8 @@ Options:
     --pattern STRING         Regex pattern to pass to pytest -k
     --collect-only           Collect tests only without running them (skips server startup)
     --typescript-only        Skip Python tests and run only TypeScript client tests
+    --install-deps           Install missing provider dependencies before running tests
+                             (mirrors the CI setup step: ogx stack list-deps <config> | xargs -L1 uv pip install)
     --help                   Show this help message
 
 Suites are defined in tests/integration/suites.py and define which tests to run.
@@ -118,6 +121,10 @@ while [[ $# -gt 0 ]]; do
         ;;
     --typescript-only)
         TYPESCRIPT_ONLY=true
+        shift
+        ;;
+    --install-deps)
+        INSTALL_DEPS=true
         shift
         ;;
     --help)
@@ -251,6 +258,87 @@ fi
 if ! command -v pytest &>/dev/null; then
     echo "pytest could not be found, ensure pytest is installed"
     exit 1
+fi
+
+# Function to check that the provider dependencies for a stack config are
+# installed, mirroring the CI setup step in .github/actions/setup-test-environment
+#   ogx stack list-deps <config> | xargs -L1 uv pip install
+# which is not visible to local runs. With INSTALL_DEPS=true, missing
+# dependencies are installed automatically; otherwise the function fails with
+# the exact command to run.
+check_provider_dependencies() {
+    local config_name="$1"
+
+    local deps_output
+    if ! deps_output=$(ogx stack list-deps "$config_name" 2>/dev/null); then
+        echo "Warning: Could not determine dependencies for '$config_name', skipping dependency check"
+        return 0
+    fi
+
+    local installed
+    installed=" $(uv pip list --format=freeze 2>/dev/null | cut -d= -f1 | tr '[:upper:]' '[:lower:]' | sed 's/[_.]/-/g' | tr '\n' ' ')"
+
+    local missing=()
+    local token name skip_next=false
+    for token in $deps_output; do
+        if $skip_next; then
+            skip_next=false
+            continue
+        fi
+        case "$token" in
+        --*)
+            # Skip pip flags and their values (e.g. --extra-index-url <url>)
+            skip_next=true
+            continue
+            ;;
+        -*)
+            continue
+            ;;
+        esac
+        # Strip extras, version specifiers, and environment markers to get the package name
+        name=$(echo "$token" | sed -E 's/\[.*\]//; s/[<>=!~;].*//' | tr '[:upper:]' '[:lower:]' | sed 's/[_.]/-/g')
+        if [[ -n "$name" && ! "$installed" == *" $name "* ]]; then
+            missing+=("$token")
+        fi
+    done
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        echo "✅ All provider dependencies for '$config_name' are installed"
+        return 0
+    fi
+
+    if [[ "$INSTALL_DEPS" == true ]]; then
+        echo "Installing missing provider dependencies: ${missing[*]}"
+        ogx stack list-deps "$config_name" | xargs -L1 uv pip install
+        return 0
+    fi
+
+    echo "❌ Missing required provider dependencies for '$config_name':"
+    for token in "${missing[@]}"; do
+        echo "   - $token"
+    done
+    echo ""
+    echo "Install them with (the same step CI runs):"
+    echo "    ogx stack list-deps $config_name | xargs -L1 uv pip install"
+    echo ""
+    echo "Or re-run this script with --install-deps to install them automatically."
+    return 1
+}
+
+# Preflight: ensure provider dependencies are installed for the stack config.
+# Skipped for docker configs (dependencies are baked into the image), remote
+# http configs, and collect-only runs.
+if [[ "$COLLECT_ONLY" == false && -n "$STACK_CONFIG" ]]; then
+    case "$STACK_CONFIG" in
+    docker:* | http://*)
+        ;;
+    server:*)
+        check_provider_dependencies "${STACK_CONFIG#server:}" || exit 1
+        ;;
+    *)
+        check_provider_dependencies "$STACK_CONFIG" || exit 1
+        ;;
+    esac
 fi
 
 # Helper function to find next available port

--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -309,7 +309,10 @@ check_provider_dependencies() {
 
     if [[ "$INSTALL_DEPS" == true ]]; then
         echo "Installing missing provider dependencies: ${missing[*]}"
-        ogx stack list-deps "$config_name" | xargs -L1 uv pip install
+        if ! ogx stack list-deps "$config_name" | xargs -L1 uv pip install; then
+            echo "Failed to install provider dependencies for '$config_name'" >&2
+            return 1
+        fi
         return 0
     fi
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -10,6 +10,14 @@ uv run --group test \
   pytest -sv tests/integration/ --stack-config=starter
 ```
 
+### Provider dependencies
+
+`scripts/integration-tests.sh` checks that the provider dependencies for the
+stack config are installed — the same `ogx stack list-deps <config> |
+xargs -L1 uv pip install` step CI runs — and fails early with the exact
+install command when any are missing. Pass `--install-deps` to install them
+automatically before running the tests.
+
 ## Configuration Options
 
 You can see all options with:

--- a/tests/unit/test_integration_runner.py
+++ b/tests/unit/test_integration_runner.py
@@ -1,0 +1,81 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("install_exit_code", [0, 42])
+def test_integration_runner_stops_after_failed_dependency_install(tmp_path: Path, install_exit_code: int) -> None:
+    command_dir = tmp_path / "bin"
+    command_dir.mkdir()
+    install_log = tmp_path / "install.log"
+    pytest_log = tmp_path / "pytest.log"
+    commands = {
+        "uv": """#!/bin/bash
+case "$1 $2" in
+    "pip list")
+        if [[ "${3:-}" != "--format=freeze" ]]; then
+            echo "ogx 1.0.2"
+        fi
+        ;;
+    "pip install")
+        echo "$*" > "$INSTALL_LOG"
+        exit "$INSTALL_EXIT_CODE"
+        ;;
+    *) exit 99 ;;
+esac
+""",
+        "ogx": """#!/bin/bash
+if [[ "$1 $2" == "stack list-deps" ]]; then
+    echo "sentence-transformers>=2"
+else
+    exit 99
+fi
+""",
+        "python": "#!/bin/bash\nexit 0\n",
+        "pytest": '#!/bin/bash\necho "$*" > "$PYTEST_LOG"\n',
+    }
+    for name, contents in commands.items():
+        command = command_dir / name
+        command.write_text(contents)
+        command.chmod(0o755)
+
+    environment = {
+        **os.environ,
+        "PATH": f"{command_dir}{os.pathsep}{os.environ['PATH']}",
+        "TMPDIR": str(tmp_path),
+        "INSTALL_EXIT_CODE": str(install_exit_code),
+        "INSTALL_LOG": str(install_log),
+        "PYTEST_LOG": str(pytest_log),
+    }
+    environment.pop("TS_CLIENT_PATH", None)
+    environment.pop("INTEGRATION_TESTS_POST_CMD", None)
+    root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [
+            "bash",
+            str(root / "scripts/integration-tests.sh"),
+            "--stack-config",
+            "ci-tests",
+            "--setup",
+            "gpt",
+            "--install-deps",
+        ],
+        cwd=root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert install_log.read_text().strip() == "pip install sentence-transformers>=2"
+    assert result.returncode == (0 if install_exit_code == 0 else 1), result.stdout + result.stderr
+    assert pytest_log.exists() == (install_exit_code == 0)


### PR DESCRIPTION
Backport #6471 to `release-1.0.x` so local integration runs detect missing provider dependencies before starting the server or tests. `--install-deps` installs the same dependencies used by CI, and the CI action now uses this shared path.

The release branch still builds its shell arguments as a string, so this backport appends `--install-deps` as a string. Copying main's array append would silently omit the flag on this branch.

Also propagate installation failures explicitly: the caller checks the preflight function's result, which disables Bash's automatic exit behavior inside that function. A failed installation now stops the runner before pytest starts.

Fixes #6462.

Validation: `bash -n scripts/integration-tests.sh`; seven shell/action probes covering missing dependencies, automatic installation, package-name normalization, remote/collection skips, and the CI flag enabled/disabled; `uv run pytest -q tests/unit/test_integration_runner.py` passes both install-success and install-failure cases. The failure regression reproduces on the original runner. All changed-file pre-commit hooks, including mypy, passed with Python 3.12 and Bash 5.2. The action probe fails against the unadapted array append and passes with this backport.
