### PR TITLE
fix: Wait for published wheels before building release images.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -959,22 +959,40 @@ jobs:
             echo "Publishing test image: ${IMAGE}:test-${VERSION} (package: ${PACKAGE_NAME})"
           fi
 
-      - name: Wait for package on test PyPI
-        if: steps.meta.outputs.install_mode == 'test-pypi'
+      - name: Wait for packages on the selected index
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          INSTALL_MODE: ${{ steps.meta.outputs.install_mode }}
+          PACKAGE_NAME: ${{ steps.meta.outputs.package_name || 'ogx' }}
         run: |
-          VERSION="${{ needs.compute-version.outputs.version }}"
-          PACKAGE_NAME="${{ steps.meta.outputs.package_name }}"
-          URL="https://test.pypi.org/pypi/${PACKAGE_NAME}/${VERSION}/json"
-          echo "Polling ${URL} ..."
+          case "$INSTALL_MODE" in
+            pypi) INDEX_URL="https://pypi.org/simple" ;;
+            test-pypi) INDEX_URL="https://test.pypi.org/simple" ;;
+            *) echo "::error::Failed to select package index for ${INSTALL_MODE}"; exit 1 ;;
+          esac
+          PACKAGES=("$PACKAGE_NAME")
+          # Pre-rename releases can bundle their API instead of publishing it separately.
+          if [ "$PACKAGE_NAME" == "ogx" ]; then PACKAGES+=(ogx-api); fi
+
           for i in $(seq 1 20); do
-            if curl -sf "$URL" -o /dev/null; then
-              echo "${PACKAGE_NAME}==${VERSION} is available on test PyPI"
+            READY=true
+            for package in "${PACKAGES[@]}"; do
+              WHEEL_PREFIX="${package//-/_}-${VERSION}-"
+              if ! curl --fail --silent --show-error --connect-timeout 5 --max-time 10 \
+                -H 'Accept: application/vnd.pypi.simple.v1+json' "${INDEX_URL}/${package}/" \
+                | jq --exit-status --arg prefix "$WHEEL_PREFIX" \
+                  'any(.files[]; (.filename | startswith($prefix) and endswith(".whl")) and (.yanked | not))' > /dev/null; then
+                echo "Attempt ${i}/20: ${package}==${VERSION} is not yet available on ${INDEX_URL}"
+                READY=false
+              fi
+            done
+            if [ "$READY" == "true" ]; then
+              echo "Release wheels are available on ${INDEX_URL}"
               exit 0
             fi
-            echo "Attempt ${i}/20: not yet available, waiting 30s..."
-            sleep 30
+            if [ "$i" -lt 20 ]; then sleep 30; fi
           done
-          echo "::error::${PACKAGE_NAME}==${VERSION} did not appear on test PyPI after 10 minutes"
+          echo "::error::Failed to find release wheels for ${PACKAGES[*]}==${VERSION} on ${INDEX_URL} after 20 attempts"
           exit 1
 
       - name: Generate config labels

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -128,6 +128,7 @@ Backports are handled automatically by Mergify — patch releases ship whatever 
 
 - [ ] Create GitHub release: tag `v0.4.5`, target `release-0.4.x`
   - The release workflow publishes the server packages using the clients published above.
+  - Before building Docker images, it checks the selected package index for the exact server and API wheels. Missing or withdrawn wheels are retried for up to 20 attempts, with 30 seconds between attempts; the build stops if they remain unavailable. Historical `llama-stack` releases only require the server wheel because their API may be bundled.
   - Mark an older maintenance release as not latest.
 - [ ] Verify all 4 packages published:
   - [ogx on PyPI](https://pypi.org/project/ogx/)

--- a/tests/unit/test_release_workflows.py
+++ b/tests/unit/test_release_workflows.py
@@ -184,3 +184,100 @@ def test_old_release_does_not_change_main_version(tmp_path: Path, version: str, 
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert outputs["update_main"] == update
+
+
+def _package_readiness_step() -> dict[str, Any]:
+    document = yaml.safe_load((WORKFLOWS / "pypi.yml").read_text())
+    return next(
+        step
+        for step in document["jobs"]["publish-docker-images"]["steps"]
+        if step["name"].startswith("Wait for package")
+    )
+
+
+@pytest.mark.parametrize("mode,host", [("pypi", "pypi.org"), ("test-pypi", "test.pypi.org")])
+def test_docker_waits_for_both_packages_on_the_selected_index(tmp_path: Path, mode: str, host: str) -> None:
+    step = _package_readiness_step()
+    assert not step.get("if"), "The readiness check must run for production as well as TestPyPI"
+    result, _ = _run(
+        step,
+        tmp_path,
+        {
+            "needs.compute-version.outputs.version": "1.0.3",
+            "steps.meta.outputs.install_mode": mode,
+            "steps.meta.outputs.package_name || 'ogx'": "ogx",
+        },
+        r"""
+        curl() {
+          local argument url
+          for argument in "$@"; do
+            case "$argument" in https://*) url="$argument" ;; esac
+          done
+          printf '%s\n' "$url" >> requests
+          case "$url" in
+            */ogx-api/)
+              if [ ! -f api-requested ]; then touch api-requested; return 22; fi
+              printf '%s\n' '{"meta":{"api-version":"1.0"},"files":[{"filename":"ogx_api-1.0.3-py3-none-any.whl","yanked":false}]}' ;;
+            */ogx/)
+              printf '%s\n' '{"meta":{"api-version":"1.0"},"files":[{"filename":"ogx-1.0.3-py3-none-any.whl","yanked":false}]}' ;;
+            *) return 22 ;;
+          esac
+        }
+        sleep() { printf '%s\n' "$1" >> sleeps; }
+        """,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    requests = (tmp_path / "requests").read_text().splitlines()
+    assert requests.count(f"https://{host}/simple/ogx-api/") == 2
+    assert requests.count(f"https://{host}/simple/ogx/") == 2
+    assert (tmp_path / "sleeps").read_text().splitlines() == ["30"]
+
+
+@pytest.mark.parametrize(
+    "unavailable_file",
+    [
+        '{"filename":"ogx-1.0.2-py3-none-any.whl","yanked":false}',
+        '{"filename":"ogx-1.0.3.tar.gz","yanked":false}',
+        '{"filename":"ogx-1.0.3-py3-none-any.whl","yanked":"withdrawn"}',
+        '{"filename":"ogx-1.0.3-py3-none-any.whl","yanked":""}',
+        '{"filename":"ogx-1.0.3-py3-none-any.whl","yanked":true}',
+    ],
+)
+def test_docker_stops_after_bounded_wait_for_missing_or_yanked_release(tmp_path: Path, unavailable_file: str) -> None:
+    (tmp_path / "index.json").write_text('{"meta":{"api-version":"1.0"},"files":[' + unavailable_file + "]}")
+    result, _ = _run(
+        _package_readiness_step(),
+        tmp_path,
+        {
+            "needs.compute-version.outputs.version": "1.0.3",
+            "steps.meta.outputs.install_mode": "pypi",
+            "steps.meta.outputs.package_name || 'ogx'": "ogx",
+        },
+        'curl() { echo request >> requests; cat index.json; }\nsleep() { echo "$1" >> sleeps; }',
+    )
+    assert result.returncode != 0
+    assert len((tmp_path / "requests").read_text().splitlines()) == 40
+    assert (tmp_path / "sleeps").read_text().splitlines() == ["30"] * 19
+
+
+def test_docker_wait_preserves_legacy_releases_with_bundled_api(tmp_path: Path) -> None:
+    result, _ = _run(
+        _package_readiness_step(),
+        tmp_path,
+        {
+            "needs.compute-version.outputs.version": "0.5.0",
+            "steps.meta.outputs.install_mode": "pypi",
+            "steps.meta.outputs.package_name || 'ogx'": "llama-stack",
+        },
+        r"""
+        curl() {
+          printf '%s\n' "$@" >> requests
+          printf '%s\n' '{"meta":{"api-version":"1.0"},"files":[{"filename":"llama_stack-0.5.0-py3-none-any.whl","yanked":false}]}'
+        }
+        sleep() { return 1; }
+        """,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    requests = (tmp_path / "requests").read_text()
+    assert "https://pypi.org/simple/llama-stack/" in requests
+    assert "llama-stack-api" not in requests


### PR DESCRIPTION
the Docker jobs can start before the newly published wheels are visible on the package index. the [v1.0.3 starter build](https://github.com/ogx-ai/ogx/actions/runs/34521865718/attempts/1) failed to resolve `ogx==1.0.3`; the PostgreSQL build resolved it shortly afterward. the [v1.3.1 release](https://github.com/ogx-ai/ogx/actions/runs/33559140522) hit the same failure. production builds currently skip the wait entirely.

this checks the selected PyPI or TestPyPI Simple index for the exact, non-yanked server and API wheels before starting Docker. it retries up to 20 times with 30 seconds between attempts and bounded HTTP timeouts, then stops if the wheels remain unavailable. historical `llama-stack` releases only require the server wheel because their API may be bundled. the probe reduces the publication race; separate CDN views can still differ.

validation: all 45 release-workflow tests pass, including production/TestPyPI selection, delayed API publication, exhausted retries, wrong versions, source-only releases, yanked wheels, and bundled legacy APIs. the actual shell step also passed against public PyPI for v1.0.3. changed-file pre-commit checks, including actionlint and mypy, and an independent review passed.
