### PR TITLE
chore(ui): Update the 1.0 release lockfile to ogx-client 1.0.3.

### DIFF
--- a/src/ogx_ui/package-lock.json
+++ b/src/ogx_ui/package-lock.json
@@ -27,7 +27,7 @@
         "next": "15.5.25",
         "next-auth": "^4.24.11",
         "next-themes": "^0.4.6",
-        "ogx-client": "^1.0.2",
+        "ogx-client": "^1.0.3",
         "papaparse": "^5.5.3",
         "react": "^19.0.0",
         "react-dom": "^19.2.0",
@@ -11259,9 +11259,9 @@
       }
     },
     "node_modules/ogx-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.2.tgz",
-      "integrity": "sha512-wlgUV/4ROjBP6yI2zc+kUwk1JpdV8M/D+D08sv3tJ4Y9c2qzGDmnqCvnNUXqfOBPEzxN/oRG3MgtSzdrEb4jFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ogx-client/-/ogx-client-1.0.3.tgz",
+      "integrity": "sha512-33YB82ah7/4O1UYdV2ayYuSwLK57hb0VIDEQpzT6cb9AnlnxnRGNPU67LG3UifBC4lTrjvW8B/4+GFyb0jNzYg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/src/ogx_ui/package.json
+++ b/src/ogx_ui/package.json
@@ -52,7 +52,7 @@
     "next": "15.5.25",
     "next-auth": "^4.24.11",
     "next-themes": "^0.4.6",
-    "ogx-client": "^1.0.2",
+    "ogx-client": "^1.0.3",
     "papaparse": "^5.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
the v1.0.3 release branch still locks the UI's `ogx-client` to 1.0.2. this completes step C of the post-release workflow by locking the published package to exactly 1.0.3 and updating the manifest range to `^1.0.3`. the diff is limited to the client range, version, package URL, and integrity hash.

validation: a clean `npm ci` installs exactly 1.0.3; type checking, all 22 UI test suites (309 tests, two existing skips), the production build, and every applicable changed-file pre-commit check pass with Node 22. regenerating `uv.lock` produces no changes.
