### PR TITLE
chore: remove unused storage pip_packages helpers

### DIFF
--- a/src/ogx/core/storage/datatypes.py
+++ b/src/ogx/core/storage/datatypes.py
@@ -49,10 +49,6 @@ class RedisKVStoreConfig(CommonConfig):
         return f"redis://{self.host}:{self.port}"
 
     @classmethod
-    def pip_packages(cls) -> list[str]:
-        return ["redis"]
-
-    @classmethod
     def sample_run_config(cls) -> dict[str, str]:
         return {
             "type": StorageBackendType.KV_REDIS.value,
@@ -68,10 +64,6 @@ class SqliteKVStoreConfig(CommonConfig):
     db_path: str = Field(
         description="File path for the sqlite database",
     )
-
-    @classmethod
-    def pip_packages(cls) -> list[str]:
-        return ["aiosqlite"]
 
     @classmethod
     def sample_run_config(cls, __distro_dir__: str, db_name: str = "kvstore.db") -> dict[str, str]:
@@ -125,10 +117,6 @@ class PostgresKVStoreConfig(CommonConfig):
             raise ValueError("Table name must be less than 63 characters")
         return v
 
-    @classmethod
-    def pip_packages(cls) -> list[str]:
-        return ["asyncpg"]
-
 
 class MongoDBKVStoreConfig(CommonConfig):
     """Configuration for the MongoDB key-value store backend."""
@@ -140,10 +128,6 @@ class MongoDBKVStoreConfig(CommonConfig):
     user: str | None = None
     password: str | None = None
     collection_name: str = "ogx_kvstore"
-
-    @classmethod
-    def pip_packages(cls) -> list[str]:
-        return ["pymongo"]
 
     @classmethod
     def sample_run_config(cls, collection_name: str = "ogx_kvstore") -> dict[str, str]:
@@ -167,11 +151,6 @@ class SqlAlchemySqlStoreConfig(BaseModel):
     @abstractmethod
     def engine_str(self) -> str | URL: ...
 
-    # TODO: move this when we have a better way to specify dependencies with internal APIs
-    @classmethod
-    def pip_packages(cls) -> list[str]:
-        return ["sqlalchemy[asyncio]"]
-
 
 class SqliteSqlStoreConfig(SqlAlchemySqlStoreConfig):
     """Configuration for the SQLite SQL store backend."""
@@ -191,10 +170,6 @@ class SqliteSqlStoreConfig(SqlAlchemySqlStoreConfig):
             "type": StorageBackendType.SQL_SQLITE.value,
             "db_path": "${env.SQLITE_STORE_DIR:=" + __distro_dir__ + "}/" + db_name,
         }
-
-    @classmethod
-    def pip_packages(cls) -> list[str]:
-        return super().pip_packages() + ["aiosqlite"]
 
 
 class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
@@ -224,10 +199,6 @@ class PostgresSqlStoreConfig(SqlAlchemySqlStoreConfig):
             port=int(self.port),
             database=self.db,
         )
-
-    @classmethod
-    def pip_packages(cls) -> list[str]:
-        return super().pip_packages() + ["asyncpg"]
 
     @classmethod
     def sample_run_config(cls, **kwargs: object) -> dict[str, str]:

--- a/src/ogx/core/storage/kvstore/config.py
+++ b/src/ogx/core/storage/kvstore/config.py
@@ -13,27 +13,8 @@ from ogx.core.storage.datatypes import (
     PostgresKVStoreConfig,
     RedisKVStoreConfig,
     SqliteKVStoreConfig,
-    StorageBackendType,
 )
 
 KVStoreConfig = Annotated[
     RedisKVStoreConfig | SqliteKVStoreConfig | PostgresKVStoreConfig | MongoDBKVStoreConfig, Field(discriminator="type")
 ]
-
-
-def get_pip_packages(store_config: dict | KVStoreConfig) -> list[str]:
-    """Get pip packages for KV store config, handling both dict and object cases."""
-    if isinstance(store_config, dict):
-        store_type = store_config.get("type")
-        if store_type == StorageBackendType.KV_SQLITE.value:
-            return SqliteKVStoreConfig.pip_packages()
-        elif store_type == StorageBackendType.KV_POSTGRES.value:
-            return PostgresKVStoreConfig.pip_packages()
-        elif store_type == StorageBackendType.KV_REDIS.value:
-            return RedisKVStoreConfig.pip_packages()
-        elif store_type == StorageBackendType.KV_MONGODB.value:
-            return MongoDBKVStoreConfig.pip_packages()
-        else:
-            raise ValueError(f"Unknown KV store type: {store_type}")
-    else:
-        return store_config.pip_packages()

--- a/src/ogx/core/storage/sqlstore/sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlstore.py
@@ -14,7 +14,6 @@ from ogx.core.storage.datatypes import (
     SqliteSqlStoreConfig,
     SqlStoreReference,
     StorageBackendConfig,
-    StorageBackendType,
 )
 from ogx_api.internal.sqlstore import SqlStore
 
@@ -29,20 +28,6 @@ SqlStoreConfig = Annotated[
     SqliteSqlStoreConfig | PostgresSqlStoreConfig,
     Field(discriminator="type"),
 ]
-
-
-def get_pip_packages(store_config: dict | SqlStoreConfig) -> list[str]:
-    """Get pip packages for SQL store config, handling both dict and object cases."""
-    if isinstance(store_config, dict):
-        store_type = store_config.get("type")
-        if store_type == StorageBackendType.SQL_SQLITE.value:
-            return SqliteSqlStoreConfig.pip_packages()
-        elif store_type == StorageBackendType.SQL_POSTGRES.value:
-            return PostgresSqlStoreConfig.pip_packages()
-        else:
-            raise ValueError(f"Unknown SQL store type: {store_type}")
-    else:
-        return store_config.pip_packages()
 
 
 async def _sqlstore_impl(reference: SqlStoreReference) -> SqlStore:


### PR DESCRIPTION
Remove the pip_packages classmethods on the KV store and SQL store config classes along with the get_pip_packages helpers in the kvstore and sqlstore modules. These were only reachable through the two helpers, which are not called anywhere. The registry's sql_store_pip_packages constant is kept since it is still used by the files providers.
