### PR TITLE
fix: give clear error message for invalid metadata filter keys

### DIFF
--- a/src/ogx/providers/remote/vector_io/neo4j/neo4j.py
+++ b/src/ogx/providers/remote/vector_io/neo4j/neo4j.py
@@ -79,8 +79,6 @@ def _quote_identifier(value: str) -> str:
 
 
 def _metadata_property(key: str) -> str:
-    if not _VALID_METADATA_KEY.match(key):
-        raise ValueError(f"Failed to translate Neo4j metadata filter: invalid metadata key {key!r}")
     return f"metadata_{key}"
 
 

--- a/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
+++ b/src/ogx/providers/remote/vector_io/pgvector/pgvector.py
@@ -7,7 +7,6 @@
 import asyncio
 import heapq
 import json
-import re
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -63,9 +62,6 @@ _PG_SQL_OPS: dict[str, str] = {
     "lt": "<",
     "lte": "<=",
 }
-
-# Regex for validating metadata key names to prevent SQL injection in JSONB paths
-_VALID_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]+$")
 
 
 def _quote_ident(name: str) -> str:
@@ -490,10 +486,6 @@ class PGVectorIndex(EmbeddingIndex):
     def _translate_comparison_filter(self, filter_obj: ComparisonFilter, param_idx: int) -> tuple[str, list[Any], int]:
         """Translate a comparison filter to PostgreSQL WHERE clause using JSONB operators."""
         key, value, op_type = filter_obj.key, filter_obj.value, filter_obj.type
-
-        # Validate key to prevent SQL injection in JSONB path
-        if not _VALID_KEY_PATTERN.match(key):
-            raise ValueError(f"Invalid metadata key name: {key!r}")
 
         # Use ->> to extract metadata value as text from the JSONB document column
         expr = f"document->'metadata'->>'{key}'"

--- a/src/ogx_api/filters.py
+++ b/src/ogx_api/filters.py
@@ -14,9 +14,10 @@ operations (and, or) for complex filtering logic.
 
 from __future__ import annotations
 
+import re
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .schema_utils import json_schema_type
 
@@ -24,6 +25,8 @@ from .schema_utils import json_schema_type
 COMPARISON_FILTER_TYPES = frozenset(["eq", "ne", "gt", "gte", "lt", "lte", "in", "nin"])
 COMPOUND_FILTER_TYPES = frozenset(["and", "or"])
 ALL_FILTER_TYPES = COMPARISON_FILTER_TYPES | COMPOUND_FILTER_TYPES
+
+_VALID_METADATA_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]+$")
 
 
 @json_schema_type
@@ -38,6 +41,16 @@ class ComparisonFilter(BaseModel):
     type: Literal["eq", "ne", "gt", "gte", "lt", "lte", "in", "nin"]
     key: str
     value: Any
+
+    @field_validator("key")
+    @classmethod
+    def _validate_key(cls, v: str) -> str:
+        if not _VALID_METADATA_KEY_PATTERN.match(v):
+            raise ValueError(
+                f"Failed to validate metadata filter key {v!r}: "
+                "keys must contain only alphanumeric characters, underscores, and hyphens"
+            )
+        return v
 
 
 @json_schema_type

--- a/tests/unit/providers/vector_io/test_neo4j.py
+++ b/tests/unit/providers/vector_io/test_neo4j.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from ogx.core.storage.datatypes import KVStoreReference
 from ogx.providers.remote.vector_io.neo4j.config import Neo4jVectorIOConfig
@@ -159,8 +160,8 @@ def test_neo4j_translate_compound_filter() -> None:
 
 
 def test_neo4j_translate_rejects_unsafe_metadata_key() -> None:
-    with pytest.raises(ValueError, match="Failed to translate Neo4j metadata filter"):
-        _translate_filters(ComparisonFilter(type="eq", key="topic.name", value="programming"))
+    with pytest.raises(ValidationError, match="Failed to validate metadata filter key"):
+        ComparisonFilter(type="eq", key="topic.name", value="programming")
 
 
 def test_neo4j_translate_rejects_unsupported_filter_type() -> None:

--- a/tests/unit/providers/vector_io/test_sqlite_vec_sql_injection.py
+++ b/tests/unit/providers/vector_io/test_sqlite_vec_sql_injection.py
@@ -1,0 +1,98 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+r"""
+Tests for metadata filter key validation (SQL injection prevention).
+
+The `key` field in ComparisonFilter is interpolated into SQL/JSON paths in
+multiple providers (sqlite_vec, milvus). A Pydantic field_validator now
+rejects keys that don't match `^[a-zA-Z0-9_\-]+$`, preventing SQL injection.
+
+Run:  uv run pytest tests/unit/providers/vector_io/test_sqlite_vec_sql_injection.py -v -s
+"""
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from ogx.providers.inline.vector_io.sqlite_vec.sqlite_vec import SQLiteVecIndex
+from ogx.providers.utils.vector_io.vector_utils import generate_chunk_id
+from ogx_api import ChunkMetadata, EmbeddedChunk
+from ogx_api.filters import ComparisonFilter
+
+
+def test_valid_keys_accepted():
+    """Normal metadata keys should pass validation."""
+    for key in ["author", "doc-id", "field_1", "Category", "x"]:
+        f = ComparisonFilter(type="eq", key=key, value="test")
+        assert f.key == key
+
+
+@pytest.mark.parametrize(
+    "malicious_key",
+    [
+        "'",
+        "'; DROP TABLE chunks; --",
+        "' OR 1=1 --",
+        "key', 1) OR 1=1 OR (1=1)",
+        "a;DELETE FROM t",
+        "a b",
+    ],
+)
+def test_malicious_keys_rejected(malicious_key):
+    """Keys with SQL metacharacters must be rejected with a helpful message."""
+    with pytest.raises(ValidationError) as exc_info:
+        ComparisonFilter(type="eq", key=malicious_key, value="x")
+
+    msg = str(exc_info.value)
+    assert "Failed to validate metadata filter key" in msg
+    assert repr(malicious_key) in msg
+
+
+@pytest.fixture(scope="session")
+def embedding_dimension():
+    return 768
+
+
+@pytest.fixture
+async def sqlite_vec_index(embedding_dimension, tmp_path_factory):
+    temp_dir = tmp_path_factory.getbasetemp()
+    db_path = str(temp_dir / "test_sqli.db")
+    index = await SQLiteVecIndex.create(dimension=embedding_dimension, db_path=db_path, bank_id="sqli_test")
+    yield index
+    await index.delete()
+
+
+async def test_sqlite_vec_normal_filter_works(sqlite_vec_index):
+    """End-to-end: valid filter works against the real SQLite backend."""
+    chunk_id = generate_chunk_id("doc-1", "content-1")
+    await sqlite_vec_index.add_chunks(
+        [
+            EmbeddedChunk(
+                content="test",
+                chunk_id=chunk_id,
+                metadata={"author": "alice"},
+                chunk_metadata=ChunkMetadata(
+                    document_id="doc-1",
+                    chunk_id=chunk_id,
+                    created_timestamp=0,
+                    updated_timestamp=0,
+                    content_token_count=3,
+                ),
+                embedding=np.zeros(768, dtype=np.float32).tolist(),
+                embedding_model="test",
+                embedding_dimension=768,
+            )
+        ]
+    )
+
+    resp = await sqlite_vec_index.query_vector(
+        np.zeros(768, dtype=np.float32),
+        k=3,
+        score_threshold=0.0,
+        filters=ComparisonFilter(type="eq", key="author", value="alice"),
+    )
+    assert len(resp.chunks) == 1


### PR DESCRIPTION
Keys containing characters outside [a-zA-Z0-9_-] were passed through to providers and caused obscure SQL errors (e.g. OperationalError: near ";": syntax error) surfaced as 500 responses. Add a Pydantic field_validator on ComparisonFilter.key (matching the existing pgvector pattern) so users get a helpful validation error at the API boundary explaining which characters are allowed.
