### PR TITLE
fix: preserve provider data context across lazy library client streams

### DIFF
--- a/src/ogx/core/library_client.py
+++ b/src/ogx/core/library_client.py
@@ -19,7 +19,7 @@ from collections.abc import AsyncGenerator, Generator, Mapping
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
-from typing import Any, TypeVar, Union, get_args, get_origin
+from typing import Any, TypeVar, Union, cast, get_args, get_origin
 
 import httpx
 import yaml
@@ -324,10 +324,16 @@ async def _route_call_in_process(
 
             if async_streaming:
                 # Wrap the body_iterator as an AsyncByteStream for lazy async
-                # iteration, preserving time-to-first-token benefits.
+                # iteration, preserving time-to-first-token benefits. The stream
+                # is consumed after the request_provider_data_context above
+                # exits, so preserve the captured context across iterations.
                 mock_response = httpx.Response(
                     status_code=result.status_code,
-                    stream=_SSEAsyncByteStream(result.body_iterator),
+                    stream=_SSEAsyncByteStream(
+                        preserve_contexts_async_generator(
+                            cast(AsyncGenerator[Any, None], result.body_iterator), [PROVIDER_DATA_VAR]
+                        )
+                    ),
                     headers={"Content-Type": content_type},
                     request=httpx.Request(method=method, url=url),
                 )

--- a/src/ogx_api/inference/fastapi_routes.py
+++ b/src/ogx_api/inference/fastapi_routes.py
@@ -174,7 +174,7 @@ def create_router(impl: Inference) -> APIRouter:
         result = await impl.openai_chat_completion(params)
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_sse_generator(result, context="chat_completion")),
+                _sse_generator(result, context="chat_completion"),
                 media_type="text/event-stream",
             )
         return result
@@ -252,7 +252,7 @@ def create_router(impl: Inference) -> APIRouter:
         result = await impl.openai_completion(params)
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_sse_generator(result, context="completion")),
+                _sse_generator(result, context="completion"),
                 media_type="text/event-stream",
             )
         return result

--- a/src/ogx_api/interactions/fastapi_routes.py
+++ b/src/ogx_api/interactions/fastapi_routes.py
@@ -156,7 +156,7 @@ def create_router(impl: Interactions) -> APIRouter:
             return result
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_google_sse_generator(cast(AsyncIterator[Any], result))),
+                _google_sse_generator(cast(AsyncIterator[Any], result)),
                 media_type="text/event-stream",
             )
 

--- a/src/ogx_api/messages/fastapi_routes.py
+++ b/src/ogx_api/messages/fastapi_routes.py
@@ -169,7 +169,7 @@ def create_router(impl: Messages) -> APIRouter:
 
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(_anthropic_sse_generator(result)),
+                _anthropic_sse_generator(result),
                 media_type="text/event-stream",
                 headers=response_headers,
             )

--- a/src/ogx_api/responses/fastapi_routes.py
+++ b/src/ogx_api/responses/fastapi_routes.py
@@ -450,7 +450,7 @@ def create_router(impl: Responses) -> APIRouter:
         # The implementation is typed to return an `AsyncIterator` for streaming.
         if isinstance(result, AsyncIterator):
             return StreamingResponse(
-                _preserve_context_for_sse(sse_generator(result)),
+                sse_generator(result),
                 media_type="text/event-stream",
             )
 

--- a/src/ogx_api/utils.py
+++ b/src/ogx_api/utils.py
@@ -1,0 +1,52 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Shared utility functions for the OGX API."""
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def _serialize_sse_data(data: Any) -> str:
+    if isinstance(data, BaseModel):
+        return data.model_dump_json()
+    return json.dumps(data)
+
+
+def create_sse_event(data: Any) -> str:
+    """Create a Server-Sent Event string: data: <json>\\n\\n."""
+    return f"data: {_serialize_sse_data(data)}\n\n"
+
+
+def create_sse_event_with_type(event_type: str, data: Any) -> str:
+    """Create a named Server-Sent Event string: event: <type>\\ndata: <json>\\n\\n."""
+    return f"event: {event_type}\ndata: {_serialize_sse_data(data)}\n\n"
+
+
+async def sse_stream(
+    event_gen: AsyncIterator[Any],
+    format_event: Callable[[Any], str],
+    format_error_event: Callable[[Exception], str],
+) -> AsyncGenerator[str, None]:
+    """Yield SSE events from an async generator.
+
+    Each item is serialized with ``format_event``. Cancellation closes the
+    underlying generator. Any other exception is reported as the final event
+    via ``format_error_event``, which should also log the exception.
+    """
+    try:
+        async for item in event_gen:
+            yield format_event(item)
+    except asyncio.CancelledError:
+        if hasattr(event_gen, "aclose"):
+            await event_gen.aclose()
+        raise
+    except Exception as e:
+        yield format_error_event(e)

--- a/tests/unit/core/routers/test_responses_router.py
+++ b/tests/unit/core/routers/test_responses_router.py
@@ -190,45 +190,6 @@ async def test_sse_format_is_correct():
     assert '"type": "response.output_text.delta"' in events[0]
 
 
-async def test_sse_stream_keeps_provider_context():
-    from ogx.core.request_headers import PROVIDER_DATA_VAR
-
-    app = FastAPI()
-    impl = AsyncMock(spec=Responses)
-    provider_data = {"provider": "test"}
-
-    async def _stream():
-        yield {"provider_data": PROVIDER_DATA_VAR.get()}
-        yield {"type": "response.completed"}
-
-    impl.create_openai_response.return_value = _stream()
-
-    router = build_fastapi_router(Api.responses, impl)
-    assert router is not None
-    app.include_router(router)
-
-    create = next(
-        r.endpoint
-        for r in router.routes
-        if getattr(r, "path", None) == "/v1/responses" and "POST" in getattr(r, "methods", set())
-    )
-
-    token = PROVIDER_DATA_VAR.set(provider_data)
-    try:
-        request = CreateResponseRequest(input="hi", model="test", stream=True)
-        response = await create(request)
-    finally:
-        PROVIDER_DATA_VAR.reset(token)
-
-    first_event = None
-    async for chunk in response.body_iterator:
-        first_event = chunk
-        break
-
-    assert first_event is not None
-    assert '"provider_data": {"provider": "test"}' in first_event
-
-
 async def test_sse_stream_reports_value_error_as_http_exception():
     app = FastAPI()
     impl = AsyncMock(spec=Responses)

--- a/tests/unit/core/test_library_client_streaming.py
+++ b/tests/unit/core/test_library_client_streaming.py
@@ -1,0 +1,53 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import json
+from collections.abc import AsyncGenerator
+
+from fastapi.responses import StreamingResponse
+
+from ogx.core.library_client import _route_call_in_process
+from ogx.core.request_headers import PROVIDER_DATA_VAR
+from ogx.core.server.routes import RouteAuthInfo, RouteImpls
+
+
+async def test_async_streaming_preserves_provider_data_context():
+    """Provider data must survive lazy iteration of the SSE stream.
+
+    AsyncOGXAsLibraryClient.call_api returns a response whose stream is
+    consumed after request_provider_data_context has exited, so the body
+    iterator must re-enter the captured context on each chunk.
+    """
+
+    async def endpoint() -> StreamingResponse:
+        async def gen() -> AsyncGenerator[str, None]:
+            yield json.dumps({"provider_data": PROVIDER_DATA_VAR.get()})
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    route_impls: RouteImpls = {
+        "post": {
+            r"^/v1/test$": (endpoint, "/v1/test", RouteAuthInfo()),
+        }
+    }
+
+    rest_response = await _route_call_in_process(
+        method="POST",
+        url="http://localhost/v1/test",
+        header_params=None,
+        body=None,
+        post_params=None,
+        route_impls=route_impls,
+        provider_data={"provider": "test"},
+        sanitize_headers=lambda headers: dict(headers or {}),
+        convert_body=lambda _func, body, **_kwargs: body,
+        async_streaming=True,
+    )
+
+    assert PROVIDER_DATA_VAR.get() is None
+
+    payload = b"".join([chunk async for chunk in rest_response.response.stream]).decode("utf-8")
+    assert '"provider_data": {"provider": "test"}' in payload


### PR DESCRIPTION
The async library client returned SSE streams that are consumed after request_provider_data_context exits, so code reading PROVIDER_DATA_VAR mid-stream saw the default value. Wrap the body iterator in preserve_contexts_async_generator (already used by the stainless streaming path) so the captured context is re-entered on each chunk.

With the root cause fixed in the library client, the per-route _preserve_context_for_sse workaround is no longer needed and is removed from ogx_api.utils and all four SSE route files, along with the now unused ogx_api.common.sse_context module. Replace the route-level context test with a library client test that exercises the real call_api streaming path.
