### PR TITLE
docs: Shorten the JOSS manuscript and correct its references.

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -2,8 +2,8 @@
   author       = {{OGX Contributors}},
   title        = {{OGX} (Open GenAI Stack)},
   year         = {2026},
-  url          = {https://github.com/ogx-ai/ogx/tree/9424b4d9e5eca99bfc79a6e0004e28adf5f58704},
-  note         = {Formerly Llama Stack. Software version under JOSS review: v1.0.2 (commit 9424b4d9e5eca99bfc79a6e0004e28adf5f58704). \url{https://github.com/ogx-ai/ogx/tree/9424b4d9e5eca99bfc79a6e0004e28adf5f58704}}
+  url          = {https://github.com/ogx-ai/ogx/tree/5393c94b2d23a3069b3708f9ca81ad350d2deb21},
+  note         = {Formerly Llama Stack. Software release: v1.0.3 (commit 5393c94b2d23a3069b3708f9ca81ad350d2deb21). \url{https://github.com/ogx-ai/ogx/tree/5393c94b2d23a3069b3708f9ca81ad350d2deb21}}
 }
 
 @misc{ogxk8soperator,

--- a/paper.bib
+++ b/paper.bib
@@ -49,12 +49,14 @@
 }
 
 @inproceedings{sglang,
-  author    = {Zheng, Lianmin and Yin, Liangsheng and Xie, Zhiqiang and Huang, Jeff and Sun, Chuyue and Yu, Cody Hao and Cao, Shiyi and Kober, Christos and Shi, Liang and Wu, Chien-Sheng and Zhang, Hao and Sheng, Ying and Gonzalez, Joseph E. and Stoica, Ion and Ma, Wei-Lin},
+  author    = {Zheng, Lianmin and Yin, Liangsheng and Xie, Zhiqiang and Sun, Chuyue and Huang, Jeff and Yu, Cody Hao and Cao, Shiyi and Kozyrakis, Christos and Stoica, Ion and Gonzalez, Joseph E. and Barrett, Clark and Sheng, Ying},
   title     = {{SGLang}: Efficient Execution of Structured Language Model Programs},
   booktitle = {Advances in Neural Information Processing Systems},
   year      = {2024},
   volume    = {37},
-  publisher = {Curran Associates, Inc.}
+  publisher = {Curran Associates, Inc.},
+  doi       = {10.52202/079017-2000},
+  url       = {https://proceedings.neurips.cc/paper_files/paper/2024/hash/724be4472168f31ba1c9ac630f15dec8-Abstract-Conference.html}
 }
 
 @manual{openaiResponsesAPI,

--- a/paper.md
+++ b/paper.md
@@ -138,7 +138,7 @@ As of June 2026, the project has over 8,400 GitHub stars, 242 contributors, 4,00
 
 # AI Usage Disclosure
 
-Generative AI tools, including GitHub Copilot, Anthropic Claude, and OpenAI Codex, were used for code completion, documentation drafting, and paper drafting. Assistance was limited to generating candidate text or code that human contributors reviewed, edited, tested, and validated. Core architectural decisions, API design, the security model, and final paper content were made by human authors.
+Generative AI tools, including GitHub Copilot, Anthropic Claude, and OpenAI Codex (GPT-6), were used for code completion, documentation drafting, and paper drafting. Assistance was limited to generating candidate text or code that human contributors reviewed, edited, tested, and validated. Core architectural decisions, API design, the security model, and final paper content were made by human authors.
 
 # Acknowledgements
 

--- a/paper.md
+++ b/paper.md
@@ -49,21 +49,19 @@ bibliography: paper.bib
 
 # Summary
 
-OGX (Open GenAI Stack), formerly Llama Stack [@llamastack], is an open-source AI application server and Python library that implements the APIs of major frontier labs (OpenAI, Anthropic, Google) with pluggable backend providers [@ogx]. Teams building agentic AI applications---such as retrieval-augmented generation (RAG) pipelines, multi-turn conversational agents, and tool-calling workflows---can develop against a single, stable API surface and deploy with any combination of inference engine, vector database, and safety backend, without changing application code.
+OGX (Open GenAI Stack), formerly Llama Stack [@llamastack], is an open-source AI application server and Python library with interchangeable backend providers [@ogx]. Teams building retrieval-augmented generation (RAG) pipelines, conversational agents, and tool-calling workflows can change their inference engine, vector database, and safety backend without rewriting application code.
 
-OGX's primary API focus is the Responses API for server-side agentic orchestration, conforming to the Open Responses specification [@openresponses]. The server also exposes Chat Completions, Embeddings, Vector Stores, Files, and Batches endpoints. Beyond OpenAI compatibility, OGX natively supports the Anthropic Messages API (`/v1/messages`) and Google GenAI Interactions API (`/v1alpha/interactions`), allowing teams using any of the three major client SDKs to connect to the same server. OGX supports over 20 inference providers (including vLLM, Ollama, OpenAI, Anthropic, Bedrock, and Gemini), 13 vector store backends, and 7 safety providers. It can run as an HTTP server for production deployments or be imported directly as a Python library for scripting and notebooks. A companion Kubernetes Operator [@ogxk8soperator] automates deployment lifecycle management through custom resources, supporting multi-architecture builds, hot-swappable distribution images, and both shared and per-tenant isolation topologies. Together, OGX and its operator serve as the self-hosted, model-agnostic backend for AI-powered developer tools such as Claude Code, Codex CLI, OpenCode, and OpenHands.
+OGX implements OpenAI, Anthropic, and Google APIs, with the Responses API for server-side orchestration as its primary focus [@openresponses]. It supports over 20 inference providers, 13 vector store backends, and 7 safety providers. A companion Kubernetes Operator [@ogxk8soperator] manages deployments, including shared and per-tenant instances. Together, OGX and its operator provide a self-hosted backend for AI-powered developer tools such as Claude Code, Codex CLI, OpenCode, and OpenHands.
 
 # Statement of Need
 
 AI application development today is tightly coupled to proprietary API providers. While inference-only workloads can increasingly be swapped across providers---vLLM, for example, supports the Responses API for basic inference---applications that rely on the full stack (retrieval, tool calling, conversation state, safety guardrails) remain difficult to migrate without rewriting significant application logic. This coupling limits reproducibility, makes comparisons across model providers difficult, and prevents teams from running AI workloads on controlled infrastructure---a requirement in regulated, privacy-sensitive, and air-gapped environments.
 
-Existing open-source tools address parts of this problem but not the whole. Inference engines like vLLM [@kwon2023vllm] and SGLang [@sglang] serve models efficiently but do not provide retrieval, tool calling, or conversation management. Gateway proxies like LiteLLM route requests across providers but do not execute the agentic loop or manage vector stores. Client-side frameworks like LangChain [@langchain] and LangGraph [@langgraph] provide developer abstractions but push orchestration, state management, and security enforcement to the application layer.
-
-OGX fills this gap by providing a complete, self-hosted AI application server that implements the OpenAI API surface---with the Responses API as its primary focus---alongside Anthropic Messages and Google GenAI Interactions compatibility layers. Developers write code against standard endpoints (`/v1/responses`, `/v1/chat/completions`, `/v1/vector_stores`) and swap the underlying infrastructure through configuration, not code changes. This decouples three decisions that are currently entangled: which SDK to use, which model to run, and where to deploy.
+OGX addresses this need through standard APIs and configurable infrastructure. Researchers can compare backends while keeping retrieval, tool authorization, and conversation handling in one server. This separates the choice of client SDK, model, and deployment environment, supporting reproducible configurations on controlled infrastructure.
 
 # State of the Field
 
-The AI application ecosystem has stratified into layers that each solve a subset of the deployment problem. OGX continues the Llama Stack project under a renamed, model-agnostic mission; the relevant comparison is therefore the server-side API layer that OGX provides versus adjacent inference engines, gateways, and client-side frameworks.
+OGX continues Llama Stack under a renamed, model-agnostic mission. Its server-side API layer complements inference engines, gateways, and client-side frameworks, which address different parts of the deployment problem.
 
 **Inference engines** (vLLM [@kwon2023vllm], SGLang [@sglang], Ollama) focus on efficient model serving. They optimize throughput and latency but do not provide retrieval, conversation state, tool execution, or safety guardrails. An application using vLLM for inference must separately integrate a vector database, implement its own agentic loop, and manage multi-turn state.
 
@@ -73,7 +71,7 @@ The AI application ecosystem has stratified into layers that each solve a subset
 
 **Proprietary platforms** (OpenAI's Responses API [@openaiResponsesAPI], Databricks Mosaic AI [@databricksAgentFramework]) offer integrated experiences but couple applications to a specific vendor's infrastructure and pricing.
 
-OGX occupies a distinct position: a self-hosted, vendor-neutral server that implements the full API surface---inference, retrieval, tool execution, conversation management, and safety---with pluggable providers at every layer. Its conformance to the Open Responses specification [@openresponses] ensures interoperability with any client that speaks the same protocol. It does not compete with client-side frameworks; it is the infrastructure they deploy against when reproducibility, provider portability, and centralized policy enforcement matter.
+OGX integrates inference, retrieval, tool execution, conversation management, and safety behind Open Responses-compatible APIs [@openresponses]. Combining these responsibilities in a server addresses a different trust boundary from extending a client-side framework: applications share centralized policy enforcement and provider configuration while retaining their own agent logic.
 
 # Software Design
 
@@ -107,7 +105,7 @@ The OGX Kubernetes Operator [@ogxk8soperator] provides declarative deployment th
 
 # Example Usage
 
-The following example demonstrates building a RAG agent using the standard OpenAI SDK against an OGX server. The same code works regardless of which inference provider or vector store backend is configured:
+This RAG example uses the standard OpenAI SDK against OGX, with inference and vector storage selected through server configuration:
 
 ```python
 from openai import OpenAI
@@ -128,7 +126,7 @@ response = client.responses.create(
 print(response.output_text)
 ```
 
-Switching from a local Ollama backend to a production vLLM cluster requires changing only the server's distribution configuration---the client code above remains identical. Published tutorials demonstrate this portability across diverse enterprise backends, including IBM watsonx.ai with Milvus vector storage [@ibm_rag_milvus] and Oracle Cloud Infrastructure with OCI AI Blueprints [@oracle_oci_ogx].
+Switching from Ollama to vLLM changes the server configuration while preserving this client code. Published tutorials cover IBM watsonx.ai with Milvus [@ibm_rag_milvus] and Oracle Cloud Infrastructure with OCI AI Blueprints [@oracle_oci_ogx].
 
 # Research Impact Statement
 
@@ -140,7 +138,7 @@ As of June 2026, the project has over 8,400 GitHub stars, 242 contributors, 4,00
 
 # AI Usage Disclosure
 
-Generative AI tools, including GitHub Copilot and Anthropic Claude models available during development, were used for code completion, documentation drafting, and paper drafting. Assistance was limited to generating candidate text or code that human contributors reviewed, edited, tested, and validated. Core architectural decisions, API design, the security model, and final paper content were made by human authors.
+Generative AI tools, including GitHub Copilot, Anthropic Claude, and OpenAI Codex, were used for code completion, documentation drafting, and paper drafting. Assistance was limited to generating candidate text or code that human contributors reviewed, edited, tested, and validated. Core architectural decisions, API design, the security model, and final paper content were made by human authors.
 
 # Acknowledgements
 

--- a/paper/README.md
+++ b/paper/README.md
@@ -4,11 +4,12 @@ This directory holds `ogx.tex` (and its build artifacts `ogx.bbl`, `ogx.pdf`,
 `references.bib`), a standalone, diagram-heavy technical whitepaper. **It is a
 separate document from the JOSS submission**, not an alternate build of it.
 
-- **JOSS manuscript:** [`paper.md`](https://github.com/ogx-ai/ogx/blob/3a1e778b362a5f827796b0dd3529bd883607ed59/paper.md)
-  and [`paper.bib`](https://github.com/ogx-ai/ogx/blob/3a1e778b362a5f827796b0dd3529bd883607ed59/paper.bib)
-  at commit `3a1e778b362a5f827796b0dd3529bd883607ed59`, including the
-  revised deployment wording and versioned software and operator citations
-  recorded below. These links identify the manuscript independently of the
+- **JOSS manuscript:** [`paper.md`](https://github.com/ogx-ai/ogx/blob/ef952f3d023a5d4f6e82ea1ec48b07a812529ed9/paper.md)
+  and [`paper.bib`](https://github.com/ogx-ai/ogx/blob/ef952f3d023a5d4f6e82ea1ec48b07a812529ed9/paper.bib)
+  at commit `ef952f3d023a5d4f6e82ea1ec48b07a812529ed9`, including the
+  shortened manuscript, corrected SGLang reference, revised deployment
+  wording, and versioned source citations recorded below. These links
+  identify the manuscript independently of the
   software release tag.
 - **This whitepaper:** `ogx.tex`, built against `references.bib` and `ogx.bbl`
   in this directory. It shares subject matter with `paper.md` but is
@@ -28,7 +29,7 @@ manuscript are identified independently:
 | --- | --- | --- |
 | OGX software | `v1.0.2` | commit `9424b4d9e5eca99bfc79a6e0004e28adf5f58704` |
 | OGX Kubernetes Operator | `v0.10.0` | commit `7fa16532e1434bf74493ca305b1e21030914ae57` |
-| Manuscript (`paper.md` / `paper.bib`) | -- | commit `3a1e778b362a5f827796b0dd3529bd883607ed59` |
+| Manuscript (`paper.md` / `paper.bib`) | -- | commit `ef952f3d023a5d4f6e82ea1ec48b07a812529ed9` |
 
 The operator reference is an existing tagged source snapshot. Its
 [`OGXServer` API](https://github.com/ogx-ai/ogx-k8s-operator/blob/7fa16532e1434bf74493ca305b1e21030914ae57/api/v1beta1/ogxserver_types.go)

--- a/paper/README.md
+++ b/paper/README.md
@@ -41,14 +41,19 @@ not establish the operator version used by historical deployments.
 
 ## JOSS proof
 
-The [existing JOSS proof](https://github.com/openjournals/joss-papers/blob/28806e6eceeb8d146d178df7f4194fa2549ad4fc/joss.11234/10.21105.joss.11234.pdf)
-was generated on 31 August 2026 and predates these manuscript updates. It
-still contains the unversioned software and operator citations. The pinned
-manuscript above identifies the revised source, not the build commit of that
-older proof.
-After merging the updates, run `@editorialbot generate pdf` on the
+The [JOSS proof generated on 10 September 2026](https://github.com/openjournals/joss-papers/blob/45c9cbbc304d51ba94241c9ecd1322574bfcd7e8/joss.11234/10.21105.joss.11234.pdf)
+contains the revised deployment wording and versioned software and operator
+citations. Its corresponding manuscript pair is pinned at
+[`3a1e778b362a5f827796b0dd3529bd883607ed59`](https://github.com/ogx-ai/ogx/tree/3a1e778b362a5f827796b0dd3529bd883607ed59);
+those files are byte-identical to the merged source when the proof was
+requested. This identifies a source snapshot, without claiming the bot's
+checkout commit. The PDF SHA-256 is
+`e7c843d2b827bbb9333d7d1df33c83aa1da84300899f83e0eaaaa15a48730b57`.
+
+That proof predates the shortened manuscript and corrected SGLang reference
+pinned above. After merging those updates, run `@editorialbot generate pdf` on the
 [JOSS review issue](https://github.com/openjournals/joss-reviews/issues/11234)
-to generate a proof with the revised wording and versioned citations, and
+to generate a proof with the final manuscript, and
 record the new proof link alongside its manuscript source revision. If either
 manuscript file changes, update both source links and the table before
 regenerating the proof.

--- a/paper/README.md
+++ b/paper/README.md
@@ -4,9 +4,9 @@ This directory holds `ogx.tex` (and its build artifacts `ogx.bbl`, `ogx.pdf`,
 `references.bib`), a standalone, diagram-heavy technical whitepaper. **It is a
 separate document from the JOSS submission**, not an alternate build of it.
 
-- **JOSS manuscript:** [`paper.md`](https://github.com/ogx-ai/ogx/blob/ef952f3d023a5d4f6e82ea1ec48b07a812529ed9/paper.md)
-  and [`paper.bib`](https://github.com/ogx-ai/ogx/blob/ef952f3d023a5d4f6e82ea1ec48b07a812529ed9/paper.bib)
-  at commit `ef952f3d023a5d4f6e82ea1ec48b07a812529ed9`, including the
+- **JOSS manuscript:** [`paper.md`](https://github.com/ogx-ai/ogx/blob/7ce8d77a4faa98863529f227d874b75770b6c805/paper.md)
+  and [`paper.bib`](https://github.com/ogx-ai/ogx/blob/7ce8d77a4faa98863529f227d874b75770b6c805/paper.bib)
+  at commit `7ce8d77a4faa98863529f227d874b75770b6c805`, including the
   shortened manuscript, corrected SGLang reference, revised deployment
   wording, and versioned source citations recorded below. These links
   identify the manuscript independently of the
@@ -22,14 +22,14 @@ manuscript, use the pinned links above.
 
 ## Source references
 
-The software version under review, operator source reference, and revised
+The software version for this revision, operator source reference, and revised
 manuscript are identified independently:
 
 | Component | Revision | Reference |
 | --- | --- | --- |
-| OGX software | `v1.0.2` | commit `9424b4d9e5eca99bfc79a6e0004e28adf5f58704` |
+| OGX software | `v1.0.3` | commit `5393c94b2d23a3069b3708f9ca81ad350d2deb21` |
 | OGX Kubernetes Operator | `v0.10.0` | commit `7fa16532e1434bf74493ca305b1e21030914ae57` |
-| Manuscript (`paper.md` / `paper.bib`) | -- | commit `ef952f3d023a5d4f6e82ea1ec48b07a812529ed9` |
+| Manuscript (`paper.md` / `paper.bib`) | -- | commit `7ce8d77a4faa98863529f227d874b75770b6c805` |
 
 The operator reference is an existing tagged source snapshot. Its
 [`OGXServer` API](https://github.com/ogx-ai/ogx-k8s-operator/blob/7fa16532e1434bf74493ca305b1e21030914ae57/api/v1beta1/ogxserver_types.go)
@@ -42,16 +42,17 @@ not establish the operator version used by historical deployments.
 ## JOSS proof
 
 The [JOSS proof generated on 10 September 2026](https://github.com/openjournals/joss-papers/blob/45c9cbbc304d51ba94241c9ecd1322574bfcd7e8/joss.11234/10.21105.joss.11234.pdf)
-contains the revised deployment wording and versioned software and operator
-citations. Its corresponding manuscript pair is pinned at
+contains the revised deployment wording, OGX `v1.0.2` citation, and versioned
+operator citation. Its corresponding manuscript pair is pinned at
 [`3a1e778b362a5f827796b0dd3529bd883607ed59`](https://github.com/ogx-ai/ogx/tree/3a1e778b362a5f827796b0dd3529bd883607ed59);
 those files are byte-identical to the merged source when the proof was
 requested. This identifies a source snapshot, without claiming the bot's
 checkout commit. The PDF SHA-256 is
 `e7c843d2b827bbb9333d7d1df33c83aa1da84300899f83e0eaaaa15a48730b57`.
 
-That proof predates the shortened manuscript and corrected SGLang reference
-pinned above. After merging those updates, run `@editorialbot generate pdf` on the
+That proof predates the shortened manuscript, OGX `v1.0.3` citation, and
+corrected SGLang reference pinned above. After merging those updates, run
+`@editorialbot generate pdf` on the
 [JOSS review issue](https://github.com/openjournals/joss-reviews/issues/11234)
 to generate a proof with the final manuscript, and
 record the new proof link alongside its manuscript source revision. If either


### PR DESCRIPTION
the JOSS bot flagged the manuscript's length and a possible missing SGLang DOI. this revision removes repeated overview material, retains every required section and the qualified deployment statement from #6486, and reduces the manuscript body to 1,573 whitespace-separated words (1,521 excluding the code block).

the SGLang citation now uses the DOI and complete author order verified against the [NeurIPS proceedings](https://proceedings.neurips.cc/paper_files/paper/2024/hash/724be4472168f31ba1c9ac630f15dec8-Abstract-Conference.html). the OGX citation points to the published [v1.0.3 release](https://github.com/ogx-ai/ogx/releases/tag/v1.0.3), at `5393c94b2d23a3069b3708f9ca81ad350d2deb21`. the AI disclosure names OpenAI Codex (GPT-6), used for these revisions; historical Copilot/Claude model versions still need author confirmation. `paper/README.md` pins both revised source files to `7ce8d77a4faa98863529f227d874b75770b6c805`.

validation: changed-file pre-commit passed; an independent read-only check confirmed all required manuscript sections and 22 citation keys are retained, and the Research Impact Statement is unchanged. the revised manuscript remains within JOSS's 750–1750-word guidance by both local counts. the official PDF needs regeneration after merge.

the README now also records the verified 10 September proof, its SHA-256, and the corresponding source snapshot; #6484 is closed. that proof contains the merged source-reference and deployment-wording fixes and predates this shortening. the final proof follow-up is tracked in [JOSS #11234](https://github.com/openjournals/joss-reviews/issues/11234). this is a manuscript-only change and needs no software-release backport.
