### PR TITLE
fix!: allow empty choices list in the OpenAI legacy completions usage chunk

### DIFF
--- a/client-sdks/stainless/openapi.yml
+++ b/client-sdks/stainless/openapi.yml
@@ -6011,7 +6011,6 @@ components:
           description: List of choices.
           items:
             $ref: '#/components/schemas/OpenAICompletionChoice'
-          minItems: 1
           title: Choices
           type: array
         created:
@@ -6029,6 +6028,10 @@ components:
           type: string
           enum:
           - text_completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
+          description: Token usage information (typically included in the final chunk with stream_options).
+          nullable: true
       required:
       - id
       - choices

--- a/docs/docs/api-openai/conformance.mdx
+++ b/docs/docs/api-openai/conformance.mdx
@@ -18,12 +18,12 @@ This documentation is auto-generated from the OpenAI API specification compariso
 
 | Metric | Value |
 |--------|-------|
-| **Overall Conformance Score** | 93.7% |
+| **Overall Conformance Score** | 93.8% |
 | **Endpoints Implemented** | 29/146 |
 | **Total Properties Checked** | 3432 |
 | **Schema/Type Issues** | 150 |
-| **Missing Properties** | 65 |
-| **Total Issues to Fix** | 215 |
+| **Missing Properties** | 64 |
+| **Total Issues to Fix** | 214 |
 
 ## Integration Test Coverage
 
@@ -45,8 +45,8 @@ Categories are sorted by conformance score (lowest first, needing most attention
 | Category | Score | Properties | Issues | Missing |
 |----------|-------|------------|--------|---------|
 | Batch | 39.9% | 168 | 60 | 41 |
-| Completions | 58.7% | 46 | 17 | 2 |
 | Models | 60.0% | 15 | 0 | 6 |
+| Completions | 60.9% | 46 | 17 | 1 |
 | Embeddings | 78.6% | 14 | 3 | 0 |
 | Vector stores | 82.9% | 310 | 41 | 12 |
 | Files | 92.9% | 42 | 1 | 2 |
@@ -396,47 +396,6 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 
 </details>
 
-### Completions
-
-**Score:** 58.7% · **Issues:** 17 · **Missing:** 2
-
-#### `/completions`
-
-**POST**
-
-<details>
-<summary>Missing Properties (2)</summary>
-
-- `responses.200.content.application/json.properties.system_fingerprint`
-- `responses.200.content.application/json.properties.usage`
-
-</details>
-
-<details>
-<summary>Schema Issues (17)</summary>
-
-| Property | Issues |
-|----------|--------|
-| `requestBody.content.application/json.properties.best_of` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
-| `requestBody.content.application/json.properties.echo` | Type removed: ['boolean']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: False -&gt; None |
-| `requestBody.content.application/json.properties.frequency_penalty` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 0 -&gt; None |
-| `requestBody.content.application/json.properties.logit_bias` | Type removed: ['object']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
-| `requestBody.content.application/json.properties.logprobs` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
-| `requestBody.content.application/json.properties.max_tokens` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 16 -&gt; None |
-| `requestBody.content.application/json.properties.model` | Type added: ['string']; Union variants removed: 2 |
-| `requestBody.content.application/json.properties.n` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
-| `requestBody.content.application/json.properties.presence_penalty` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 0 -&gt; None |
-| `requestBody.content.application/json.properties.prompt` | Union variants added: 4; Default changed: &lt;\|endoftext\|&gt; -&gt; None |
-| `requestBody.content.application/json.properties.seed` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
-| `requestBody.content.application/json.properties.stop` | Nullable added (OpenAI non-nullable); Union variants added: 3 |
-| `requestBody.content.application/json.properties.stream` | Type removed: ['boolean']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: False -&gt; None |
-| `requestBody.content.application/json.properties.suffix` | Type removed: ['string']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
-| `requestBody.content.application/json.properties.temperature` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
-| `requestBody.content.application/json.properties.top_p` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
-| `requestBody.content.application/json.properties.user` | Type removed: ['string']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
-
-</details>
-
 ### Models
 
 **Score:** 60.0% · **Issues:** 0 · **Missing:** 6
@@ -464,6 +423,46 @@ Below is a detailed breakdown of conformance issues and missing properties for e
 - `responses.200.content.application/json.properties.id`
 - `responses.200.content.application/json.properties.object`
 - `responses.200.content.application/json.properties.owned_by`
+
+</details>
+
+### Completions
+
+**Score:** 60.9% · **Issues:** 17 · **Missing:** 1
+
+#### `/completions`
+
+**POST**
+
+<details>
+<summary>Missing Properties (1)</summary>
+
+- `responses.200.content.application/json.properties.system_fingerprint`
+
+</details>
+
+<details>
+<summary>Schema Issues (17)</summary>
+
+| Property | Issues |
+|----------|--------|
+| `requestBody.content.application/json.properties.best_of` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
+| `requestBody.content.application/json.properties.echo` | Type removed: ['boolean']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: False -&gt; None |
+| `requestBody.content.application/json.properties.frequency_penalty` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 0 -&gt; None |
+| `requestBody.content.application/json.properties.logit_bias` | Type removed: ['object']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
+| `requestBody.content.application/json.properties.logprobs` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
+| `requestBody.content.application/json.properties.max_tokens` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 16 -&gt; None |
+| `requestBody.content.application/json.properties.model` | Type added: ['string']; Union variants removed: 2 |
+| `requestBody.content.application/json.properties.n` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
+| `requestBody.content.application/json.properties.presence_penalty` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 0 -&gt; None |
+| `requestBody.content.application/json.properties.prompt` | Union variants added: 4; Default changed: &lt;\|endoftext\|&gt; -&gt; None |
+| `requestBody.content.application/json.properties.seed` | Type removed: ['integer']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
+| `requestBody.content.application/json.properties.stop` | Nullable added (OpenAI non-nullable); Union variants added: 3 |
+| `requestBody.content.application/json.properties.stream` | Type removed: ['boolean']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: False -&gt; None |
+| `requestBody.content.application/json.properties.suffix` | Type removed: ['string']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
+| `requestBody.content.application/json.properties.temperature` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
+| `requestBody.content.application/json.properties.top_p` | Type removed: ['number']; Nullable added (OpenAI non-nullable); Union variants added: 2; Default changed: 1 -&gt; None |
+| `requestBody.content.application/json.properties.user` | Type removed: ['string']; Nullable added (OpenAI non-nullable); Union variants added: 2 |
 
 </details>
 

--- a/docs/static/deprecated-ogx-spec.yaml
+++ b/docs/static/deprecated-ogx-spec.yaml
@@ -1431,7 +1431,6 @@ components:
           description: List of choices.
           items:
             $ref: '#/components/schemas/OpenAICompletionChoice'
-          minItems: 1
           title: Choices
           type: array
         created:
@@ -1449,6 +1448,10 @@ components:
           type: string
           enum:
           - text_completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
+          description: Token usage information (typically included in the final chunk with stream_options).
+          nullable: true
       required:
       - id
       - choices

--- a/docs/static/experimental-ogx-spec.yaml
+++ b/docs/static/experimental-ogx-spec.yaml
@@ -2392,7 +2392,6 @@ components:
           description: List of choices.
           items:
             $ref: '#/components/schemas/OpenAICompletionChoice'
-          minItems: 1
           title: Choices
           type: array
         created:
@@ -2410,6 +2409,10 @@ components:
           type: string
           enum:
           - text_completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
+          description: Token usage information (typically included in the final chunk with stream_options).
+          nullable: true
       required:
       - id
       - choices

--- a/docs/static/ogx-spec.yaml
+++ b/docs/static/ogx-spec.yaml
@@ -4984,7 +4984,6 @@ components:
           description: List of choices.
           items:
             $ref: '#/components/schemas/OpenAICompletionChoice'
-          minItems: 1
           title: Choices
           type: array
         created:
@@ -5002,6 +5001,10 @@ components:
           type: string
           enum:
           - text_completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
+          description: Token usage information (typically included in the final chunk with stream_options).
+          nullable: true
       required:
       - id
       - choices

--- a/docs/static/openai-coverage.json
+++ b/docs/static/openai-coverage.json
@@ -127,10 +127,10 @@
       ]
     },
     "conformance": {
-      "score": 93.7,
+      "score": 93.8,
       "issues": 150,
-      "missing_properties": 65,
-      "total_problems": 215,
+      "missing_properties": 64,
+      "total_problems": 214,
       "total_properties": 3432
     }
   },
@@ -790,9 +790,9 @@
       ]
     },
     "Completions": {
-      "score": 58.7,
+      "score": 60.9,
       "issues": 17,
-      "missing_properties": 2,
+      "missing_properties": 1,
       "total_properties": 46,
       "endpoints": [
         {
@@ -801,8 +801,7 @@
             {
               "method": "POST",
               "missing_properties": [
-                "POST.responses.200.content.application/json.properties.system_fingerprint",
-                "POST.responses.200.content.application/json.properties.usage"
+                "POST.responses.200.content.application/json.properties.system_fingerprint"
               ],
               "conformance_issues": [
                 {
@@ -948,7 +947,7 @@
                   ]
                 }
               ],
-              "missing_count": 2,
+              "missing_count": 1,
               "issues_count": 17
             }
           ]

--- a/docs/static/stainless-ogx-spec.yaml
+++ b/docs/static/stainless-ogx-spec.yaml
@@ -6011,7 +6011,6 @@ components:
           description: List of choices.
           items:
             $ref: '#/components/schemas/OpenAICompletionChoice'
-          minItems: 1
           title: Choices
           type: array
         created:
@@ -6029,6 +6028,10 @@ components:
           type: string
           enum:
           - text_completion
+        usage:
+          $ref: '#/components/schemas/OpenAIChatCompletionUsage'
+          description: Token usage information (typically included in the final chunk with stream_options).
+          nullable: true
       required:
       - id
       - choices

--- a/src/ogx_api/inference/models.py
+++ b/src/ogx_api/inference/models.py
@@ -793,10 +793,17 @@ class OpenAICompletion(BaseModel):
     """Response from an OpenAI-compatible completion request."""
 
     id: str = Field(..., description="The ID of the completion.")
-    choices: list[OpenAICompletionChoice] = Field(..., min_length=1, description="List of choices.")
+    # The final usage-only chunk (stream_options.include_usage) carries an empty
+    # choices list, so choices must not require at least one item.
+    choices: list[OpenAICompletionChoice] = Field(..., description="List of choices.")
     created: int = Field(..., ge=0, description="The Unix timestamp in seconds when the completion was created.")
     model: str = Field(..., description="The model that was used to generate the completion.")
     object: Literal["text_completion"] = Field(default="text_completion", description="The object type.")
+    usage: OpenAIChatCompletionUsage | None = Field(
+        default=None,
+        json_schema_extra=remove_null_from_anyof,
+        description="Token usage information (typically included in the final chunk with stream_options).",
+    )
 
 
 @json_schema_type

--- a/tests/integration/inference/test_openai_completion.py
+++ b/tests/integration/inference/test_openai_completion.py
@@ -227,6 +227,58 @@ def test_openai_completion_streaming(ogx_client, client_with_models, text_model_
     assert len(content_str) > 10
 
 
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        "inference:completion:sanity",
+    ],
+)
+def test_openai_completion_streaming_usage_chunk(ogx_client, client_with_models, text_model_id, test_case):
+    """A streaming completion with include_usage ends with a final chunk that has an
+    empty choices list and a populated usage object. OpenAI emits that chunk when
+    include_usage is set; Fireworks sends it by default.
+
+    Every chunk must deserialize into an OpenAICompletion. The trailing
+    empty-choices chunk must not degrade to a raw dict (which happens while
+    OpenAICompletion.choices still has min_length=1), and its usage must be
+    preserved.
+    """
+    skip_if_model_doesnt_support_openai_completion(client_with_models, text_model_id)
+    tc = TestCase(test_case)
+
+    response = ogx_client.completions.create(
+        model=text_model_id,
+        prompt=tc["content"],
+        stream=True,
+        max_tokens=20,
+        stream_options={"include_usage": True},
+    )
+
+    chunks = list(response)
+    assert chunks, "expected at least one streamed chunk"
+
+    # A raw dict means OpenAICompletion.from_dict rejected the payload; the
+    # trailing empty-choices usage chunk trips this while choices has min_length=1.
+    for chunk in chunks:
+        assert not isinstance(chunk, dict), (
+            "stream yielded a raw dict instead of OpenAICompletion; the empty-choices usage chunk failed to deserialize"
+        )
+
+    # include_usage streams end with an empty-choices usage chunk.
+    usage_chunks = [chunk for chunk in chunks if not chunk.choices]
+    assert usage_chunks, "expected a trailing chunk with an empty choices list"
+    trailing = usage_chunks[-1]
+    assert trailing.usage is not None, "trailing chunk must carry a populated usage object"
+    usage = trailing.usage.model_dump() if hasattr(trailing.usage, "model_dump") else trailing.usage
+    assert usage.get("total_tokens", 0) > 0
+    assert usage.get("prompt_tokens", 0) > 0
+    assert usage.get("completion_tokens", 0) > 0
+
+    # Non-usage chunks must still carry content.
+    content = "".join(chunk.choices[0].text or "" for chunk in chunks if chunk.choices)
+    assert content.strip(), "expected some streamed content"
+
+
 def test_openai_completion_guided_choice(ogx_client, client_with_models, text_model_id):
     skip_if_provider_isnt_vllm(client_with_models, text_model_id)
 


### PR DESCRIPTION
The /v1/completions endpoint forwards the provider's streaming response, including the final usage-only chunk emitted when stream_options.include_usage is set. That chunk carries a populated usage object alongside an empty choices list, so the previous OpenAICompletion schema (choices min_length=1, no usage field) could not describe it. Clients deserializing the stream fell back to raw dicts for that chunk and silently dropped token usage.

Allow an empty choices list and add an optional usage field reusing OpenAIChatCompletionUsage so the trailing chunk deserializes and its token counts are preserved. created and model are unchanged (they are present in the trailing chunk). Adding the previously-missing usage property raises the Completions OpenAI conformance score from 58.7% to 60.9%.

Add a streaming integration test asserting the final empty-choices chunk deserializes into an OpenAICompletion (not a raw dict) with a populated usage object, and that non-usage chunks still carry content. A recording is not yet committed, so the test needs one in record mode before it can pass in replay.

BREAKING CHANGE: the /v1/completions response schema's choices array no longer requires at least one item (minItems 1 -> 0). The only newly-permitted shape is an empty choices list in the trailing usage chunk.