### PR TITLE
fix: Backport reproducible client-first releases to 1.0.x.

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -100,10 +100,35 @@ jobs:
           echo "Next fallback: ${NEXT_FALLBACK}"
           echo "Release branch: ${RELEASE_BRANCH}"
 
+      - name: Check whether this release advances main
+        id: main-version
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          MAIN_FALLBACK=$(git show origin/main:pyproject.toml | sed -n 's/^fallback_version = "\(.*\)"/\1/p')
+          MAIN_VERSION="${MAIN_FALLBACK%%.dev*}"
+          if [[ ! "$MAIN_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Failed to parse main fallback ${MAIN_FALLBACK}"
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "update_main=false" >> "$GITHUB_OUTPUT"
+            echo "Release ${VERSION} is not stable; leaving main's version and dev tags unchanged"
+            exit 0
+          fi
+          NEWEST_VERSION=$(printf '%s\n' "$VERSION" "$MAIN_VERSION" | sort -V | tail -1)
+          if [ "$NEWEST_VERSION" == "$VERSION" ]; then
+            echo "update_main=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "update_main=false" >> "$GITHUB_OUTPUT"
+            echo "Release ${VERSION} is older than main ${MAIN_VERSION}; leaving main's version and dev tags unchanged"
+          fi
+
       # -----------------------------------------------------------------------
       # Step A: Tag main with the next dev tag
       # -----------------------------------------------------------------------
       - name: Push dev tag to main
+        if: steps.main-version.outputs.update_main == 'true'
         run: |
           DEV_TAG="${{ steps.parse.outputs.next_dev_tag }}"
 
@@ -126,6 +151,7 @@ jobs:
       # Step B: Bump fallback_version on main and open PR
       # -----------------------------------------------------------------------
       - name: Create fallback_version bump PR
+        if: steps.main-version.outputs.update_main == 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,6 +8,7 @@
 # Automates:
 #   - Updating fallback_version to the release version in both pyproject.toml files
 #   - Updating ogx-client pins to the release version
+#   - Regenerating and checking uv.lock after the client has been published
 #   - Committing all changes directly to the release branch
 #
 # =============================================================================
@@ -41,10 +42,10 @@ jobs:
           fetch-depth: 0
 
       - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.release_branch }}
         run: |
-          VERSION="${{ inputs.version }}"
-          BRANCH="${{ inputs.release_branch }}"
-
           # Validate version format (X.Y.Z)
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Invalid version format: ${VERSION}. Expected X.Y.Z (e.g., 0.5.1)"
@@ -57,12 +58,34 @@ jobs:
             exit 1
           fi
 
+          if [ "$BRANCH" != "release-${VERSION%.*}.x" ]; then
+            echo "::error::Failed to prepare ${VERSION}: expected branch release-${VERSION%.*}.x"
+            exit 1
+          fi
+
           echo "Preparing release v${VERSION} on ${BRANCH}"
 
-      - name: Update version files and commit directly to release branch
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Verify the matching client is published
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          VERSION="${{ inputs.version }}"
-          RELEASE_BRANCH="${{ inputs.release_branch }}"
+          if ! curl --fail --silent --show-error "https://pypi.org/pypi/ogx-client/${VERSION}/json" --output /dev/null; then
+            echo "::error::Failed to find ogx-client==${VERSION} on PyPI. Publish clients-only from the release branch first."
+            exit 1
+          fi
+
+      - name: Update version files and lock dependencies
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
 
           # --- Update fallback_version in both pyproject.toml files ---
           sed -i "s/^fallback_version = .*/fallback_version = \"${VERSION}\"/" pyproject.toml
@@ -73,6 +96,14 @@ jobs:
           # Match patterns like: "ogx-client>=X.Y.Z" or "ogx-client==X.Y.Z"
           sed -i -E "s/\"ogx-client[><=!]+[0-9]+\.[0-9]+\.[0-9]+[^\"]*\"/\"ogx-client==${VERSION}\"/" pyproject.toml
 
+          uv lock
+          uv lock --check
+
+      - name: Commit prepared release
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+        run: |
           # Show what changed
           echo "=== Changes ==="
           git diff
@@ -85,7 +116,7 @@ jobs:
 
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml src/ogx_api/pyproject.toml
+          git add pyproject.toml src/ogx_api/pyproject.toml uv.lock
           git commit -s -m "chore: prepare release v${VERSION}"
           git push origin "HEAD:${RELEASE_BRANCH}"
           echo "Committed version updates directly to ${RELEASE_BRANCH}"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -65,6 +65,9 @@
 #   published successfully but image builds failed. Requires "version" to be
 #   set to the already-published version.
 #
+# skip_latest: Keep Docker latest unchanged and publish npm clients under
+#   release-X.Y when backfilling. Release events also protect newer Docker tags.
+#
 # =============================================================================
 
 name: Build, test, and publish packages
@@ -117,6 +120,11 @@ on:
         default: 'main'
       docker_only:
         description: 'Skip package build/publish; only build and push Docker images (requires version)'
+        required: false
+        type: boolean
+        default: false
+      skip_latest:
+        description: 'Keep Docker and npm latest tags unchanged when backfilling an older release.'
         required: false
         type: boolean
         default: false
@@ -222,6 +230,8 @@ jobs:
         id: should-build
         run: |
           PACKAGES="${{ inputs.packages || 'all' }}"
+          # Clients are published before preparation locks the server to their exact version.
+          if [ "${{ github.event_name }}" == "release" ]; then PACKAGES="ogx-only"; fi
           PACKAGE="${{ matrix.package }}"
           TYPE="${{ matrix.type }}"
 
@@ -229,7 +239,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "$PACKAGES" == "ogx-only" ] && [ "$TYPE" == "local" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
-          elif [ "$PACKAGES" == "clients-only" ] && [ "$TYPE" == "external" ]; then
+          elif [ "$PACKAGES" == "clients-only" ] && { [ "$TYPE" == "external" ] || [ "$TYPE" == "openapi-sdk" ]; }; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -332,75 +342,12 @@ jobs:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.compute-version.outputs.version }}
 
       # === EXTERNAL PYTHON PACKAGE BUILD ===
-      - name: Check and bump version if exists on PyPI
+      - name: Set external Python package version
         if: steps.should-build.outputs.skip != 'true' && matrix.type == 'external' && matrix.registry == 'pypi'
         id: version-check
-        run: |
-          BASE_VERSION="${{ needs.compute-version.outputs.version }}"
-          MATRIX_PACKAGE="${{ matrix.package }}"
-
-          # Map matrix package name to actual PyPI package name
-          if [ "$MATRIX_PACKAGE" == "ogx-client-python" ]; then
-            PACKAGE="ogx-client"
-          else
-            PACKAGE="$MATRIX_PACKAGE"
-          fi
-
-          # Function to check if version exists on PyPI
-          check_version_exists() {
-            local pkg=$1
-            local ver=$2
-            if curl -sf "https://pypi.org/pypi/${pkg}/${ver}/json" -o /dev/null 2>&1; then
-              return 0  # exists
-            else
-              return 1  # does not exist
-            fi
-          }
-
-          # Start with the base version and increment patch if needed
-          VERSION="$BASE_VERSION"
-
-          # Only check/bump for non-dev versions (production releases)
-          if [[ ! "$VERSION" =~ \.dev ]]; then
-            echo "Checking if ${PACKAGE} ${VERSION} exists on PyPI..."
-
-            # Parse version components
-            if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
-              MAJOR="${BASH_REMATCH[1]}"
-              MINOR="${BASH_REMATCH[2]}"
-              PATCH="${BASH_REMATCH[3]}"
-              SUFFIX="${BASH_REMATCH[4]}"
-
-              # Keep incrementing patch version until we find one that doesn't exist
-              MAX_ATTEMPTS=10
-              ATTEMPT=0
-              while check_version_exists "$PACKAGE" "$VERSION"; do
-                ATTEMPT=$((ATTEMPT + 1))
-                if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-                  echo "::error::Reached maximum attempts ($MAX_ATTEMPTS) trying to find unused version"
-                  exit 1
-                fi
-
-                echo "Version ${VERSION} already exists on PyPI, trying next patch version..."
-                PATCH=$((PATCH + 1))
-                VERSION="${MAJOR}.${MINOR}.${PATCH}${SUFFIX}"
-                echo "Checking ${VERSION}..."
-              done
-
-              if [ "$VERSION" != "$BASE_VERSION" ]; then
-                echo "::notice::Bumped ${MATRIX_PACKAGE} (PyPI: ${PACKAGE}) version from ${BASE_VERSION} to ${VERSION} (already existed on PyPI)"
-              else
-                echo "Version ${VERSION} is available on PyPI for ${PACKAGE}"
-              fi
-            else
-              echo "::warning::Could not parse version ${VERSION}, using as-is"
-            fi
-          else
-            echo "Dev version detected (${VERSION}), skipping PyPI check"
-          fi
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Final version: ${VERSION}"
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+        run: echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build external Python package
         if: steps.should-build.outputs.skip != 'true' && matrix.type == 'external' && matrix.registry == 'pypi'
@@ -419,76 +366,14 @@ jobs:
           python -m build --outdir dist
 
       # === NPM PACKAGE BUILD ===
-      - name: Check and bump npm version if exists
+      - name: Set npm package version
         if: steps.should-build.outputs.skip != 'true' && matrix.registry == 'npm'
         id: npm-version-check
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
         run: |
-          BASE_VERSION="${{ needs.compute-version.outputs.version }}"
-          MATRIX_PACKAGE="${{ matrix.package }}"
-
-          # Map matrix package name to actual npm package name
-          if [ "$MATRIX_PACKAGE" == "ogx-client-typescript" ]; then
-            PACKAGE="ogx-client"
-          else
-            PACKAGE="$MATRIX_PACKAGE"
-          fi
-
-          # Convert PEP 440 dev version to valid semver for npm
-          # e.g. 0.4.5.dev20260202 -> 0.4.5-dev.20260202
-          VERSION="${BASE_VERSION/.dev/-dev.}"
-
-          # Function to check if version exists on npm using registry API
-          check_npm_version_exists() {
-            local pkg=$1
-            local ver=$2
-            if curl -sf "https://registry.npmjs.org/${pkg}/${ver}" -o /dev/null 2>&1; then
-              return 0  # exists
-            else
-              return 1  # does not exist
-            fi
-          }
-
-          # Only check/bump for non-dev versions (production releases)
-          if [[ ! "$VERSION" =~ -dev\. ]]; then
-            echo "Checking if ${PACKAGE} ${VERSION} exists on npm..."
-
-            # Parse version components (semver format)
-            if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
-              MAJOR="${BASH_REMATCH[1]}"
-              MINOR="${BASH_REMATCH[2]}"
-              PATCH="${BASH_REMATCH[3]}"
-              SUFFIX="${BASH_REMATCH[4]}"
-
-              # Keep incrementing patch version until we find one that doesn't exist
-              MAX_ATTEMPTS=10
-              ATTEMPT=0
-              while check_npm_version_exists "$PACKAGE" "$VERSION"; do
-                ATTEMPT=$((ATTEMPT + 1))
-                if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-                  echo "::error::Reached maximum attempts ($MAX_ATTEMPTS) trying to find unused version"
-                  exit 1
-                fi
-
-                echo "Version ${VERSION} already exists on npm, trying next patch version..."
-                PATCH=$((PATCH + 1))
-                VERSION="${MAJOR}.${MINOR}.${PATCH}${SUFFIX}"
-                echo "Checking ${VERSION}..."
-              done
-
-              if [ "$VERSION" != "${BASE_VERSION/.dev/-dev.}" ]; then
-                echo "::notice::Bumped ${MATRIX_PACKAGE} (npm: ${PACKAGE}) version from ${BASE_VERSION/.dev/-dev.} to ${VERSION} (already existed on npm)"
-              else
-                echo "Version ${VERSION} is available on npm for ${PACKAGE}"
-              fi
-            else
-              echo "::warning::Could not parse version ${VERSION}, using as-is"
-            fi
-          else
-            echo "Dev version detected (${VERSION}), skipping npm check"
-          fi
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Final version: ${VERSION}"
+          # Translate PEP 440 development versions to npm semver without changing the release.
+          echo "version=${VERSION/.dev/-dev.}" >> "$GITHUB_OUTPUT"
 
       - name: Build TypeScript package
         if: steps.should-build.outputs.skip != 'true' && matrix.registry == 'npm'
@@ -496,7 +381,7 @@ jobs:
         run: |
           NPM_VERSION="${{ steps.npm-version-check.outputs.version }}"
           echo "Setting version to $NPM_VERSION"
-          npm version "$NPM_VERSION" --no-git-tag-version
+          npm version "$NPM_VERSION" --no-git-tag-version --allow-same-version
           npm install
           npm run build
 
@@ -696,7 +581,7 @@ jobs:
       id-token: write  # for PyPI trusted publishing
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: test-package
+    needs: [test-package, compute-version]
     strategy:
       max-parallel: 1
       matrix:
@@ -721,6 +606,8 @@ jobs:
         id: should-publish
         run: |
           PACKAGES="${{ inputs.packages || 'all' }}"
+          # Clients are published before preparation locks the server to their exact version.
+          if [ "${{ github.event_name }}" == "release" ]; then PACKAGES="ogx-only"; fi
           PACKAGE="${{ matrix.package }}"
           TYPE="${{ matrix.type }}"
 
@@ -728,7 +615,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "$PACKAGES" == "ogx-only" ] && [ "$TYPE" == "local" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
-          elif [ "$PACKAGES" == "clients-only" ] && [ "$TYPE" == "external" ]; then
+          elif [ "$PACKAGES" == "clients-only" ] && { [ "$TYPE" == "external" ] || [ "$TYPE" == "openapi-sdk" ]; }; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -838,6 +725,8 @@ jobs:
         if: steps.should-publish.outputs.skip != 'true' && matrix.registry == 'npm' && steps.check-artifacts.outputs.has_artifacts == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          SKIP_LATEST: ${{ inputs.skip_latest }}
         run: |
           DRY_RUN="${{ inputs.dry_run }}"
           EVENT="${{ github.event_name }}"
@@ -862,7 +751,15 @@ jobs:
             fi
             # Extract and publish from the tarball
             TARBALL=$(find ./dist -name '*.tgz' | head -1)
-            npm publish "$TARBALL" --access public
+            DIST_TAG="latest"
+            if [ "$SKIP_LATEST" == "true" ]; then
+              if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)\. ]]; then
+                echo "::error::Failed to determine npm release stream from ${VERSION}"
+                exit 1
+              fi
+              DIST_TAG="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+            fi
+            npm publish "$TARBALL" --access public --tag "$DIST_TAG"
           else
             echo "DRY RUN: Verifying npm package (not publishing)"
             echo "Package tarball:"
@@ -941,6 +838,8 @@ jobs:
 
       - name: Determine image tags and build args
         id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ needs.compute-version.outputs.version }}"
           DISTRO="${{ matrix.distro }}"
@@ -950,12 +849,37 @@ jobs:
           EVENT="${{ github.event_name }}"
 
           if [ "$EVENT" == "release" ] || [ "$DRY_RUN" == "off" ]; then
+            SKIP_LATEST="${{ inputs.skip_latest }}"
+            if [ "$EVENT" == "release" ] && [ "$SKIP_LATEST" != "true" ]; then
+              if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                SKIP_LATEST="true"
+              else
+                if ! LATEST_TAG=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name'); then
+                  echo "::error::Failed to look up the latest release; refusing to overwrite Docker latest"
+                  exit 1
+                fi
+                LATEST_VERSION="${LATEST_TAG#v}"
+                if [[ ! "$LATEST_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "::error::Failed to parse latest release ${LATEST_TAG}; refusing to overwrite Docker latest"
+                  exit 1
+                fi
+                NEWEST_VERSION=$(printf '%s\n' "$VERSION" "$LATEST_VERSION" | sort -V | tail -1)
+                if [ "$NEWEST_VERSION" != "$VERSION" ]; then SKIP_LATEST="true"; fi
+              fi
+            fi
+            if [ "$SKIP_LATEST" == "true" ]; then
+              TAGS="${IMAGE}:${VERSION}"
+              LATEST_NOTE=""
+            else
+              TAGS="${IMAGE}:${VERSION},${IMAGE}:latest"
+              LATEST_NOTE=" + latest"
+            fi
             {
               echo "install_mode=pypi"
-              echo "tags=${IMAGE}:${VERSION},${IMAGE}:latest"
+              echo "tags=${TAGS}"
               echo "version_arg=PYPI_VERSION=${VERSION}"
             } >> "$GITHUB_OUTPUT"
-            echo "Publishing production image: ${IMAGE}:${VERSION} + latest"
+            echo "Publishing production image: ${IMAGE}:${VERSION}${LATEST_NOTE}"
           else
             {
               echo "install_mode=test-pypi"

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -112,14 +112,23 @@ For each release, the Release Owner should complete:
 
 Backports are handled automatically by Mergify — patch releases ship whatever has already been backported to the release branch. No manual cherry-picking needed.
 
+- [ ] Wait for the release branch's required checks to pass.
+- [ ] Run [**Build, test, and publish packages**](https://github.com/ogx-ai/ogx/actions/workflows/pypi.yml) from `release-0.4.x` with `version=0.4.5`, `packages=clients-only`, and `dry_run=build-only`.
+- [ ] After the client build passes, run the same workflow from the same release branch with `dry_run=off` to publish the clients at exactly `0.4.5`.
+  - Keep the default client ref so external clients use their matching release branch.
+  - Set `skip_latest=true` when releasing an older maintenance line.
+  - Verify `ogx-client==0.4.5` is available on PyPI and npm before preparing the server release. Do not substitute a different client version if publication fails.
 - [ ] Run the [**Prepare release**](https://github.com/ogx-ai/ogx/actions/workflows/prepare-release.yml) workflow:
   - Input `version`: `0.4.5`
   - Input `release_branch`: `release-0.4.x`
-  - This commits `fallback_version` and `ogx-client` pin updates directly to the release branch
+  - This verifies the matching client is on PyPI, updates `fallback_version` and the exact `ogx-client` pin, regenerates `uv.lock`, and runs `uv lock --check` before committing all three files to the release branch.
+- [ ] Verify the preparation commit and its required checks pass before tagging. A failed client lookup or dependency resolution leaves the release branch unmodified.
 
 **Release:**
 
 - [ ] Create GitHub release: tag `v0.4.5`, target `release-0.4.x`
+  - The release workflow publishes the server packages using the clients published above.
+  - Mark an older maintenance release as not latest.
 - [ ] Verify all 4 packages published:
   - [ogx on PyPI](https://pypi.org/project/ogx/)
   - [ogx-api on PyPI](https://pypi.org/project/ogx-api/)
@@ -130,9 +139,8 @@ Backports are handled automatically by Mergify — patch releases ship whatever 
 
 The following steps are handled automatically by the [**Post-release automation**](https://github.com/ogx-ai/ogx/actions/workflows/post-release.yml) workflow, which triggers on `release: published`:
 
-- Tags `main` with `v0.4.6-dev` (next dev tag)
-- Commits `fallback_version` bump to `"0.4.6.dev0"` directly to `main`
-- Commits the npm lockfile update directly to `release-0.4.x`
+- Tags `main` with the next dev tag and opens a fallback-version PR when the release is at least as new as main's current version.
+- Opens the npm lockfile update PR for `release-0.4.x`.
 
 #### Minor release (e.g., 0.5.0 — new release branch)
 
@@ -188,13 +196,13 @@ The unified workflow (`.github/workflows/pypi.yml`) builds and publishes all pac
 - **Local packages** (ogx, ogx-api): version comes from the git tag via `SETUPTOOLS_SCM_PRETEND_VERSION`
 - **External packages** (ogx-client python/typescript): the workflow patches `pyproject.toml`/`_version.py`/`package.json` at build time using the tag version via `sed`/`npm version`
 - `fallback_version` is only used for nightly/dev builds and Docker — not for releases
-- The workflow always runs from `main` but checks out the tag's commit for local packages
+- Manual workflows run from the selected branch or tag; release workflows run from the released tag. Select the target release branch for the client publication step.
 
 ### Workflow Modes
 
 | Trigger | Version | Target |
 |---|---|---|
-| `release: published` | From tag (`v0.4.5` → `0.4.5`) | pypi.org + npm |
+| `release: published` | From tag (`v0.4.5` → `0.4.5`) | Server packages on pypi.org; clients must already be published |
 | `schedule` (nightly) | `{base}.dev{YYYYMMDD}` (from dev tag or fallback) | test.pypi.org |
 | `workflow_dispatch` dry_run=test-pypi | `{base}.dev{YYYYMMDD}` or manual `version` input | test.pypi.org |
 | `workflow_dispatch` dry_run=off | Manual `version` input | pypi.org + npm |
@@ -204,11 +212,13 @@ The unified workflow (`.github/workflows/pypi.yml`) builds and publishes all pac
 
 ### Prepare release (`.github/workflows/prepare-release.yml`)
 
-Triggered via `workflow_dispatch`. Takes a version and release branch as input, then:
+Triggered via `workflow_dispatch` after publishing the matching clients. Takes a version and matching release branch as input, then:
 
+- Verifies `ogx-client==X.Y.Z` is available on PyPI
 - Updates `fallback_version` to the release version in both `pyproject.toml` files
 - Updates `ogx-client` pins to `==X.Y.Z`
-- Opens a PR to the release branch
+- Regenerates `uv.lock` and verifies it with `uv lock --check`
+- Commits both manifests and the lockfile directly to the release branch only after all checks pass
 
 ### Post-release (`.github/workflows/post-release.yml`)
 
@@ -224,15 +234,7 @@ The nightly build (in `pypi.yml`) derives its base version from `git describe --
 
 ## Future Improvements
 
-### 1. Remove the client pin problem
-
-The `ogx-client==X.Y.Z` pin in `pyproject.toml` can't be satisfied until the client is published, but the client is published in the same workflow run. Options:
-
-- Change the pin to `>=X.Y.Z` or `~=X.Y` so it doesn't require an exact match that doesn't exist yet
-- Remove the pin from the release branch entirely and let the workflow handle compatibility
-- Publish client packages first in a separate step, then update pins, then publish ogx
-
-### 2. Let setuptools-scm infer version from tags directly
+### 1. Let setuptools-scm infer version from tags directly
 
 Right now the workflow computes the version separately and passes it via `SETUPTOOLS_SCM_PRETEND_VERSION`. With dev tags now on `main`, setuptools-scm can potentially infer versions natively, which would:
 
@@ -241,6 +243,6 @@ Right now the workflow computes the version separately and passes it via `SETUPT
 - Make `uv build` work correctly locally without any env vars
 - Let setuptools-scm generate dev versions automatically (e.g., `0.5.0.dev3+gabcdef` based on commits since last tag)
 
-### 3. Client repos should use dynamic versioning
+### 2. Client repos should use dynamic versioning
 
 The `ogx-client-python` and `ogx-client-typescript` repos use static versions. The workflow patches them with `sed` at build time, which is fragile. If those repos adopted setuptools-scm (Python) or a similar scheme, the workflow could just set an env var instead of rewriting files.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -224,9 +224,11 @@ Triggered via `workflow_dispatch` after publishing the matching clients. Takes a
 
 Triggered automatically after the `pypi.yml` workflow succeeds for a release event. Handles:
 
-- **Dev tag**: Tags `main` with `vX.Y.(Z+1)-dev` so setuptools-scm can infer versions
-- **Fallback bump**: Commits `fallback_version` bump to the next `.dev0` directly to `main`
+- **Dev tag**: Tags `main` with `vX.Y.(Z+1)-dev` when the released stable version is at least as new as main's current version
+- **Fallback bump**: Opens a PR to bump `fallback_version` to the next `.dev0` under the same condition
 - **npm lockfile**: Opens a PR to the release branch updating the UI lockfile
+
+Older maintenance releases leave main's version and dev tags unchanged while still updating their release-branch UI dependency.
 
 ### Nightly version computation
 

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -1,0 +1,186 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Exercise release workflow shell decisions without publishing artifacts."""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+def _step(workflow: str, job: str, step_id: str) -> dict[str, Any]:
+    document = yaml.safe_load((WORKFLOWS / workflow).read_text())
+    return next(step for step in document["jobs"][job]["steps"] if step.get("id", step.get("name")) == step_id)
+
+
+def _run(
+    step: dict[str, Any], tmp_path: Path, values: dict[str, str], prefix: str = ""
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    def replace(match: re.Match[str]) -> str:
+        expression = match.group(1).strip()
+        return values.get(expression, "")
+
+    output = tmp_path / "output"
+    output.write_text("")
+    env = {**os.environ, "GITHUB_OUTPUT": str(output), "GITHUB_REPOSITORY": "ogx-ai/ogx"}
+    env.update({key: re.sub(r"\$\{\{(.*?)\}\}", replace, str(value)) for key, value in step.get("env", {}).items()})
+    script = re.sub(r"\$\{\{(.*?)\}\}", replace, step["run"])
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", prefix + "\n" + script],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    outputs = dict(line.split("=", 1) for line in output.read_text().splitlines() if "=" in line)
+    return result, outputs
+
+
+@pytest.mark.parametrize("step_id", ["version-check", "npm-version-check"])
+@pytest.mark.parametrize("version,expected", [("1.0.3", "1.0.3"), ("1.3.2.dev20260909", "1.3.2.dev20260909")])
+def test_client_build_keeps_requested_version_when_registry_has_it(
+    tmp_path: Path, step_id: str, version: str, expected: str
+) -> None:
+    result, outputs = _run(
+        _step("pypi.yml", "build-package", step_id),
+        tmp_path,
+        {"needs.compute-version.outputs.version": version, "matrix.package": "ogx-client-python"},
+        "curl() { return 0; }",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert outputs["version"] == (expected.replace(".dev", "-dev.") if step_id == "npm-version-check" else expected)
+
+
+@pytest.mark.parametrize("job,step_id", [("build-package", "should-build"), ("publish-packages", "should-publish")])
+@pytest.mark.parametrize(
+    "event,selection,kind,skip",
+    [
+        ("release", "all", "external", "true"),
+        ("release", "all", "openapi-sdk", "true"),
+        ("release", "all", "local", "false"),
+        ("workflow_dispatch", "ogx-only", "openapi-sdk", "true"),
+        ("workflow_dispatch", "ogx-only", "local", "false"),
+        ("workflow_dispatch", "clients-only", "openapi-sdk", "false"),
+        ("workflow_dispatch", "clients-only", "external", "false"),
+        ("workflow_dispatch", "clients-only", "local", "true"),
+        ("push", "all", "external", "false"),
+    ],
+)
+def test_package_selection(
+    tmp_path: Path, job: str, step_id: str, event: str, selection: str, kind: str, skip: str
+) -> None:
+    result, outputs = _run(
+        _step("pypi.yml", job, step_id),
+        tmp_path,
+        {
+            "github.event_name": event,
+            "inputs.packages || 'all'": selection,
+            "matrix.type": kind,
+            "matrix.package": "test-package",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert outputs["skip"] == skip
+
+
+@pytest.mark.parametrize(
+    "event,version,latest,skip,latest_tag",
+    [
+        ("release", "1.0.3", "v1.3.1", "false", False),
+        ("release", "1.3.1", "v1.3.1", "false", True),
+        ("release", "1.10.0", "v1.9.9", "false", True),
+        ("release", "1.3.2rc1", "v1.3.1", "false", False),
+        ("workflow_dispatch", "1.0.3", "v1.3.1", "true", False),
+        ("workflow_dispatch", "1.3.2", "v1.3.1", "false", True),
+    ],
+)
+def test_docker_latest_tag(tmp_path: Path, event: str, version: str, latest: str, skip: str, latest_tag: bool) -> None:
+    result, outputs = _run(
+        _step("pypi.yml", "publish-docker-images", "meta"),
+        tmp_path,
+        {
+            "github.event_name": event,
+            "inputs.dry_run": "off",
+            "inputs.skip_latest": skip,
+            "inputs.package_name || 'ogx'": "ogx",
+            "matrix.distro": "starter",
+            "needs.compute-version.outputs.version": version,
+        },
+        f"gh() {{ printf '%s\\n' '{latest}'; }}",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert outputs["tags"] == "ogxai/distribution-starter:" + version + (
+        ",ogxai/distribution-starter:latest" if latest_tag else ""
+    )
+
+
+@pytest.mark.parametrize("command", ["return 1", "printf '%s\\n' invalid"])
+def test_docker_fails_closed_when_latest_release_is_unavailable(tmp_path: Path, command: str) -> None:
+    result, outputs = _run(
+        _step("pypi.yml", "publish-docker-images", "meta"),
+        tmp_path,
+        {
+            "github.event_name": "release",
+            "inputs.skip_latest": "false",
+            "matrix.distro": "starter",
+            "inputs.package_name || 'ogx'": "ogx",
+            "needs.compute-version.outputs.version": "1.0.3",
+        },
+        f"gh() {{ {command}; }}",
+    )
+    assert result.returncode != 0
+    assert "tags" not in outputs
+
+
+@pytest.mark.parametrize("skip,expected", [("true", "release-1.0"), ("false", "latest")])
+def test_npm_backfill_uses_release_stream_dist_tag(tmp_path: Path, skip: str, expected: str) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "client.tgz").touch()
+    result, _ = _run(
+        _step("pypi.yml", "publish-packages", "Publish to npm"),
+        tmp_path,
+        {
+            "github.event_name": "workflow_dispatch",
+            "inputs.dry_run": "off",
+            "inputs.skip_latest": skip,
+            "needs.compute-version.outputs.version": "1.0.3",
+            "secrets.NPM_TOKEN": "test-token",
+        },
+        "npm() { printf '%s\\n' \"$@\" > npm-arguments; }",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    arguments = (tmp_path / "npm-arguments").read_text().splitlines()
+    assert arguments[arguments.index("--tag") + 1] == expected
+
+
+@pytest.mark.parametrize(
+    "version,current,update",
+    [
+        ("1.0.3", "1.3.1.dev0", "false"),
+        ("1.3.1", "1.3.1.dev0", "true"),
+        ("1.10.0", "1.9.9.dev0", "true"),
+        ("1.3.2rc1", "1.3.1.dev0", "false"),
+        ("1.0.3rc1", "1.3.1.dev0", "false"),
+    ],
+)
+def test_old_release_does_not_change_main_version(tmp_path: Path, version: str, current: str, update: str) -> None:
+    result, outputs = _run(
+        _step("post-release.yml", "post-release", "main-version"),
+        tmp_path,
+        {
+            "steps.parse.outputs.version": version,
+        },
+        f"git() {{ printf '%s\\n' 'fallback_version = \"{current}\"'; }}",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert outputs["update_main"] == update


### PR DESCRIPTION
Backport #6526's release-reproducibility fix to `release-1.0.x` for the JOSS patch release (#6460).

Publish the exact client versions first, then resolve and verify `uv.lock` before committing the server version and dependency pins. Release events publish the server packages, and maintenance releases preserve Docker/npm `latest` and main's newer development version. This branch retains the external Python client build used by 1.0 rather than importing main's generated SDK pipeline.

Validation: 37 workflow behavior cases pass on the release branch; six preparation probes pass; actionlint, action-pin checks, and changed-file validation pass. The non-publishing 1.0.3 client build and Python 3.12/3.13 package validation passed in https://github.com/ogx-ai/ogx/actions/runs/34341001690.

The default-branch post-release guard in #6526 must merge before publishing the GitHub release so older releases cannot change main's version.
