### PR TITLE
fix: Stop integration tests when dependency installation fails.

### DIFF
--- a/scripts/integration-tests.sh
+++ b/scripts/integration-tests.sh
@@ -309,7 +309,10 @@ check_provider_dependencies() {
 
     if [[ "$INSTALL_DEPS" == true ]]; then
         echo "Installing missing provider dependencies: ${missing[*]}"
-        ogx stack list-deps "$config_name" | xargs -L1 uv pip install
+        if ! ogx stack list-deps "$config_name" | xargs -L1 uv pip install; then
+            echo "Failed to install provider dependencies for '$config_name'" >&2
+            return 1
+        fi
         return 0
     fi
 

--- a/tests/unit/test_integration_runner.py
+++ b/tests/unit/test_integration_runner.py
@@ -1,0 +1,81 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("install_exit_code", [0, 42])
+def test_integration_runner_stops_after_failed_dependency_install(tmp_path: Path, install_exit_code: int) -> None:
+    command_dir = tmp_path / "bin"
+    command_dir.mkdir()
+    install_log = tmp_path / "install.log"
+    pytest_log = tmp_path / "pytest.log"
+    commands = {
+        "uv": """#!/bin/bash
+case "$1 $2" in
+    "pip list")
+        if [[ "${3:-}" != "--format=freeze" ]]; then
+            echo "ogx 1.0.2"
+        fi
+        ;;
+    "pip install")
+        echo "$*" > "$INSTALL_LOG"
+        exit "$INSTALL_EXIT_CODE"
+        ;;
+    *) exit 99 ;;
+esac
+""",
+        "ogx": """#!/bin/bash
+if [[ "$1 $2" == "stack list-deps" ]]; then
+    echo "sentence-transformers>=2"
+else
+    exit 99
+fi
+""",
+        "python": "#!/bin/bash\nexit 0\n",
+        "pytest": '#!/bin/bash\necho "$*" > "$PYTEST_LOG"\n',
+    }
+    for name, contents in commands.items():
+        command = command_dir / name
+        command.write_text(contents)
+        command.chmod(0o755)
+
+    environment = {
+        **os.environ,
+        "PATH": f"{command_dir}{os.pathsep}{os.environ['PATH']}",
+        "TMPDIR": str(tmp_path),
+        "INSTALL_EXIT_CODE": str(install_exit_code),
+        "INSTALL_LOG": str(install_log),
+        "PYTEST_LOG": str(pytest_log),
+    }
+    environment.pop("TS_CLIENT_PATH", None)
+    environment.pop("INTEGRATION_TESTS_POST_CMD", None)
+    root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        [
+            "bash",
+            str(root / "scripts/integration-tests.sh"),
+            "--stack-config",
+            "ci-tests",
+            "--setup",
+            "gpt",
+            "--install-deps",
+        ],
+        cwd=root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert install_log.read_text().strip() == "pip install sentence-transformers>=2"
+    assert result.returncode == (0 if install_exit_code == 0 else 1), result.stdout + result.stderr
+    assert pytest_log.exists() == (install_exit_code == 0)


### PR DESCRIPTION
Stop the integration runner when `--install-deps` cannot install a provider dependency. The caller checks the preflight function's result, so Bash disables automatic exit behavior inside that function; its unconditional success return previously allowed tests to run after failed installations.

Check the install pipeline explicitly and return failure before starting the server or pytest. A regression test executes the real runner with successful and failing install commands and verifies that pytest only starts after a successful installation.

Validation: `uv run pytest -q tests/unit/test_integration_runner.py` passes both cases; the failure case reproduces against the original runner. `bash -n scripts/integration-tests.sh` and all changed-file pre-commit hooks, including mypy, pass. This is also included in the #6471 backport to `release-1.0.x`.
